### PR TITLE
feat(traits): typed PartialToolResult shape with progress + heartbeat

### DIFF
--- a/core/crates/omegon-traits/src/lib.rs
+++ b/core/crates/omegon-traits/src/lib.rs
@@ -847,8 +847,17 @@ pub enum IpcEventPayload {
     },
 
     /// Partial result while tool is still running (optional; not all tools emit).
+    ///
+    /// Carries the same [`PartialToolResult`] payload as `AgentEvent::ToolUpdate`
+    /// — `tail` is the latest noise-stripped, tail-truncated buffer of
+    /// accumulated output, and `progress` carries elapsed time + opportunistic
+    /// phase / units / tally signal. Consumers may render `tail` directly,
+    /// route progress to dashboards, or skip the event entirely.
     #[serde(rename = "tool.updated")]
-    ToolUpdated { id: String },
+    ToolUpdated {
+        id: String,
+        partial: PartialToolResult,
+    },
 
     #[serde(rename = "tool.ended")]
     ToolEnded {
@@ -932,10 +941,149 @@ pub struct ToolResult {
     pub details: Value,
 }
 
+// ───────────────────────────────────────────────────────────────────────────
+// Partial / streaming tool state
+// ───────────────────────────────────────────────────────────────────────────
+
+/// Snapshot of a tool's working state during execution.
+///
+/// Distinct from [`ToolResult`] (the *terminal* value the tool produces) —
+/// a partial is a digest of in-progress work, suitable for live rendering
+/// by operators or for routing to higher-layer rollups (pod / family
+/// vital signs).
+///
+/// Runners populate as much of [`progress`] as they can know; the rest is
+/// left as defaults / `None`. The [`tail`] field carries the latest
+/// noise-stripped, tail-truncated buffer of accumulated output and is
+/// empty for heartbeat-only updates.
+///
+/// [`progress`]: PartialToolResult::progress
+/// [`tail`]: PartialToolResult::tail
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct PartialToolResult {
+    /// Tail snapshot of accumulated output. Already noise-stripped and
+    /// tail-truncated by the runner — consumers can render directly.
+    /// Empty when [`ToolProgress::heartbeat`] is true.
+    #[serde(default)]
+    pub tail: String,
+
+    /// Structured progress signal.
+    pub progress: ToolProgress,
+
+    /// Runner-specific extras that don't fit the typed schema.
+    /// Use sparingly — prefer extending [`ToolProgress`] if a field
+    /// proves useful to more than one runner.
+    #[serde(default)]
+    pub details: Value,
+}
+
+impl PartialToolResult {
+    /// Construct a content-bearing partial: a fresh tail snapshot with
+    /// elapsed time, no other progress fields populated.
+    pub fn content(tail: impl Into<String>, elapsed_ms: u64) -> Self {
+        Self {
+            tail: tail.into(),
+            progress: ToolProgress {
+                elapsed_ms,
+                ..ToolProgress::default()
+            },
+            details: Value::Null,
+        }
+    }
+
+    /// Construct a heartbeat-only partial: no content, just liveness.
+    /// Used by runners that go quiet for long stretches (sleeping shell
+    /// commands, slow remote calls, blocked-on-IO scenarios) to signal
+    /// "still alive, just waiting."
+    pub fn heartbeat(elapsed_ms: u64) -> Self {
+        Self {
+            tail: String::new(),
+            progress: ToolProgress {
+                elapsed_ms,
+                heartbeat: true,
+                ..ToolProgress::default()
+            },
+            details: Value::Null,
+        }
+    }
+}
+
+/// Structured progress signal for an in-flight tool.
+///
+/// Two fields are universal — every runner can populate them:
+/// - [`elapsed_ms`]: wall-clock since the tool started
+/// - [`heartbeat`]: marks updates that exist purely to signal liveness
+///
+/// The remainder are opportunistic: populated when the runner has natural
+/// access to the data, left at default / `None` otherwise. Consumers must
+/// not assume any optional field will be present.
+///
+/// [`elapsed_ms`]: ToolProgress::elapsed_ms
+/// [`heartbeat`]: ToolProgress::heartbeat
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct ToolProgress {
+    /// Wall-clock duration since the tool started, in milliseconds.
+    #[serde(default)]
+    pub elapsed_ms: u64,
+
+    /// True if this update carries no new content — purely a liveness
+    /// signal. Consumers can skip rendering content for these and just
+    /// update an "alive at T" timestamp.
+    #[serde(default)]
+    pub heartbeat: bool,
+
+    /// Optional human-readable phase label, e.g. `"compiling foo"`,
+    /// `"running test bar::baz"`, `"fetching schema"`. Used by runners
+    /// with structural progress (validate, MCP) to give operators a
+    /// sense of *where* the tool is in its work.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub phase: Option<String>,
+
+    /// Cardinal progress: how many units of work have been done,
+    /// optionally out of a known total. Examples by runner:
+    /// - bash: lines of output (no total)
+    /// - validate: tests run (total = total tests if known up front)
+    /// - local_inference: tokens generated (total = max_tokens)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub units: Option<ProgressUnits>,
+
+    /// Counts of discrete outcomes the tool has observed so far.
+    /// Populated by runners with discrete-result semantics (validate,
+    /// test runners, MCP servers reporting structured results). `None`
+    /// for runners with continuous output (bash).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tally: Option<ProgressTally>,
+}
+
+/// Cardinal progress count, optionally bounded by a known total.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ProgressUnits {
+    /// How many units processed so far.
+    pub current: u64,
+    /// Total units, if known up front. `None` if the runner can't predict.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub total: Option<u64>,
+    /// Human-readable unit label: `"lines"`, `"tests"`, `"files"`,
+    /// `"bytes"`, `"tokens"`, `"items"`, etc.
+    pub unit: String,
+}
+
+/// Tally of discrete outcomes a tool has observed during execution.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct ProgressTally {
+    pub ok: u64,
+    pub fail: u64,
+    pub skip: u64,
+    /// Anything that doesn't fit the ok/fail/skip taxonomy
+    /// (warnings, indeterminate results, etc.).
+    #[serde(default)]
+    pub other: u64,
+}
+
 /// A sink for streaming partial tool output during execution.
 ///
 /// Runners that don't stream simply ignore the sink. Runners that do
-/// (currently `bash`) push partial `ToolResult`s as work happens; the
+/// (currently `bash`) push [`PartialToolResult`]s as work happens; the
 /// dispatch layer in `bus`/`loop.rs` converts each partial into an
 /// `AgentEvent::ToolUpdate` emission for downstream consumers.
 ///
@@ -946,7 +1094,7 @@ pub struct ToolResult {
 /// [`ToolProgressSink::is_active`].
 #[derive(Clone)]
 pub struct ToolProgressSink {
-    inner: Option<Arc<dyn Fn(ToolResult) + Send + Sync>>,
+    inner: Option<Arc<dyn Fn(PartialToolResult) + Send + Sync>>,
 }
 
 impl ToolProgressSink {
@@ -956,10 +1104,10 @@ impl ToolProgressSink {
     }
 
     /// Wrap a callback as a sink. Typically the dispatch layer passes
-    /// a closure that forwards into a tokio mpsc channel.
+    /// a closure that forwards into a broadcast channel.
     pub fn from_fn<F>(f: F) -> Self
     where
-        F: Fn(ToolResult) + Send + Sync + 'static,
+        F: Fn(PartialToolResult) + Send + Sync + 'static,
     {
         Self {
             inner: Some(Arc::new(f)),
@@ -967,7 +1115,7 @@ impl ToolProgressSink {
     }
 
     /// Push a partial result. No-op if the sink is inactive.
-    pub fn send(&self, partial: ToolResult) {
+    pub fn send(&self, partial: PartialToolResult) {
         if let Some(cb) = &self.inner {
             cb(partial);
         }
@@ -1393,7 +1541,7 @@ pub enum AgentEvent {
     },
     ToolUpdate {
         id: String,
-        partial: ToolResult,
+        partial: PartialToolResult,
     },
     ToolEnd {
         id: String,

--- a/core/crates/omegon/src/ipc/connection.rs
+++ b/core/crates/omegon/src/ipc/connection.rs
@@ -771,7 +771,10 @@ fn project_event(ev: &AgentEvent) -> Option<IpcEventPayload> {
             name: name.clone(),
             args: args.clone(),
         }),
-        AgentEvent::ToolUpdate { id, .. } => Some(IpcEventPayload::ToolUpdated { id: id.clone() }),
+        AgentEvent::ToolUpdate { id, partial } => Some(IpcEventPayload::ToolUpdated {
+            id: id.clone(),
+            partial: partial.clone(),
+        }),
         AgentEvent::ToolEnd {
             id,
             name,

--- a/core/crates/omegon/src/tools/bash.rs
+++ b/core/crates/omegon/src/tools/bash.rs
@@ -1,7 +1,9 @@
 //! Bash tool — execute shell commands with output capture.
 
 use anyhow::Result;
-use omegon_traits::{ContentBlock, ToolProgressSink, ToolResult};
+use omegon_traits::{
+    ContentBlock, PartialToolResult, ProgressUnits, ToolProgress, ToolProgressSink, ToolResult,
+};
 use std::path::Path;
 use std::time::{Duration, Instant};
 use tokio::io::{AsyncBufReadExt, BufReader};
@@ -11,11 +13,17 @@ use tokio_util::sync::CancellationToken;
 const MAX_OUTPUT_BYTES: usize = 50 * 1024;
 const MAX_OUTPUT_LINES: usize = 2000;
 
-/// Minimum interval between streamed partials. Cheap rate-limit so a
-/// command spewing thousands of lines a second doesn't flood the
-/// broadcast channel — the partial is still a complete tail snapshot,
-/// not an incremental delta, so consumers always see fresh state.
+/// Minimum interval between content-bearing streamed partials. Cheap
+/// rate-limit so a command spewing thousands of lines a second doesn't
+/// flood the broadcast channel — the partial is still a complete tail
+/// snapshot, not an incremental delta, so consumers always see fresh
+/// state on the next tick.
 const STREAM_FLUSH_INTERVAL: Duration = Duration::from_millis(150);
+
+/// How long the buffer must be quiet before bash emits an idle heartbeat
+/// partial. Lets operators see "still alive, just waiting" for commands
+/// like `sleep 60 && echo done` that produce no output for long stretches.
+const IDLE_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(5);
 
 pub async fn execute(
     command: &str,
@@ -102,6 +110,7 @@ pub async fn execute_streaming(
     // gets the same semantic info; live consumers see lines in chronological
     // arrival order which is what they want.
     let mut combined = String::new();
+    let mut lines_seen: u64 = 0;
     let mut last_flush = Instant::now();
     let sink_active = sink.is_active();
 
@@ -114,6 +123,15 @@ pub async fn execute_streaming(
     };
     tokio::pin!(timeout_fut);
 
+    // Heartbeat ticker — only matters when a sink is attached. We construct
+    // it unconditionally so the select arm exists, and gate the actual send
+    // on `sink_active` inside the arm. The first tick fires after one full
+    // interval, so a fast command never sees a heartbeat.
+    let mut heartbeat = tokio::time::interval_at(
+        tokio::time::Instant::now() + IDLE_HEARTBEAT_INTERVAL,
+        IDLE_HEARTBEAT_INTERVAL,
+    );
+
     let exit_status = loop {
         tokio::select! {
             biased;
@@ -125,19 +143,29 @@ pub async fn execute_streaming(
                 let _ = child.kill().await;
                 anyhow::bail!("Command timed out after {} seconds", timeout_secs.unwrap());
             }
+            _ = heartbeat.tick() => {
+                // Only emit if quiet — if we've flushed content recently
+                // there's nothing to signal beyond what just went out.
+                if sink_active && last_flush.elapsed() >= IDLE_HEARTBEAT_INTERVAL {
+                    sink.send(PartialToolResult::heartbeat(start.elapsed().as_millis() as u64));
+                    last_flush = Instant::now();
+                }
+            }
             line = stdout_lines.next_line() => {
                 match line? {
                     Some(l) => {
                         combined.push_str(&l);
                         combined.push('\n');
-                        maybe_flush_partial(&sink, sink_active, &combined, &mut last_flush);
+                        lines_seen += 1;
+                        maybe_flush_partial(&sink, sink_active, &combined, lines_seen, start, &mut last_flush);
                     }
                     None => {
                         // stdout closed — drain remaining stderr then wait for exit
                         while let Some(l) = stderr_lines.next_line().await? {
                             combined.push_str(&l);
                             combined.push('\n');
-                            maybe_flush_partial(&sink, sink_active, &combined, &mut last_flush);
+                            lines_seen += 1;
+                            maybe_flush_partial(&sink, sink_active, &combined, lines_seen, start, &mut last_flush);
                         }
                         break child.wait().await?;
                     }
@@ -148,14 +176,16 @@ pub async fn execute_streaming(
                     Some(l) => {
                         combined.push_str(&l);
                         combined.push('\n');
-                        maybe_flush_partial(&sink, sink_active, &combined, &mut last_flush);
+                        lines_seen += 1;
+                        maybe_flush_partial(&sink, sink_active, &combined, lines_seen, start, &mut last_flush);
                     }
                     None => {
                         // stderr closed — drain remaining stdout then wait for exit
                         while let Some(l) = stdout_lines.next_line().await? {
                             combined.push_str(&l);
                             combined.push('\n');
-                            maybe_flush_partial(&sink, sink_active, &combined, &mut last_flush);
+                            lines_seen += 1;
+                            maybe_flush_partial(&sink, sink_active, &combined, lines_seen, start, &mut last_flush);
                         }
                         break child.wait().await?;
                     }
@@ -199,10 +229,20 @@ pub async fn execute_streaming(
 
 /// Push a tail-truncated snapshot of `buffer` to the sink, rate-limited
 /// by [`STREAM_FLUSH_INTERVAL`]. Cheap when no consumer is attached.
+///
+/// The partial carries:
+/// - `tail`: noise-stripped, tail-truncated buffer (consumers render directly)
+/// - `progress.elapsed_ms`: wall-clock since the command started
+/// - `progress.units`: cumulative line count, no upper bound (bash doesn't
+///   know how much output is coming)
+/// - `details`: legacy bash-specific keys preserved for any consumer that
+///   was sniffing them
 fn maybe_flush_partial(
     sink: &ToolProgressSink,
     sink_active: bool,
     buffer: &str,
+    lines_seen: u64,
+    started_at: Instant,
     last_flush: &mut Instant,
 ) {
     if !sink_active {
@@ -215,12 +255,21 @@ fn maybe_flush_partial(
 
     let cleaned = strip_terminal_noise(buffer);
     let truncated = truncate_tail(&cleaned);
-    sink.send(ToolResult {
-        content: vec![ContentBlock::Text {
-            text: truncated.content,
-        }],
+
+    sink.send(PartialToolResult {
+        tail: truncated.content,
+        progress: ToolProgress {
+            elapsed_ms: started_at.elapsed().as_millis() as u64,
+            heartbeat: false,
+            phase: None,
+            units: Some(ProgressUnits {
+                current: lines_seen,
+                total: None,
+                unit: "lines".to_string(),
+            }),
+            tally: None,
+        },
         details: serde_json::json!({
-            "partial": true,
             "totalLines": truncated.total_lines,
             "totalBytes": truncated.total_bytes,
             "truncated": truncated.was_truncated,
@@ -550,9 +599,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn streaming_sink_receives_partials() {
+    async fn streaming_sink_receives_typed_partials() {
         use std::sync::{Arc, Mutex};
-        let collected: Arc<Mutex<Vec<ToolResult>>> = Arc::new(Mutex::new(Vec::new()));
+        let collected: Arc<Mutex<Vec<PartialToolResult>>> = Arc::new(Mutex::new(Vec::new()));
         let collected_for_sink = collected.clone();
         let sink = ToolProgressSink::from_fn(move |partial| {
             collected_for_sink.lock().unwrap().push(partial);
@@ -582,16 +631,90 @@ mod tests {
         assert_eq!(result.details["exitCode"], 0);
 
         // At least one partial should have flown through the sink. We don't
-        // assert an exact count because flush timing is wall-clock dependent;
-        // we only require that streaming actually happened.
+        // assert an exact count because flush timing is wall-clock dependent.
         let partials = collected.lock().unwrap();
         assert!(
             !partials.is_empty(),
             "expected at least one streamed partial"
         );
-        // Each partial should be marked as such in details.
-        for p in partials.iter() {
-            assert_eq!(p.details["partial"], true);
+
+        // Find content-bearing partials (heartbeats may also exist for slow
+        // tests but the body of this command is < IDLE_HEARTBEAT_INTERVAL).
+        let content_partials: Vec<&PartialToolResult> =
+            partials.iter().filter(|p| !p.progress.heartbeat).collect();
+        assert!(
+            !content_partials.is_empty(),
+            "expected at least one content partial"
+        );
+
+        // Every content partial should populate the typed shape correctly.
+        for p in &content_partials {
+            assert!(!p.tail.is_empty(), "content partial should carry tail");
+            assert!(p.progress.elapsed_ms > 0, "elapsed_ms should be set");
+            let units = p
+                .progress
+                .units
+                .as_ref()
+                .expect("content partial should carry units");
+            assert_eq!(units.unit, "lines");
+            assert!(units.current > 0, "lines counter should advance");
+            assert!(
+                units.total.is_none(),
+                "bash has no concept of total line count"
+            );
+            assert!(p.progress.phase.is_none(), "bash sets no phase label");
+            assert!(p.progress.tally.is_none(), "bash has no outcome tally");
+        }
+
+        // Counter should be monotonically non-decreasing across partials.
+        let mut last = 0u64;
+        for p in &content_partials {
+            let cur = p.progress.units.as_ref().unwrap().current;
+            assert!(
+                cur >= last,
+                "lines counter regressed: {last} -> {cur}"
+            );
+            last = cur;
+        }
+    }
+
+    #[tokio::test]
+    async fn streaming_sink_emits_idle_heartbeat() {
+        use std::sync::{Arc, Mutex};
+        let collected: Arc<Mutex<Vec<PartialToolResult>>> = Arc::new(Mutex::new(Vec::new()));
+        let collected_for_sink = collected.clone();
+        let sink = ToolProgressSink::from_fn(move |partial| {
+            collected_for_sink.lock().unwrap().push(partial);
+        });
+
+        // Sleep longer than IDLE_HEARTBEAT_INTERVAL (5s) with no output, then
+        // emit a single line. We should see at least one heartbeat partial
+        // followed by a content partial.
+        let cancel = CancellationToken::new();
+        let result = execute_streaming(
+            "sleep 6 && echo done",
+            Path::new("."),
+            Some(15),
+            cancel,
+            sink,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result.details["exitCode"], 0);
+        assert!(result.content[0].as_text().unwrap().contains("done"));
+
+        let partials = collected.lock().unwrap();
+        let heartbeats: Vec<&PartialToolResult> =
+            partials.iter().filter(|p| p.progress.heartbeat).collect();
+        assert!(
+            !heartbeats.is_empty(),
+            "expected at least one idle heartbeat during 6s sleep, got {} partials total",
+            partials.len()
+        );
+        for hb in &heartbeats {
+            assert!(hb.tail.is_empty(), "heartbeat should carry no content");
+            assert!(hb.progress.elapsed_ms > 0);
         }
     }
 

--- a/core/crates/omegon/src/web/ws.rs
+++ b/core/crates/omegon/src/web/ws.rs
@@ -1711,18 +1711,38 @@ fn serialize_agent_event(event: &AgentEvent) -> Value {
             "args": args,
         }),
         AgentEvent::ToolUpdate { id, partial } => {
-            let text = partial
-                .content
-                .iter()
-                .filter_map(|c| c.as_text())
-                .collect::<Vec<_>>()
-                .join("\n");
-            json!({
+            // Surface the typed shape so the dashboard can render live
+            // tail + progress instead of guessing from raw text. Heartbeats
+            // arrive with `tail` empty and `heartbeat: true` — consumers can
+            // use them to refresh a "last seen alive" timestamp without
+            // re-rendering content.
+            let mut payload = json!({
                 "type": "tool_update",
                 "event_name": "tool.updated",
                 "id": id,
-                "partial": escape_html(&text),
-            })
+                "partial": escape_html(&partial.tail),
+                "heartbeat": partial.progress.heartbeat,
+                "elapsed_ms": partial.progress.elapsed_ms,
+            });
+            if let Some(phase) = &partial.progress.phase {
+                payload["phase"] = json!(phase);
+            }
+            if let Some(units) = &partial.progress.units {
+                payload["units"] = json!({
+                    "current": units.current,
+                    "total": units.total,
+                    "unit": units.unit,
+                });
+            }
+            if let Some(tally) = &partial.progress.tally {
+                payload["tally"] = json!({
+                    "ok": tally.ok,
+                    "fail": tally.fail,
+                    "skip": tally.skip,
+                    "other": tally.other,
+                });
+            }
+            payload
         }
         AgentEvent::ToolEnd {
             id,
@@ -2264,12 +2284,7 @@ mod tests {
             },
             AgentEvent::ToolUpdate {
                 id: "1".into(),
-                partial: omegon_traits::ToolResult {
-                    content: vec![omegon_traits::ContentBlock::Text {
-                        text: "partial".into(),
-                    }],
-                    details: serde_json::json!(null),
-                },
+                partial: omegon_traits::PartialToolResult::content("partial", 100),
             },
             AgentEvent::ToolEnd {
                 id: "1".into(),


### PR DESCRIPTION
## Summary

- Replaces `partial: ToolResult` on `AgentEvent::ToolUpdate` and `IpcEventPayload::ToolUpdated` with a real `PartialToolResult` shape: `tail` + structured `ToolProgress` (elapsed time, optional phase / units / tally / heartbeat) + free-form `details` escape hatch.
- Bash runner populates the new shape with line counts and elapsed time.
- New idle-heartbeat path: bash emits a heartbeat-only partial after 5s of silence so commands like `sleep 60 && echo done` no longer look hung to operators.
- IPC `ToolUpdated` previously sent `{ id }` only — now forwards the full payload so upstream operators (Auspex et al.) get the data without having to ask. The web dashboard payload also expands to include the typed fields.

## Why

omegon/styrene-lab/omegon#23 added the streaming infrastructure and bash population, but the partial payload was just \`ToolResult\` reused for an in-progress shape it doesn't fit. The bash runner was already smuggling progress hints into \`details\` (\`partial: true\`, \`totalLines\`, \`totalBytes\`) — that's the smell that says the type is wrong.

This PR makes the type right *based on what the tool needs to express*, not what any specific consumer wants. Universal fields (tail, elapsed_ms, heartbeat) are first-class. Opportunistic fields (phase, units, tally) are \`Option\`-typed and consumers must not assume they're present. \`details\` remains for runner-specific extras that don't fit the typed schema.

## Design notes

- **Two universals.** Every runner can populate \`elapsed_ms\` and emit \`heartbeat\`. Everything else is opportunistic.
- **Tail is a snapshot, not a delta.** Same property as the first PR — consumers render directly without merging state.
- **Heartbeats are content-free.** \`tail\` is empty and \`progress.heartbeat = true\`. Consumers can use them to refresh a "last seen alive" timestamp without re-rendering content.
- **\`PartialToolResult::content(tail, elapsed_ms)\` and \`::heartbeat(elapsed_ms)\`** convenience constructors keep runner code from manually building the full struct on every flush.
- **IPC carries the full partial, not a digest.** The user's framing was "give the tool what it needs, consumers can request more later" — and what the tool needs is to express its full progress state. Auspex (or any other operator surface) can now read \`tail\`/\`progress\`/\`details\` directly. Whether they choose to display all of it is their call.

## Per-runner population so far

| Runner | tail | elapsed_ms | heartbeat | phase | units | tally |
|---|---|---|---|---|---|---|
| bash | ✓ | ✓ | ✓ (5s idle) | — | ✓ (lines, no total) | — |
| validate, MCP, change, ... | — | — | — | — | — | — |

Other runners pick this up in follow-up branches as needed.

## Test plan

- [x] \`cargo check -p omegon\` — clean (only the 6 pre-existing warnings)
- [x] \`cargo test -p omegon --bin omegon\` — **1505 passed, 0 failed, 1 ignored**
- [x] Existing streaming test rewritten as \`streaming_sink_receives_typed_partials\` — asserts \`tail\` non-empty, \`elapsed_ms\` set, \`units\` carries lines with no total, monotonically non-decreasing line counter, \`phase\`/\`tally\` correctly absent
- [x] New \`streaming_sink_emits_idle_heartbeat\` actually runs \`sleep 6 && echo done\` and confirms at least one heartbeat partial fires during the silence
- [x] Test fixture in \`web/ws.rs::tests\` updated to construct \`PartialToolResult\` via the new \`::content\` constructor
- [ ] Watch CI for the heartbeat test — it sleeps 6s wall-clock and may be slower under contention; should still pass since the test only requires \`heartbeats.is_empty() == false\`, not a specific count

## Out of scope (deliberate)

- TUI consumption of the new shape — the TUI catch-all still drops \`ToolUpdate\`. That branch waits until L2/L3 rollups land so the TUI can subscribe at the right layer.
- Streaming for other runners (validate, MCP, etc.). Validate in particular is harder than originally scoped — it's a parse-the-summary wrapper around \`cargo check\`/\`tsc\`/\`ruff\`, not a runner with native phase/tally structure. A follow-up will likely give it tail+elapsed streaming and skip the structural progress fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)