### PR TITLE
feat(loop): export controller streak counters on TurnEnd

### DIFF
--- a/core/crates/omegon-traits/src/lib.rs
+++ b/core/crates/omegon-traits/src/lib.rs
@@ -823,6 +823,13 @@ pub enum IpcEventPayload {
         /// Parsed provider quota/headroom telemetry from response headers or status endpoints.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         provider_telemetry: Option<ProviderTelemetrySnapshot>,
+        /// Multi-turn drift / progress streak counts from the agent loop's
+        /// controller. Each is the number of *consecutive* recent turns
+        /// that exhibited the named condition; resets to 0 the moment a
+        /// turn breaks the streak. See `AgentEvent::TurnEnd` for the
+        /// authoritative documentation of each counter's meaning.
+        #[serde(default, skip_serializing_if = "ControllerStreaks::is_zero")]
+        streaks: ControllerStreaks,
     },
 
     // ── Message streaming ──────────────────────────────────────────────────
@@ -1518,6 +1525,51 @@ pub enum ProgressNudgeReason {
     CommitHygiene,
 }
 
+/// Multi-turn streak counts from the agent loop's controller.
+///
+/// Bundled into a struct so they can be carried as a single field on
+/// `AgentEvent::TurnEnd` and `IpcEventPayload::TurnEnded` without
+/// inflating those variants further. Each counter is the number of
+/// *consecutive* recent turns that exhibited the named condition;
+/// the controller resets each one to 0 the moment a turn breaks
+/// the streak.
+///
+/// Consumers can use these to surface "this pod has been in
+/// OrientationChurn for 4 turns" without reconstructing the signal
+/// from the per-turn `drift_kind` history.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ControllerStreaks {
+    /// Consecutive turns classified as `DriftKind::OrientationChurn`.
+    #[serde(default)]
+    pub orientation_churn: u32,
+    /// Consecutive turns classified as `DriftKind::RepeatedActionFailure`.
+    #[serde(default)]
+    pub repeated_action_failure: u32,
+    /// Consecutive turns classified as `DriftKind::ValidationThrash`.
+    #[serde(default)]
+    pub validation_thrash: u32,
+    /// Consecutive turns classified as `DriftKind::ClosureStall`.
+    #[serde(default)]
+    pub closure_stall: u32,
+    /// Consecutive turns showing a `ConstraintDiscovery` progress signal —
+    /// exploratory work that's productive but not yet converging.
+    #[serde(default)]
+    pub constraint_discovery: u32,
+    /// Consecutive turns the controller judged to have sufficient
+    /// evidence to act. High values indicate "ready to commit / close
+    /// out" rather than continuing to gather context.
+    #[serde(default)]
+    pub evidence_sufficient: u32,
+}
+
+impl ControllerStreaks {
+    /// True iff every counter is zero — used by serializers to skip the
+    /// field on the wire when nothing of interest is happening.
+    pub fn is_zero(&self) -> bool {
+        *self == Self::default()
+    }
+}
+
 #[derive(Debug, Clone)]
 pub enum AgentEvent {
     TurnStart {
@@ -1589,6 +1641,12 @@ pub enum AgentEvent {
         files_modified_count: usize,
         /// Cumulative tool calls for checkpoint persistence.
         stats_tool_calls: u32,
+        /// Multi-turn drift / progress streak counts from the agent loop's
+        /// controller. Lets consumers see "this pod has been in
+        /// OrientationChurn for 4 turns" without reconstructing the signal
+        /// from the per-turn `drift_kind` history. See [`ControllerStreaks`]
+        /// for the meaning of each counter.
+        streaks: ControllerStreaks,
     },
     AgentEnd,
     PhaseChanged {

--- a/core/crates/omegon/src/ipc/connection.rs
+++ b/core/crates/omegon/src/ipc/connection.rs
@@ -750,6 +750,7 @@ fn project_event(ev: &AgentEvent) -> Option<IpcEventPayload> {
             actual_output_tokens,
             cache_read_tokens,
             provider_telemetry,
+            streaks,
             ..
         } => Some(IpcEventPayload::TurnEnded {
             turn: *turn,
@@ -758,6 +759,7 @@ fn project_event(ev: &AgentEvent) -> Option<IpcEventPayload> {
             actual_output_tokens: *actual_output_tokens,
             cache_read_tokens: *cache_read_tokens,
             provider_telemetry: provider_telemetry.clone(),
+            streaks: *streaks,
         }),
         AgentEvent::MessageChunk { text } => {
             Some(IpcEventPayload::MessageDelta { text: text.clone() })

--- a/core/crates/omegon/src/loop.rs
+++ b/core/crates/omegon/src/loop.rs
@@ -345,6 +345,22 @@ impl ControllerState {
         *self = Self::default();
     }
 
+    /// Snapshot the streak counters as the public `ControllerStreaks`
+    /// shape that's carried on `AgentEvent::TurnEnd`. The internal
+    /// `consecutive_tool_continuations` field is intentionally not
+    /// exported — it's a continuation-pressure heuristic, not a
+    /// drift-streak signal that operators care about.
+    fn streaks(&self) -> omegon_traits::ControllerStreaks {
+        omegon_traits::ControllerStreaks {
+            orientation_churn: self.orientation_churn_streak,
+            repeated_action_failure: self.repeated_action_failure_streak,
+            validation_thrash: self.validation_thrash_streak,
+            closure_stall: self.closure_stall_streak,
+            constraint_discovery: self.constraint_discovery_streak,
+            evidence_sufficient: self.evidence_sufficient_streak,
+        }
+    }
+
     fn observe_turn(
         &mut self,
         turn_end_reason: TurnEndReason,
@@ -798,6 +814,7 @@ pub async fn run(
                 files_read_count: conversation.intent.files_read.len(),
                 files_modified_count: conversation.intent.files_modified.len(),
                 stats_tool_calls: conversation.intent.stats.tool_calls,
+                streaks: controller.streaks(),
             });
             break;
         }
@@ -1034,6 +1051,7 @@ pub async fn run(
                     files_read_count: conversation.intent.files_read.len(),
                     files_modified_count: conversation.intent.files_modified.len(),
                     stats_tool_calls: conversation.intent.stats.tool_calls,
+                    streaks: controller.streaks(),
                 });
                 break;
             }
@@ -1114,6 +1132,7 @@ pub async fn run(
                     files_read_count: conversation.intent.files_read.len(),
                     files_modified_count: conversation.intent.files_modified.len(),
                     stats_tool_calls: conversation.intent.stats.tool_calls,
+                    streaks: controller.streaks(),
                 });
                 continue; // give it one more turn to commit
             }
@@ -1156,6 +1175,7 @@ pub async fn run(
                 files_read_count: conversation.intent.files_read.len(),
                 files_modified_count: conversation.intent.files_modified.len(),
                 stats_tool_calls: conversation.intent.stats.tool_calls,
+                streaks: controller.streaks(),
             });
             break;
         }
@@ -1378,6 +1398,7 @@ pub async fn run(
             files_read_count: conversation.intent.files_read.len(),
             files_modified_count: conversation.intent.files_modified.len(),
             stats_tool_calls: conversation.intent.stats.tool_calls,
+            streaks: controller.streaks(),
         });
     }
 
@@ -3027,6 +3048,34 @@ mod tests {
             arguments: serde_json::json!({"path": "core/src/context.rs"}),
         }];
         assert!(!should_inject_execution_pressure(4, &config, &conversation, &tool_calls));
+    }
+
+    #[test]
+    fn controller_streaks_snapshot_exports_six_counters_and_omits_internal_state() {
+        // The internal `consecutive_tool_continuations` counter is a
+        // continuation-pressure heuristic, not a drift-streak signal —
+        // it intentionally does not appear on the public ControllerStreaks
+        // shape. The other six counters round-trip 1:1.
+        let controller = ControllerState {
+            consecutive_tool_continuations: 99, // intentionally NOT exported
+            orientation_churn_streak: 4,
+            repeated_action_failure_streak: 2,
+            validation_thrash_streak: 1,
+            closure_stall_streak: 7,
+            constraint_discovery_streak: 3,
+            evidence_sufficient_streak: 5,
+        };
+        let snapshot = controller.streaks();
+        assert_eq!(snapshot.orientation_churn, 4);
+        assert_eq!(snapshot.repeated_action_failure, 2);
+        assert_eq!(snapshot.validation_thrash, 1);
+        assert_eq!(snapshot.closure_stall, 7);
+        assert_eq!(snapshot.constraint_discovery, 3);
+        assert_eq!(snapshot.evidence_sufficient, 5);
+        // Default controller should produce a zero snapshot that
+        // serializes to skip-on-the-wire via `is_zero()`.
+        let zero = ControllerState::default().streaks();
+        assert!(zero.is_zero(), "default controller should be all zeros");
     }
 
     #[test]

--- a/core/crates/omegon/src/main.rs
+++ b/core/crates/omegon/src/main.rs
@@ -1681,6 +1681,11 @@ async fn run_interactive_command(cli: &Cli) -> anyhow::Result<()> {
                                         files_read_count: runtime_state.conversation.intent.files_read.len(),
                                         files_modified_count: runtime_state.conversation.intent.files_modified.len(),
                                         stats_tool_calls: runtime_state.conversation.intent.stats.tool_calls,
+                                        // Compaction-completion synthetic emit — no controller in scope.
+                                        // Streak counters are an in-loop signal; out-of-loop emitters
+                                        // surface zeros and let consumers tell the difference between
+                                        // "no streaks" and "no controller" via the loop's own emissions.
+                                        streaks: omegon_traits::ControllerStreaks::default(),
                                     });
                                 }
                             }

--- a/core/crates/omegon/src/tui/tests.rs
+++ b/core/crates/omegon/src/tui/tests.rs
@@ -295,6 +295,7 @@ fn turn_end_does_not_overwrite_footer_context_with_last_request_input_tokens() {
         files_read_count: 0,
         files_modified_count: 0,
         stats_tool_calls: 0,
+        streaks: omegon_traits::ControllerStreaks::default(),
     });
 
     let after = app.footer_data.context_percent;
@@ -330,6 +331,7 @@ fn turn_end_tracks_session_usage_by_model_attribution() {
         files_read_count: 0,
         files_modified_count: 0,
         stats_tool_calls: 0,
+        streaks: omegon_traits::ControllerStreaks::default(),
     });
     app.handle_agent_event(AgentEvent::TurnEnd {
         turn: 2,
@@ -352,6 +354,7 @@ fn turn_end_tracks_session_usage_by_model_attribution() {
         files_read_count: 0,
         files_modified_count: 0,
         stats_tool_calls: 0,
+        streaks: omegon_traits::ControllerStreaks::default(),
     });
 
     assert_eq!(app.footer_data.session_input_tokens, 112_000);

--- a/core/crates/omegon/src/web/ws.rs
+++ b/core/crates/omegon/src/web/ws.rs
@@ -1664,6 +1664,7 @@ fn serialize_agent_event(event: &AgentEvent) -> Value {
             dominant_phase,
             drift_kind,
             progress_nudge_reason,
+            streaks,
             ..
         } => json!({
             "type": "turn_end",
@@ -1680,6 +1681,14 @@ fn serialize_agent_event(event: &AgentEvent) -> Value {
             "dominant_phase": dominant_phase,
             "drift_kind": drift_kind,
             "progress_nudge_reason": progress_nudge_reason,
+            "streaks": {
+                "orientation_churn": streaks.orientation_churn,
+                "repeated_action_failure": streaks.repeated_action_failure,
+                "validation_thrash": streaks.validation_thrash,
+                "closure_stall": streaks.closure_stall,
+                "constraint_discovery": streaks.constraint_discovery,
+                "evidence_sufficient": streaks.evidence_sufficient,
+            },
         }),
         AgentEvent::MessageStart { role } => json!({
             "type": "message_start",
@@ -2190,6 +2199,10 @@ mod tests {
             files_read_count: 0,
             files_modified_count: 0,
             stats_tool_calls: 0,
+            streaks: omegon_traits::ControllerStreaks {
+                closure_stall: 4,
+                ..Default::default()
+            },
         };
         let messages = serialize_ws_messages(&event);
         assert_eq!(messages.len(), 2);
@@ -2204,6 +2217,15 @@ mod tests {
         assert_eq!(messages[0]["dominant_phase"], "act");
         assert_eq!(messages[0]["drift_kind"], "closure_stall");
         assert_eq!(messages[0]["progress_nudge_reason"], "closure_pressure");
+        // Streak counters: only the closure_stall counter was set in the
+        // fixture; the rest should serialize to 0 (not be omitted) so
+        // dashboards can rely on the field always being present.
+        assert_eq!(messages[0]["streaks"]["closure_stall"], 4);
+        assert_eq!(messages[0]["streaks"]["orientation_churn"], 0);
+        assert_eq!(messages[0]["streaks"]["repeated_action_failure"], 0);
+        assert_eq!(messages[0]["streaks"]["validation_thrash"], 0);
+        assert_eq!(messages[0]["streaks"]["constraint_discovery"], 0);
+        assert_eq!(messages[0]["streaks"]["evidence_sufficient"], 0);
         assert_eq!(messages[1]["type"], "state_changed");
         assert_eq!(messages[1]["event_name"], "state.changed");
         assert_eq!(
@@ -2270,6 +2292,7 @@ mod tests {
                 files_read_count: 0,
                 files_modified_count: 0,
                 stats_tool_calls: 0,
+                streaks: omegon_traits::ControllerStreaks::default(),
             },
             AgentEvent::MessageStart {
                 role: "assistant".into(),


### PR DESCRIPTION
## Summary

- Surfaces the six multi-turn streak counters that already exist in the agent loop's \`ControllerState\` as a typed \`ControllerStreaks\` struct on \`AgentEvent::TurnEnd\` and \`IpcEventPayload::TurnEnded\`.
- The seventh internal counter (\`consecutive_tool_continuations\`) is intentionally not exported — it's a continuation-pressure heuristic, not a drift-streak signal.

## Why

The L2/L3 audit found that \`ControllerState\` already tracks streak counts every turn but they were never reaching consumers:

> The machinery for \"pod has been in OrientationChurn for 4 turns\" exists but is buried inside loop.rs in a local ControllerState. No external visibility. Would need to export streak counts to TurnEnd or create a separate \`PodStreak\` event.

This is the L2 freebie from the audit. Pure plumbing — the data is computed every turn already, the controller is in scope at every \`TurnEnd\` emission site in \`loop.rs\`, and the consumers (web dashboard, IPC, eventually TUI) all already destructure \`AgentEvent::TurnEnd\` with \`..\` so they pick up the new field for free.

Operators trying to detect \"this pod has been in OrientationChurn for 4 turns\" previously had to subscribe to the per-turn \`drift_kind\` field and reconstruct the streak themselves. With this PR they read \`turn_end.streaks.orientation_churn\` directly.

## Shape

```rust
pub struct ControllerStreaks {
    pub orientation_churn: u32,
    pub repeated_action_failure: u32,
    pub validation_thrash: u32,
    pub closure_stall: u32,
    pub constraint_discovery: u32,
    pub evidence_sufficient: u32,
}
```

Each counter is the number of *consecutive* recent turns that exhibited the named condition; the controller resets each one to 0 the moment a turn breaks the streak. \`is_zero()\` helper lets the serializer skip the field on the wire when nothing of interest is happening (\`#[serde(skip_serializing_if = \"ControllerStreaks::is_zero\")]\`).

## Plumbing

- New \`ControllerState::streaks()\` method snapshots into the public type. All five \`AgentEvent::TurnEnd\` emission sites in \`loop.rs\` now populate \`streaks: controller.streaks()\`.
- One out-of-loop construction site in \`main.rs\` (the compaction-completion synthetic emit) populates \`ControllerStreaks::default()\` since no controller is in scope. Documented inline.
- IPC \`TurnEnded\` payload carries the same struct.
- \`web/ws.rs\` \`turn_end\` JSON gains a flat \`streaks\` object with all six fields always present (dashboards rely on field stability).
- Existing pattern-match consumers in \`main.rs\`, \`web/ws.rs\`, \`ipc/connection.rs\`, \`tui/mod.rs\`, and \`checkpoint.rs\` all already used \`..\` and need no changes.
- Test fixtures in \`tui/tests.rs\` (3 sites) and \`web/ws.rs\` (2 sites) updated to construct the new field.

## Test plan

- [x] \`cargo check -p omegon\` — clean (only the 6 pre-existing warnings)
- [x] \`cargo test -p omegon --bin omegon\` — **1508 passed, 0 failed, 1 ignored** (includes 1 new loop test + extended web/ws test asserting all six counters appear on the JSON)
- [x] New \`controller_streaks_snapshot_exports_six_counters_and_omits_internal_state\` in \`loop.rs\` — confirms the snapshot helper exports exactly the six public counters and that \`consecutive_tool_continuations\` does not leak through
- [x] Extended \`serialize_turn_end_includes_usage_and_refresh_hint\` in \`web/ws.rs\` — asserts the streaks object appears with the populated \`closure_stall\` counter at 4 and all other fields explicitly at 0

## Out of scope

- TurnHeartbeat (the in-inference timer for liveness during long model calls). The audit flagged this as \"would require spawning a tokio task inside run() and careful coordination — deferred complexity.\" Not in this PR.
- Multi-turn drift summary string (e.g. \"churning since turn 7\"). The raw streak counts are sufficient — derived strings can live in consumers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)