### PR TITLE
feat(cleave): emit DecompositionStarted/ChildCompleted/Completed events

### DIFF
--- a/core/crates/omegon/src/features/cleave.rs
+++ b/core/crates/omegon/src/features/cleave.rs
@@ -17,9 +17,24 @@ use async_trait::async_trait;
 use serde_json::{Value, json};
 
 use omegon_traits::{
-    BusEvent, BusRequest, CommandDefinition, CommandResult, ContentBlock, Feature, ToolDefinition,
-    ToolResult,
+    AgentEvent, BusEvent, BusRequest, CommandDefinition, CommandResult, ContentBlock, Feature,
+    ToolDefinition, ToolResult,
 };
+use tokio::sync::broadcast;
+
+/// Shared slot for the AgentEvent broadcast sender.
+///
+/// CleaveFeature needs to emit `AgentEvent::Decomposition*` events to
+/// surface tree state changes to consumers (web dashboard, IPC / Auspex,
+/// TUI). The features layer is constructed in `setup.rs` *before* the
+/// broadcast channel exists in `main.rs`, so we hand out a shared slot
+/// at feature-construction time and let main.rs write the sender into
+/// it once the channel is up.
+///
+/// Until the slot is populated, decomposition emissions are silently
+/// dropped — this is correct for tests and for any code path that
+/// constructs the feature without a live event bus.
+pub type CleaveEventSlot = Arc<Mutex<Option<broadcast::Sender<AgentEvent>>>>;
 
 use crate::cleave::{
     self, CleavePlan,
@@ -463,6 +478,9 @@ pub struct CleaveFeature {
     pub inventory: Option<std::sync::Arc<tokio::sync::RwLock<crate::routing::ProviderInventory>>>,
     /// Startup-approved secret env inherited by child runs.
     session_secret_env: Vec<(String, String)>,
+    /// Slot holding the AgentEvent broadcast sender once the runtime has
+    /// constructed it. See [`CleaveEventSlot`] for the rationale.
+    event_sender: CleaveEventSlot,
 }
 
 impl CleaveFeature {
@@ -474,9 +492,29 @@ impl CleaveFeature {
             child_cancel_tokens: Arc::new(Mutex::new(HashMap::new())),
             inventory: None,
             session_secret_env,
+            event_sender: Arc::new(Mutex::new(None)),
         };
         feature.refresh_progress_from_workspace_state();
         feature
+    }
+
+    /// Hand out a clone of the event-sender slot so the runtime can write
+    /// the broadcast `Sender<AgentEvent>` into it once the channel exists.
+    /// Must be called *before* `bus.register(Box::new(feature))` consumes
+    /// the typed `CleaveFeature`.
+    pub fn event_sender_slot(&self) -> CleaveEventSlot {
+        Arc::clone(&self.event_sender)
+    }
+
+    /// Send a decomposition event on the broadcast channel if a sender is
+    /// installed. Silently dropped otherwise — tests and headless runs
+    /// don't have an event bus and shouldn't fail because of it.
+    fn emit_decomposition_event(&self, event: AgentEvent) {
+        if let Ok(slot) = self.event_sender.lock() {
+            if let Some(tx) = slot.as_ref() {
+                let _ = tx.send(event);
+            }
+        }
     }
 
     fn workspace_state_path(&self) -> PathBuf {
@@ -741,9 +779,43 @@ impl CleaveFeature {
             prog.total_tokens_out = 0;
         }
 
+        // ── Decomposition lifecycle event 1 of 3 ──────────────────────────
+        // Tree exists and is about to start spawning children. Consumers
+        // (web dashboard, IPC, TUI) get the list of child labels so they
+        // can render placeholder rows immediately.
+        self.emit_decomposition_event(AgentEvent::DecompositionStarted {
+            children: plan.children.iter().map(|c| c.label.clone()).collect(),
+        });
+
         let progress_sink = {
             let shared = self.shared_progress();
-            progress::callback_progress_sink(move |event| apply_progress_event(&shared, event))
+            let event_slot = self.event_sender_slot();
+            progress::callback_progress_sink(move |event| {
+                // Update internal cleave progress state first.
+                apply_progress_event(&shared, event);
+
+                // ── Decomposition lifecycle event 2 of 3 ──────────────
+                // Per-child terminal transitions get surfaced as
+                // DecompositionChildCompleted. The four terminal statuses
+                // (Completed, Failed, MergedAfterFailure, UpstreamExhausted)
+                // map to a single boolean: did the child do something
+                // useful that contributed to the merged result?
+                if let ProgressEvent::ChildStatus { child, status, .. } = event {
+                    let success = matches!(
+                        status,
+                        ChildProgressStatus::Completed
+                            | ChildProgressStatus::MergedAfterFailure
+                    );
+                    if let Ok(slot) = event_slot.lock() {
+                        if let Some(tx) = slot.as_ref() {
+                            let _ = tx.send(AgentEvent::DecompositionChildCompleted {
+                                label: child.clone(),
+                                success,
+                            });
+                        }
+                    }
+                }
+            })
         };
         let child_cancel_tokens = Arc::clone(&self.child_cancel_tokens);
 
@@ -785,6 +857,18 @@ impl CleaveFeature {
             let mut tokens = self.child_cancel_tokens.lock().unwrap();
             tokens.clear();
         }
+
+        // ── Decomposition lifecycle event 3 of 3 ──────────────────────────
+        // Run completed. `merged` is true iff at least one child's work
+        // was successfully merged into the parent branch — this matches
+        // the dashboard semantics ("did the family produce anything?")
+        // rather than the per-child success tally, which is already
+        // covered by the stream of DecompositionChildCompleted events.
+        let merged = result
+            .merge_results
+            .iter()
+            .any(|(_, outcome)| matches!(outcome, cleave::orchestrator::MergeOutcome::Success));
+        self.emit_decomposition_event(AgentEvent::DecompositionCompleted { merged });
 
         if should_cleanup_workspace(&result) {
             cleanup_workspace_dir(&workspace)?;
@@ -1181,6 +1265,64 @@ mod tests {
         let mut feature = CleaveFeature::new(dir.path(), vec![]);
         let result = feature.handle_command("cleave", "status");
         assert!(matches!(result, CommandResult::Display(ref s) if s.contains("No active")));
+    }
+
+    #[test]
+    fn event_slot_starts_empty_and_drops_emissions() {
+        // Without a sender installed, emit_decomposition_event must be a
+        // silent no-op (used in tests, headless runs, anywhere without an
+        // event bus). Reaching this assertion at all proves we don't panic.
+        let dir = tempfile::tempdir().unwrap();
+        let feature = CleaveFeature::new(dir.path(), vec![]);
+        feature.emit_decomposition_event(AgentEvent::DecompositionStarted {
+            children: vec!["a".into(), "b".into()],
+        });
+        assert!(
+            feature.event_sender_slot().lock().unwrap().is_none(),
+            "slot should still be empty"
+        );
+    }
+
+    #[tokio::test]
+    async fn event_slot_routes_emissions_when_populated() {
+        // Install a broadcast sender into the slot and verify all three
+        // decomposition variants reach a subscribed receiver. This is the
+        // mechanism the cleave run path uses; the call sites in execute_run
+        // are reviewed manually since they require a real subprocess
+        // dispatch to exercise end-to-end.
+        let dir = tempfile::tempdir().unwrap();
+        let feature = CleaveFeature::new(dir.path(), vec![]);
+        let (tx, mut rx) = broadcast::channel::<AgentEvent>(8);
+        *feature.event_sender_slot().lock().unwrap() = Some(tx);
+
+        feature.emit_decomposition_event(AgentEvent::DecompositionStarted {
+            children: vec!["alpha".into(), "beta".into()],
+        });
+        feature.emit_decomposition_event(AgentEvent::DecompositionChildCompleted {
+            label: "alpha".into(),
+            success: true,
+        });
+        feature.emit_decomposition_event(AgentEvent::DecompositionCompleted { merged: true });
+
+        match rx.recv().await.unwrap() {
+            AgentEvent::DecompositionStarted { children } => {
+                assert_eq!(children, vec!["alpha".to_string(), "beta".to_string()]);
+            }
+            other => panic!("expected DecompositionStarted, got {other:?}"),
+        }
+        match rx.recv().await.unwrap() {
+            AgentEvent::DecompositionChildCompleted { label, success } => {
+                assert_eq!(label, "alpha");
+                assert!(success);
+            }
+            other => panic!("expected DecompositionChildCompleted, got {other:?}"),
+        }
+        match rx.recv().await.unwrap() {
+            AgentEvent::DecompositionCompleted { merged } => {
+                assert!(merged);
+            }
+            other => panic!("expected DecompositionCompleted, got {other:?}"),
+        }
     }
 
     #[test]

--- a/core/crates/omegon/src/main.rs
+++ b/core/crates/omegon/src/main.rs
@@ -709,6 +709,12 @@ async fn run_embedded_command(control_port: u16, strict_port: bool) -> anyhow::R
     // ─── Event channel (shared with web dashboard) ──────────────────────
     let (events_tx, _) = broadcast::channel::<AgentEvent>(256);
 
+    // Hand the broadcast sender to the cleave feature so it can emit
+    // AgentEvent::Decomposition* events from inside its tool execution path.
+    if let Ok(mut slot) = agent.cleave_event_slot.lock() {
+        *slot = Some(events_tx.clone());
+    }
+
     // ─── Web control plane ──────────────────────────────────────────────
     let state = web::WebState::new(
         agent.dashboard_handles.clone(),
@@ -1303,6 +1309,12 @@ async fn run_interactive_command(cli: &Cli) -> anyhow::Result<()> {
     // Wire command_tx to ContextProvider for tool dispatch
     if let Ok(mut shared_tx) = agent.command_tx.lock() {
         *shared_tx = Some(command_tx.clone());
+    }
+
+    // Hand the broadcast sender to the cleave feature so it can emit
+    // AgentEvent::Decomposition* events from inside its tool execution path.
+    if let Ok(mut slot) = agent.cleave_event_slot.lock() {
+        *slot = Some(events_tx.clone());
     }
 
     let pending_compact = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
@@ -3112,6 +3124,13 @@ async fn run_agent_command(cli: &Cli, usage_json: Option<PathBuf>) -> anyhow::Re
 
     // ─── Event channel ──────────────────────────────────────────────────
     let (events_tx, mut events_rx) = broadcast::channel::<AgentEvent>(256);
+
+    // Hand the broadcast sender to the cleave feature so it can emit
+    // AgentEvent::Decomposition* events from inside its tool execution path.
+    if let Ok(mut slot) = agent.cleave_event_slot.lock() {
+        *slot = Some(events_tx.clone());
+    }
+
     let benchmark_summary = std::sync::Arc::new(std::sync::Mutex::new(BenchmarkUsageSummary {
         requested_model: Some(requested_model.clone()),
         requested_provider: Some(requested_provider.clone()),

--- a/core/crates/omegon/src/setup.rs
+++ b/core/crates/omegon/src/setup.rs
@@ -71,6 +71,11 @@ pub struct AgentSetup {
     pub extension_widgets: Vec<crate::extensions::ExtensionTabWidget>,
     /// Widget event receivers — one per discovered extension.
     pub widget_receivers: Vec<tokio::sync::broadcast::Receiver<crate::extensions::WidgetEvent>>,
+    /// Slot the AgentEvent broadcast sender gets written into once main.rs
+    /// has constructed the channel. The cleave feature reads this slot when
+    /// emitting `AgentEvent::Decomposition*` events from inside its tool
+    /// execution path. See `features::cleave::CleaveEventSlot`.
+    pub cleave_event_slot: features::cleave::CleaveEventSlot,
 }
 
 /// Pre-computed state gathered during setup for TUI initial display.
@@ -419,6 +424,11 @@ impl AgentSetup {
         // ─── Cleave (decomposition + dispatch) ─────────────────────────
         let cleave_feature = features::cleave::CleaveFeature::new(&cwd, session_secret_env.clone());
         let cleave_handle = cleave_feature.shared_progress();
+        // Capture the event-sender slot before bus.register consumes the
+        // typed feature. main.rs writes the AgentEvent broadcast sender
+        // into this slot once the channel exists, after which the cleave
+        // feature can emit DecompositionStarted/ChildCompleted/Completed.
+        let cleave_event_slot = cleave_feature.event_sender_slot();
         bus.register(Box::new(cleave_feature));
 
         // ─── Codescan (codebase_search / codebase_index) ──────────────
@@ -925,6 +935,7 @@ impl AgentSetup {
                     initial_harness_status.clone(),
                 ))),
             },
+            cleave_event_slot,
         })
     }
 


### PR DESCRIPTION
## Summary

- Wires up the producer side for the three `AgentEvent::Decomposition*` event variants — they were defined in `omegon-traits` and consumed by the TUI / web dashboard / IPC for some time, but **nothing in the cleave orchestrator was actually firing them**. Decomposition runs were invisible to every downstream operator surface.
- Three emission points in `CleaveFeature::execute_run`: \`DecompositionStarted\` (after plan parse, before dispatch), \`DecompositionChildCompleted\` (from inside the progress sink callback), \`DecompositionCompleted\` (after \`cleave::run_cleave\` returns).
- Introduces a \`CleaveEventSlot\` shared-handle pattern so the cleave feature can hold a broadcast sender despite being constructed before the channel exists.

## Why

The L2/L3 audit (background investigation tracked alongside #24) found this concretely:

> \`DecompositionStarted\`, \`DecompositionChildCompleted\`, \`DecompositionCompleted\` are defined in \`omegon-traits\` (lines 1449–1457 in AgentEvent) but no emission code found in cleave/*.rs. The orchestrator (\`orchestrator.rs\`) does NOT emit these events; it manipulates CleaveState directly.

This is the lowest-hanging fruit on the entire L1–L3 instrumentation pass: pure plumbing, no new types, no new consumers. Auspex via IPC (\`ipc/connection.rs:801-816\`), the web dashboard (\`web/ws.rs:1776-1789\`), and the TUI (\`tui/mod.rs:4614-4625\`) all already handle these variants — they were just never receiving them.

## Design notes

- **\`CleaveEventSlot\` pattern.** Features can't directly hold a \`broadcast::Sender<AgentEvent>\` because the bus is constructed in \`setup.rs\` *before* \`main.rs\` creates the broadcast channel. The pattern here:
  - \`CleaveFeature::new\` initializes an empty \`Arc<Mutex<Option<Sender>>>\`
  - \`feature.event_sender_slot()\` hands out a clone of the Arc *before* \`bus.register(Box::new(feature))\` consumes the typed feature
  - \`AgentSetup\` carries the slot through to main.rs
  - All three main.rs entry points (interactive TUI, daemon mode, headless / benchmark) write \`events_tx.clone()\` into the slot right after creating the channel
  - Until the slot is populated, emissions are silent no-ops — correct for tests and headless paths without an event bus
- **Honest architectural debt.** This crosses a clean separation that the codebase was previously maintaining: features didn't reach into the broadcast channel directly. If more features need this access in the future, a typed \`BusRequest::EmitDecompositionEvent\`-style variant would be cleaner. Deferred because the cleave feature is currently the only one with this need and the slot pattern is small enough that migration later is easy.
- **\`merged: bool\` semantics.** The audit asked whether \`DecompositionCompleted\` should reflect per-child success or overall merge outcome. Chose \"any merge succeeded\" because per-child success is already covered by the stream of \`DecompositionChildCompleted\` events — the completion event answers a different question (\"did the family produce anything?\").

## What's *not* in this PR

- **No FamilyVitalSigns rollup yet** — that's the D2 follow-up (task #10). This PR establishes that decomposition events flow at all; D2 builds the periodic snapshot event on top.
- **No conflict detection between sibling children.** Audit confirmed this would need to be built from scratch — \`ChildState\` only knows the *intended* scope, not the runtime mutation set. Defer.
- **No \`active_delegates\` population on \`HarnessStatus\`.** The hook exists but needs a separate branch to wire.

## Test plan

- [x] \`cargo check -p omegon\` — clean (only the 6 pre-existing warnings)
- [x] \`cargo test -p omegon --bin omegon features::cleave\` — **30/30 passing**, including two new tests
- [x] \`event_slot_starts_empty_and_drops_emissions\` — proves \`emit_decomposition_event\` is a silent no-op when no sender is installed
- [x] \`event_slot_routes_emissions_when_populated\` — installs a real broadcast channel into the slot and asserts all three decomposition variants reach a subscribed receiver with correct payloads
- [x] Full suite: **1506 passed**, 1 ignored. One flake: \`plugins::armory_feature::tests::execute_script_*\` — pre-existing subprocess test pool flake, passes 15/15 in isolation, untouched by this PR (I verified by re-running both armory tests in isolation).
- [ ] **Manual review needed:** the actual emission call sites in \`execute_run\` are not exercised by these unit tests because they require a real cleave subprocess dispatch. A follow-up integration test that runs an end-to-end \`cleave_run\` against a tiny synthetic plan would be valuable but is out of scope here.

## Files

- \`core/crates/omegon/src/features/cleave.rs\` — main change: new \`CleaveEventSlot\` type, new field on \`CleaveFeature\`, new accessor + emission helper, three emission call sites in \`execute_run\`, two unit tests
- \`core/crates/omegon/src/setup.rs\` — capture slot before \`bus.register\`, expose on \`AgentSetup\`
- \`core/crates/omegon/src/main.rs\` — write \`events_tx.clone()\` into the slot at all three event-channel construction sites

🤖 Generated with [Claude Code](https://claude.com/claude-code)