### PR TITLE
fix(bootstrap): stream install output live and pin permanently

### DIFF
--- a/extensions/bootstrap/index.ts
+++ b/extensions/bootstrap/index.ts
@@ -998,11 +998,10 @@ export function runAsync(
 			resolve(code);
 		};
 
-		// Heartbeat — fires every heartbeatMs while the process is running.
-		const heartbeat = setInterval(() => {
-			elapsedSec += heartbeatMs / 1000;
-			onLine(`   ⏳ still running… (${elapsedSec}s)`);
-		}, heartbeatMs);
+		// Heartbeat intentionally omitted — callers that stream output via onLine
+		// already give the user live feedback, making a separate "still running"
+		// tick redundant. The timeout guard below still enforces the 10-min cap.
+		const heartbeat = setInterval(() => { /* no-op */ }, heartbeatMs);
 
 		// Forward captured lines from both streams.
 		const attachStream = (stream: NodeJS.ReadableStream | null) => {
@@ -1102,16 +1101,21 @@ async function installDeps(ctx: CommandContext, deps: DepStatus[]): Promise<void
 			continue;
 		}
 
-		ctx.ui.notify(`\n${step} 📦 Installing ${dep.name}…\n   → \`${cmd}\``);
+		// Stream install output by exploiting showStatus() in-place update:
+		// consecutive notify("info") calls update the same text node rather than
+		// appending, giving live streaming output. A final notify("warning") pins
+		// the completed output permanently so subsequent showStatus() calls cannot
+		// overwrite it. Output lines are also kept for failure diagnosis.
+		let output = `${step} 📦 Installing ${dep.name}…\n   → \`${cmd}\``;
+		ctx.ui.notify(output, "info");
 
-		// Collect output lines — show progress inline but also keep them
-		// so we can dump a readable block on failure.
 		const outputLines: string[] = [];
 		const exitCode = await runAsync(
 			cmd,
 			(line) => {
 				outputLines.push(line);
-				ctx.ui.notify(line);
+				output += `\n${line}`;
+				ctx.ui.notify(output, "info");
 			},
 		);
 
@@ -1125,17 +1129,17 @@ async function installDeps(ctx: CommandContext, deps: DepStatus[]): Promise<void
 		}
 
 		if (exitCode === 0 && dep.check()) {
-			ctx.ui.notify(`${step} ✅ ${dep.name} installed successfully`);
+			output += `\n${step} ✅ ${dep.name} installed successfully`;
 		} else if (exitCode === 124) {
-			ctx.ui.notify(`${step} ❌ ${dep.name} install timed out (10 min limit)`);
+			output += `\n${step} ❌ ${dep.name} install timed out (10 min limit)`;
 		} else {
 			// Dump the last N lines of output so the operator can see what went wrong
 			const tail = outputLines.slice(-20).join("\n");
 			const status = exitCode === 0
 				? `Command succeeded but ${dep.name} not found on PATH`
 				: `Failed to install ${dep.name} (exit ${exitCode})`;
-			const block = [
-				`${step} ❌ ${status}`,
+			output += [
+				`\n${step} ❌ ${status}`,
 				"",
 				"Output (last 20 lines):",
 				"```",
@@ -1143,7 +1147,10 @@ async function installDeps(ctx: CommandContext, deps: DepStatus[]): Promise<void
 				"```",
 				...(dep.url ? [`Manual install: ${dep.url}`] : []),
 			].join("\n");
-			ctx.ui.notify(block);
 		}
+
+		// Pin the completed output permanently so subsequent showStatus() calls
+		// cannot overwrite it.
+		ctx.ui.notify(output, "warning");
 	}
 }


### PR DESCRIPTION
## Problem

During `/bootstrap` dependency installation, all output from the install process was invisible until completion — the UI appeared frozen, then briefly flashed output before being replaced by the final summary message.

## Root Cause

`installDeps()` called `ctx.ui.notify()` once per output line. The pi TUI `showStatus()` deduplication pattern replaces the previous notification text when consecutive `info`-level calls are made, so each line overwrote the previous one. The final summary then overwrote everything.

## Fix

Replace individual per-line `notify()` calls with a growing string re-emitted on every line via `notify('info')`. `showStatus()` updates the same text node in place for consecutive info-level calls — this gives true live streaming output with no extra API surface needed.

A final `notify('warning')` pins the completed output permanently so subsequent `showStatus()` calls in `interactiveSetup()` cannot overwrite it.

The upstream `outputLines` collection for failure diagnosis (last 20 lines on non-zero exit) is preserved.

Also removes the `⏳ still running… (Ns)` heartbeat ticker from `runAsync` — it was a workaround for the lack of streaming feedback and is now redundant. The 10-minute timeout guard is preserved.

## Testing

Tested by uninstalling and reinstalling vault CLI via `/bootstrap` — output streams live line by line during the 171MB download and install, then pins permanently on completion.