### PR TITLE
feat(tools): stream bash output through ToolProgressSink

### DIFF
--- a/core/crates/omegon-traits/src/lib.rs
+++ b/core/crates/omegon-traits/src/lib.rs
@@ -22,6 +22,7 @@ use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::path::PathBuf;
+use std::sync::Arc;
 
 // ═══════════════════════════════════════════════════════════════════════════
 // Native IPC contract — transport-facing Auspex/Omegon boundary (v1)
@@ -931,6 +932,62 @@ pub struct ToolResult {
     pub details: Value,
 }
 
+/// A sink for streaming partial tool output during execution.
+///
+/// Runners that don't stream simply ignore the sink. Runners that do
+/// (currently `bash`) push partial `ToolResult`s as work happens; the
+/// dispatch layer in `bus`/`loop.rs` converts each partial into an
+/// `AgentEvent::ToolUpdate` emission for downstream consumers.
+///
+/// The sink is intentionally callback-shaped (rather than holding a
+/// channel directly) so this crate stays free of a tokio dependency.
+/// Construct one with [`ToolProgressSink::from_fn`] in the dispatch
+/// layer; runners only see [`ToolProgressSink::send`] and
+/// [`ToolProgressSink::is_active`].
+#[derive(Clone)]
+pub struct ToolProgressSink {
+    inner: Option<Arc<dyn Fn(ToolResult) + Send + Sync>>,
+}
+
+impl ToolProgressSink {
+    /// A no-op sink. Runners that call `send` on this sink discard the partial.
+    pub fn noop() -> Self {
+        Self { inner: None }
+    }
+
+    /// Wrap a callback as a sink. Typically the dispatch layer passes
+    /// a closure that forwards into a tokio mpsc channel.
+    pub fn from_fn<F>(f: F) -> Self
+    where
+        F: Fn(ToolResult) + Send + Sync + 'static,
+    {
+        Self {
+            inner: Some(Arc::new(f)),
+        }
+    }
+
+    /// Push a partial result. No-op if the sink is inactive.
+    pub fn send(&self, partial: ToolResult) {
+        if let Some(cb) = &self.inner {
+            cb(partial);
+        }
+    }
+
+    /// Whether anyone is actually listening. Runners can use this to
+    /// skip building partials when no consumer is attached.
+    pub fn is_active(&self) -> bool {
+        self.inner.is_some()
+    }
+}
+
+impl std::fmt::Debug for ToolProgressSink {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ToolProgressSink")
+            .field("active", &self.is_active())
+            .finish()
+    }
+}
+
 /// JSON Schema definition for a tool's parameters.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ToolDefinition {
@@ -1220,6 +1277,28 @@ pub trait Feature: Send + Sync {
         anyhow::bail!("not implemented")
     }
 
+    /// Execute a tool call with a progress sink for streaming partial output.
+    ///
+    /// The default implementation forwards to [`Feature::execute`] and ignores
+    /// the sink — features that want to stream (e.g. long-running shell
+    /// commands, test runners, multi-phase work) should override this method
+    /// directly and push partial `ToolResult`s into the sink as work happens.
+    /// The dispatch layer will convert each partial into an
+    /// `AgentEvent::ToolUpdate` for downstream consumers.
+    ///
+    /// Runners that don't override this method retain the existing
+    /// fire-and-await semantics with zero behavior change.
+    async fn execute_with_sink(
+        &self,
+        tool_name: &str,
+        call_id: &str,
+        args: Value,
+        cancel: tokio_util::sync::CancellationToken,
+        _sink: ToolProgressSink,
+    ) -> anyhow::Result<ToolResult> {
+        self.execute(tool_name, call_id, args, cancel).await
+    }
+
     /// Slash commands this feature registers. Called once at startup.
     fn commands(&self) -> Vec<CommandDefinition> {
         vec![]
@@ -1430,6 +1509,20 @@ pub trait ToolProvider: Send + Sync {
         args: Value,
         cancel: tokio_util::sync::CancellationToken,
     ) -> anyhow::Result<ToolResult>;
+
+    /// Sink-aware execution. Default forwards to `execute` and discards
+    /// the sink — providers that want to stream partial output (e.g. bash)
+    /// override this method directly. Mirrors `Feature::execute_with_sink`.
+    async fn execute_with_sink(
+        &self,
+        tool_name: &str,
+        call_id: &str,
+        args: Value,
+        cancel: tokio_util::sync::CancellationToken,
+        _sink: ToolProgressSink,
+    ) -> anyhow::Result<ToolResult> {
+        self.execute(tool_name, call_id, args, cancel).await
+    }
 }
 
 /// Legacy: ContextProvider for omegon-memory.

--- a/core/crates/omegon/src/bus.rs
+++ b/core/crates/omegon/src/bus.rs
@@ -157,10 +157,32 @@ impl EventBus {
         args: Value,
         cancel: tokio_util::sync::CancellationToken,
     ) -> anyhow::Result<omegon_traits::ToolResult> {
+        self.execute_tool_with_sink(
+            tool_name,
+            call_id,
+            args,
+            cancel,
+            omegon_traits::ToolProgressSink::noop(),
+        )
+        .await
+    }
+
+    /// Like [`Self::execute_tool`] but also passes a `ToolProgressSink` so the
+    /// runner can stream partial output. The dispatch loop in `loop.rs` uses
+    /// this path; other call sites that just want a final result keep using
+    /// [`Self::execute_tool`] (which constructs a no-op sink).
+    pub async fn execute_tool_with_sink(
+        &self,
+        tool_name: &str,
+        call_id: &str,
+        args: Value,
+        cancel: tokio_util::sync::CancellationToken,
+        sink: omegon_traits::ToolProgressSink,
+    ) -> anyhow::Result<omegon_traits::ToolResult> {
         for (idx, def) in &self.tool_defs {
             if def.name == tool_name {
                 return self.features[*idx]
-                    .execute(tool_name, call_id, args, cancel)
+                    .execute_with_sink(tool_name, call_id, args, cancel, sink)
                     .await;
             }
         }

--- a/core/crates/omegon/src/features/adapter.rs
+++ b/core/crates/omegon/src/features/adapter.rs
@@ -5,7 +5,9 @@
 //! (e.g., omegon-memory) participate in the bus without implementing Feature directly.
 
 use async_trait::async_trait;
-use omegon_traits::{ContextInjection, ContextSignals, Feature, ToolDefinition, ToolResult};
+use omegon_traits::{
+    ContextInjection, ContextSignals, Feature, ToolDefinition, ToolProgressSink, ToolResult,
+};
 use serde_json::Value;
 
 /// Wraps a ToolProvider as a Feature.
@@ -42,6 +44,19 @@ impl Feature for ToolAdapter {
     ) -> anyhow::Result<ToolResult> {
         self.provider
             .execute(tool_name, call_id, args, cancel)
+            .await
+    }
+
+    async fn execute_with_sink(
+        &self,
+        tool_name: &str,
+        call_id: &str,
+        args: Value,
+        cancel: tokio_util::sync::CancellationToken,
+        sink: ToolProgressSink,
+    ) -> anyhow::Result<ToolResult> {
+        self.provider
+            .execute_with_sink(tool_name, call_id, args, cancel, sink)
             .await
     }
 }
@@ -112,6 +127,19 @@ impl Feature for ToolContextAdapter {
     ) -> anyhow::Result<ToolResult> {
         self.tool_provider
             .execute(tool_name, call_id, args, cancel)
+            .await
+    }
+
+    async fn execute_with_sink(
+        &self,
+        tool_name: &str,
+        call_id: &str,
+        args: Value,
+        cancel: tokio_util::sync::CancellationToken,
+        sink: ToolProgressSink,
+    ) -> anyhow::Result<ToolResult> {
+        self.tool_provider
+            .execute_with_sink(tool_name, call_id, args, cancel, sink)
             .await
     }
 

--- a/core/crates/omegon/src/loop.rs
+++ b/core/crates/omegon/src/loop.rs
@@ -2021,8 +2021,27 @@ async fn dispatch_tools(
             args: call.arguments.clone(),
         });
 
+        // Build a progress sink that turns each partial ToolResult into a
+        // ToolUpdate event on the broadcast channel. Runners that don't
+        // override execute_with_sink (the default) simply discard the sink
+        // and behave exactly as before.
+        let sink_events = events.clone();
+        let sink_call_id = call.id.clone();
+        let sink = omegon_traits::ToolProgressSink::from_fn(move |partial| {
+            let _ = sink_events.send(AgentEvent::ToolUpdate {
+                id: sink_call_id.clone(),
+                partial,
+            });
+        });
+
         let (result, is_error) = match bus
-            .execute_tool(&call.name, &call.id, call.arguments.clone(), cancel.clone())
+            .execute_tool_with_sink(
+                &call.name,
+                &call.id,
+                call.arguments.clone(),
+                cancel.clone(),
+                sink,
+            )
             .await
         {
             Ok(result) => (result, false),

--- a/core/crates/omegon/src/tools/bash.rs
+++ b/core/crates/omegon/src/tools/bash.rs
@@ -1,20 +1,47 @@
 //! Bash tool — execute shell commands with output capture.
 
 use anyhow::Result;
-use omegon_traits::{ContentBlock, ToolResult};
+use omegon_traits::{ContentBlock, ToolProgressSink, ToolResult};
 use std::path::Path;
-use std::time::Instant;
+use std::time::{Duration, Instant};
+use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::Command;
 use tokio_util::sync::CancellationToken;
 
 const MAX_OUTPUT_BYTES: usize = 50 * 1024;
 const MAX_OUTPUT_LINES: usize = 2000;
 
+/// Minimum interval between streamed partials. Cheap rate-limit so a
+/// command spewing thousands of lines a second doesn't flood the
+/// broadcast channel — the partial is still a complete tail snapshot,
+/// not an incremental delta, so consumers always see fresh state.
+const STREAM_FLUSH_INTERVAL: Duration = Duration::from_millis(150);
+
 pub async fn execute(
     command: &str,
     cwd: &Path,
     timeout_secs: Option<u64>,
     cancel: CancellationToken,
+) -> Result<ToolResult> {
+    execute_streaming(command, cwd, timeout_secs, cancel, ToolProgressSink::noop()).await
+}
+
+/// Like [`execute`] but streams partial output through `sink` while the
+/// command is running. Each partial is a *snapshot* of the combined
+/// stdout+stderr buffer (not a delta), built with the same noise-stripping
+/// and tail-truncation as the final result, so consumers can render the
+/// latest partial directly without merging.
+///
+/// When `sink` is inactive (the no-op sink) this is byte-for-byte
+/// equivalent to the previous `wait_with_output`-based implementation:
+/// no partials are constructed and the only behavioral difference is
+/// that we read stdout/stderr line-by-line instead of in one shot.
+pub async fn execute_streaming(
+    command: &str,
+    cwd: &Path,
+    timeout_secs: Option<u64>,
+    cancel: CancellationToken,
+    sink: ToolProgressSink,
 ) -> Result<ToolResult> {
     let start = Instant::now();
 
@@ -55,39 +82,100 @@ pub async fn execute(
         .stderr(std::process::Stdio::piped())
         .kill_on_drop(true);
 
-    let child = cmd.spawn()?;
+    let mut child = cmd.spawn()?;
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| anyhow::anyhow!("failed to capture stdout"))?;
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| anyhow::anyhow!("failed to capture stderr"))?;
 
-    let output = tokio::select! {
-        result = child.wait_with_output() => result?,
-        _ = cancel.cancelled() => {
-            anyhow::bail!("Command aborted");
+    let mut stdout_lines = BufReader::new(stdout).lines();
+    let mut stderr_lines = BufReader::new(stderr).lines();
+
+    // Combined buffer — same shape as the legacy join order (stdout, then
+    // a separator newline if stderr is non-empty, then stderr) but here we
+    // interleave by arrival because line-readers don't preserve the
+    // stdout-then-stderr ordering of the original implementation. The agent
+    // gets the same semantic info; live consumers see lines in chronological
+    // arrival order which is what they want.
+    let mut combined = String::new();
+    let mut last_flush = Instant::now();
+    let sink_active = sink.is_active();
+
+    let timeout_fut = async {
+        if let Some(secs) = timeout_secs {
+            tokio::time::sleep(Duration::from_secs(secs)).await;
+        } else {
+            std::future::pending::<()>().await;
         }
-        _ = async {
-            if let Some(secs) = timeout_secs {
-                tokio::time::sleep(std::time::Duration::from_secs(secs)).await;
-            } else {
-                std::future::pending::<()>().await;
+    };
+    tokio::pin!(timeout_fut);
+
+    let exit_status = loop {
+        tokio::select! {
+            biased;
+            _ = cancel.cancelled() => {
+                let _ = child.kill().await;
+                anyhow::bail!("Command aborted");
             }
-        } => {
-            anyhow::bail!("Command timed out after {} seconds", timeout_secs.unwrap());
+            _ = &mut timeout_fut => {
+                let _ = child.kill().await;
+                anyhow::bail!("Command timed out after {} seconds", timeout_secs.unwrap());
+            }
+            line = stdout_lines.next_line() => {
+                match line? {
+                    Some(l) => {
+                        combined.push_str(&l);
+                        combined.push('\n');
+                        maybe_flush_partial(&sink, sink_active, &combined, &mut last_flush);
+                    }
+                    None => {
+                        // stdout closed — drain remaining stderr then wait for exit
+                        while let Some(l) = stderr_lines.next_line().await? {
+                            combined.push_str(&l);
+                            combined.push('\n');
+                            maybe_flush_partial(&sink, sink_active, &combined, &mut last_flush);
+                        }
+                        break child.wait().await?;
+                    }
+                }
+            }
+            line = stderr_lines.next_line() => {
+                match line? {
+                    Some(l) => {
+                        combined.push_str(&l);
+                        combined.push('\n');
+                        maybe_flush_partial(&sink, sink_active, &combined, &mut last_flush);
+                    }
+                    None => {
+                        // stderr closed — drain remaining stdout then wait for exit
+                        while let Some(l) = stdout_lines.next_line().await? {
+                            combined.push_str(&l);
+                            combined.push('\n');
+                            maybe_flush_partial(&sink, sink_active, &combined, &mut last_flush);
+                        }
+                        break child.wait().await?;
+                    }
+                }
+            }
         }
     };
 
     let duration_ms = start.elapsed().as_millis() as u64;
-    let exit_code = output.status.code().unwrap_or(-1);
+    let exit_code = exit_status.code().unwrap_or(-1);
 
-    // Combine stdout + stderr
-    let mut full_output = String::from_utf8_lossy(&output.stdout).into_owned();
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    if !stderr.is_empty() {
-        if !full_output.is_empty() {
-            full_output.push('\n');
-        }
-        full_output.push_str(&stderr);
+    // Strip the trailing newline we added per line so the legacy String
+    // shape matches (the old impl did `lossy(stdout) + "\n" + lossy(stderr)`
+    // without a final newline).
+    if combined.ends_with('\n') {
+        combined.pop();
     }
 
     // Strip terminal control noise (mouse reports, bracketed paste, etc.)
-    let clean_output = strip_terminal_noise(&full_output);
+    let clean_output = strip_terminal_noise(&combined);
 
     // Tail-truncate if needed
     let truncated = truncate_tail(&clean_output);
@@ -107,6 +195,37 @@ pub async fn execute(
             "totalBytes": truncated.total_bytes,
         }),
     })
+}
+
+/// Push a tail-truncated snapshot of `buffer` to the sink, rate-limited
+/// by [`STREAM_FLUSH_INTERVAL`]. Cheap when no consumer is attached.
+fn maybe_flush_partial(
+    sink: &ToolProgressSink,
+    sink_active: bool,
+    buffer: &str,
+    last_flush: &mut Instant,
+) {
+    if !sink_active {
+        return;
+    }
+    if last_flush.elapsed() < STREAM_FLUSH_INTERVAL {
+        return;
+    }
+    *last_flush = Instant::now();
+
+    let cleaned = strip_terminal_noise(buffer);
+    let truncated = truncate_tail(&cleaned);
+    sink.send(ToolResult {
+        content: vec![ContentBlock::Text {
+            text: truncated.content,
+        }],
+        details: serde_json::json!({
+            "partial": true,
+            "totalLines": truncated.total_lines,
+            "totalBytes": truncated.total_bytes,
+            "truncated": truncated.was_truncated,
+        }),
+    });
 }
 
 /// Strip CSI terminal control sequences that aren't SGR color codes.
@@ -428,5 +547,70 @@ mod tests {
         let cancel = CancellationToken::new();
         let result = execute("sleep 10", Path::new("."), Some(1), cancel).await;
         assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn streaming_sink_receives_partials() {
+        use std::sync::{Arc, Mutex};
+        let collected: Arc<Mutex<Vec<ToolResult>>> = Arc::new(Mutex::new(Vec::new()));
+        let collected_for_sink = collected.clone();
+        let sink = ToolProgressSink::from_fn(move |partial| {
+            collected_for_sink.lock().unwrap().push(partial);
+        });
+
+        // Emit a handful of lines spaced beyond STREAM_FLUSH_INTERVAL so the
+        // rate-limiter actually flushes more than once.
+        let cancel = CancellationToken::new();
+        let result = execute_streaming(
+            "for i in 1 2 3 4; do echo line-$i; sleep 0.2; done",
+            Path::new("."),
+            Some(10),
+            cancel,
+            sink,
+        )
+        .await
+        .unwrap();
+
+        // Final result still contains every line.
+        let final_text = result.content[0].as_text().unwrap();
+        for i in 1..=4 {
+            assert!(
+                final_text.contains(&format!("line-{i}")),
+                "final result missing line-{i}: {final_text}"
+            );
+        }
+        assert_eq!(result.details["exitCode"], 0);
+
+        // At least one partial should have flown through the sink. We don't
+        // assert an exact count because flush timing is wall-clock dependent;
+        // we only require that streaming actually happened.
+        let partials = collected.lock().unwrap();
+        assert!(
+            !partials.is_empty(),
+            "expected at least one streamed partial"
+        );
+        // Each partial should be marked as such in details.
+        for p in partials.iter() {
+            assert_eq!(p.details["partial"], true);
+        }
+    }
+
+    #[tokio::test]
+    async fn streaming_sink_inactive_is_zero_overhead() {
+        // The default no-op sink should not affect outcome — covered by the
+        // existing `execute_*` tests since `execute` now forwards to
+        // `execute_streaming` with a noop sink, but assert it explicitly.
+        let cancel = CancellationToken::new();
+        let result = execute_streaming(
+            "echo hello",
+            Path::new("."),
+            None,
+            cancel,
+            ToolProgressSink::noop(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(result.details["exitCode"], 0);
+        assert!(result.content[0].as_text().unwrap().contains("hello"));
     }
 }

--- a/core/crates/omegon/src/tools/mod.rs
+++ b/core/crates/omegon/src/tools/mod.rs
@@ -26,7 +26,7 @@ pub mod write;
 // pub mod remember;    // session scratchpad
 
 use async_trait::async_trait;
-use omegon_traits::{ToolDefinition, ToolProvider, ToolResult};
+use omegon_traits::{ToolDefinition, ToolProgressSink, ToolProvider, ToolResult};
 use serde_json::{Value, json};
 use std::path::{Path, PathBuf};
 use tokio_util::sync::CancellationToken;
@@ -703,6 +703,47 @@ impl ToolProvider for CoreTools {
             // by their dedicated providers registered in setup.rs.
             _ => anyhow::bail!("Unknown core tool: {tool_name}"),
         }
+    }
+
+    /// Sink-aware dispatch. Currently only `bash` actually streams; every
+    /// other tool delegates to `execute` (which itself ignores the sink).
+    /// As more runners learn to stream they should grow branches here.
+    async fn execute_with_sink(
+        &self,
+        tool_name: &str,
+        call_id: &str,
+        args: Value,
+        cancel: CancellationToken,
+        sink: ToolProgressSink,
+    ) -> anyhow::Result<ToolResult> {
+        if tool_name == reg::BASH {
+            let command = args["command"]
+                .as_str()
+                .ok_or_else(|| anyhow::anyhow!("missing 'command' argument"))?;
+            let timeout = args["timeout"].as_u64();
+
+            // Same git-mutation warning as the non-streaming path. Kept inline
+            // (rather than factored out) to make the divergence between the
+            // two dispatch paths obvious — if you change one, change both.
+            if self.repo_model.is_some() {
+                let cmd_lower = command.to_lowercase();
+                if cmd_lower.contains("git commit")
+                    || cmd_lower.contains("git add ")
+                    || (cmd_lower.contains("git stash")
+                        && !cmd_lower.contains("git stash list"))
+                {
+                    tracing::warn!(
+                        command = command,
+                        "git mutation via bash — prefer the structured `commit` tool \
+                         for commits (handles submodules, lifecycle batching, working set)"
+                    );
+                }
+            }
+
+            return bash::execute_streaming(command, &self.cwd, timeout, cancel, sink).await;
+        }
+
+        self.execute(tool_name, call_id, args, cancel).await
     }
 }
 


### PR DESCRIPTION
## Summary

- Adds a non-breaking `ToolProgressSink` callback abstraction on the `Feature` and legacy `ToolProvider` traits and threads it through `EventBus` + `dispatch_tools`.
- Bash runner now reads stdout/stderr line-by-line and pushes rate-limited tail snapshots through the sink; the dispatch layer turns each partial into an `AgentEvent::ToolUpdate { id, partial }` emission.
- Producer-side only. TUI consumption (`tui-aesthetics` branch) is the explicit next step — `ToolUpdate` is still silently dropped by the TUI catch-all, which is fine because it was already dropping the variant before this PR.

## Why

The 18+ minute `python3 scripts/benchmark_matrix.py …` case the operator screenshotted shows nothing but a wall-clock timer because `bash::execute` was using `wait_with_output()` and buffering the entire run to a `String` that nobody saw until exit. Investigation across all runners (bash, validate, change, speculate, mcp, local_inference, web_search, render, read/write/edit) confirmed that **no runner emits any event between `ToolStart` and `ToolEnd`**, and `AgentEvent::ToolUpdate` was defined-but-never-emitted infrastructure.

This PR adds the seam. Bash is the highest-leverage runner (every shell-based tool call, including the python case, goes through it) and the only runner this branch touches. Future branches can override `execute_with_sink` on `validate`, `change`, MCP, etc. one runner at a time using the same pattern.

## Design notes

- **Callback-shaped sink, not a channel.** `ToolProgressSink` wraps an `Arc<dyn Fn(ToolResult) + Send + Sync>` so `omegon-traits` doesn't pick up a tokio dependency. Constructed once per call in `dispatch_tools` from a closure that clones the broadcast `Sender<AgentEvent>` and the `call_id`.
- **Default forwards to `execute`.** Every existing `Feature` and `ToolProvider` impl gets the new method for free with no behavior change. The only override in this PR is `CoreTools` (special-cases `BASH`) and the two adapters in `features/adapter.rs` (forward through to the wrapped provider).
- **Partials are full tail snapshots, not deltas.** Each partial is a noise-stripped, tail-truncated buffer up to that moment. Consumers render the latest one directly without merging state. Trades a few extra bytes for radically simpler downstream code when TUI work lands.
- **150ms flush floor.** Cheap rate-limit so a chatty command can't flood the broadcast channel. Tunable.

## Behavioral change to call out for review

The bash I/O loop was rewritten as a `tokio::select!` over two `BufReader::lines()` streams. This changes one observable thing: **stdout and stderr lines are now interleaved by arrival order instead of "all stdout, then all stderr."** Same bytes, chronological order. All 1504 existing tests still pass, but if any benchmark or harness parses bash output positionally rather than by content, it will see drift. I believe the new ordering is more correct (it's what an interactive terminal would show) but it is a real semantic change.

Cancellation, timeout, exit code, blocked-prefix detection, and tail-truncation are all preserved.

## Test plan

- [x] `cargo check -p omegon` — clean (only the 6 pre-existing warnings)
- [x] `cargo test -p omegon --bin omegon` — **1504 passed, 0 failed, 1 ignored**
- [x] New `streaming_sink_receives_partials` test — confirms partials flow end-to-end through the sink during a multi-line bash run, final result remains complete
- [x] New `streaming_sink_inactive_is_zero_overhead` test — confirms the no-op sink path is unchanged
- [x] Reviewed downstream `ToolUpdate` consumers: `web/ws.rs:1713` (text + html-escape), `ipc/connection.rs:774` (drops payload, forwards id). Both safe.
- [ ] Watch CI: the active-sink test uses 200ms sleeps to outpace the 150ms flush interval. It only requires ≥1 partial (no exact count) but could conceivably flake on a heavily contended runner.
- [ ] No `cargo clippy` run yet — if CI is strict, expect lint nits to surface.

## Out of scope (deliberate)

- TUI consumption of `ToolUpdate`. Tracked on the parked `tui-aesthetics` branch which will rebase onto this once merged.
- Streaming for `validate`, `change`, MCP, local inference, etc. Same pattern, additive, one runner per future PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)