### PR TITLE
feat(cleave): emit FamilyVitalSigns rollup event on every progress tick

### DIFF
--- a/core/crates/omegon-traits/src/lib.rs
+++ b/core/crates/omegon-traits/src/lib.rs
@@ -896,6 +896,14 @@ pub enum IpcEventPayload {
     #[serde(rename = "decomposition.completed")]
     DecompositionCompleted { merged: bool },
 
+    /// Periodic family-tree rollup carrying the cleave run's current
+    /// shape + per-child digest. See [`FamilyVitalSigns`] for the field
+    /// reference. Subscribers that just want a coherent tree view consume
+    /// this event instead of stitching together the per-child decomposition
+    /// events themselves.
+    #[serde(rename = "family.vital_signs")]
+    FamilyVitalSignsUpdated { signs: FamilyVitalSigns },
+
     // ── Harness ────────────────────────────────────────────────────────────
     /// Harness state changed. Call `get_state` to refresh the `harness` section.
     #[serde(rename = "harness.changed")]
@@ -1525,6 +1533,100 @@ pub enum ProgressNudgeReason {
     CommitHygiene,
 }
 
+// ───────────────────────────────────────────────────────────────────────────
+// L3 family vital signs — multi-agent (cleave) coordination rollup
+// ───────────────────────────────────────────────────────────────────────────
+
+/// Periodic snapshot of a cleave family's tree state and per-child digest.
+///
+/// Emitted on meaningful state transitions inside the cleave orchestrator
+/// (child spawned, child completed, activity tick, token accumulation).
+/// Consumers — Auspex via IPC, the web dashboard, the TUI — can render the
+/// family tree directly without reconstructing it from the per-event stream.
+///
+/// This is the L3 ("family / deployment") layer in the process → pod →
+/// family → cluster instrumentation hierarchy: a downsampled rollup of the
+/// individual `Decomposition*` events that the orchestrator already emits.
+/// Subscribers that only want a coherent tree view subscribe to this event
+/// instead of stitching together \`DecompositionStarted\` +
+/// \`DecompositionChildCompleted\` themselves.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct FamilyVitalSigns {
+    /// Stable id for this cleave run. Empty when no run is active.
+    #[serde(default)]
+    pub run_id: String,
+    /// True while the orchestrator is actively dispatching children.
+    #[serde(default)]
+    pub active: bool,
+    /// Total children in the plan.
+    #[serde(default)]
+    pub total_children: usize,
+    /// Children with terminal status `completed` or `merged_after_failure`.
+    #[serde(default)]
+    pub completed: usize,
+    /// Children with terminal status `failed` or `upstream_exhausted`.
+    #[serde(default)]
+    pub failed: usize,
+    /// Children currently in `running` status.
+    #[serde(default)]
+    pub running: usize,
+    /// Children still in `pending` status (waiting for a free slot or
+    /// for upstream dependencies to clear).
+    #[serde(default)]
+    pub pending: usize,
+    /// Cumulative input tokens consumed across all children. Useful for
+    /// rolling family-level cost into a parent dashboard.
+    #[serde(default)]
+    pub total_tokens_in: u64,
+    /// Cumulative output tokens consumed across all children.
+    #[serde(default)]
+    pub total_tokens_out: u64,
+    /// Per-child digest, in plan order.
+    pub children: Vec<ChildVitalSigns>,
+}
+
+/// Per-child digest carried inside [`FamilyVitalSigns`].
+///
+/// This is the cleave-side analog of L2's per-pod vital signs: enough
+/// detail for an operator to spot which child is moving, which is stuck,
+/// and what each is currently working on, without subscribing to every
+/// underlying activity event.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ChildVitalSigns {
+    /// Stable child label from the cleave plan.
+    pub label: String,
+    /// Status string: `pending` / `running` / `completed` / `failed` /
+    /// `merged_after_failure` / `upstream_exhausted`.
+    pub status: String,
+    /// Wall-clock timestamp when the child transitioned to `running`,
+    /// in unix milliseconds. `None` if not yet started.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub started_at_unix_ms: Option<u64>,
+    /// Wall-clock timestamp of the most recent activity (tool call,
+    /// turn end, status update), in unix milliseconds. `None` if no
+    /// activity has been observed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_activity_unix_ms: Option<u64>,
+    /// Final wall-clock duration in seconds, populated once the child
+    /// reaches a terminal status. `None` while still running.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub duration_secs: Option<f64>,
+    /// Most recent tool name observed inside the child (e.g. `"bash"`,
+    /// `"write"`). `None` until first activity.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_tool: Option<String>,
+    /// Most recent turn number reported by the child. `None` until first
+    /// turn-end.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_turn: Option<u32>,
+    /// Cumulative input tokens consumed by this child.
+    #[serde(default)]
+    pub tokens_in: u64,
+    /// Cumulative output tokens produced by this child.
+    #[serde(default)]
+    pub tokens_out: u64,
+}
+
 /// Multi-turn streak counts from the agent loop's controller.
 ///
 /// Bundled into a struct so they can be carried as a single field on
@@ -1661,6 +1763,12 @@ pub enum AgentEvent {
     },
     DecompositionCompleted {
         merged: bool,
+    },
+    /// Periodic family-tree rollup. See [`FamilyVitalSigns`] for the full
+    /// shape and emission semantics. Fired by the cleave orchestrator on
+    /// every state change inside an active run.
+    FamilyVitalSignsUpdated {
+        signs: FamilyVitalSigns,
     },
     /// System notification — displayed in TUI but not sent to the LLM.
     SystemNotification {

--- a/core/crates/omegon/src/features/cleave.rs
+++ b/core/crates/omegon/src/features/cleave.rs
@@ -815,6 +815,22 @@ impl CleaveFeature {
                         }
                     }
                 }
+
+                // ── Family vital signs (L3 rollup) ─────────────────────
+                // Snapshot the family tree on every progress event so
+                // subscribers see fresh per-child digest without having
+                // to reconstruct it from the per-event stream. The
+                // orchestrator doesn't fire ProgressEvents at high
+                // frequency (a handful per child per minute) so no
+                // rate-limiting is needed here.
+                if let Ok(slot) = event_slot.lock() {
+                    if let Some(tx) = slot.as_ref() {
+                        if let Ok(progress_guard) = shared.lock() {
+                            let signs = build_family_vital_signs(&progress_guard);
+                            let _ = tx.send(AgentEvent::FamilyVitalSignsUpdated { signs });
+                        }
+                    }
+                }
             })
         };
         let child_cancel_tokens = Arc::clone(&self.child_cancel_tokens);
@@ -1194,6 +1210,69 @@ fn text_result(text: &str) -> ToolResult {
     }
 }
 
+/// Snapshot the live `CleaveProgress` into the public typed
+/// [`omegon_traits::FamilyVitalSigns`] shape that's carried on
+/// `AgentEvent::FamilyVitalSignsUpdated`. The internal representation uses
+/// `std::time::Instant` for timestamps; the public type uses absolute unix
+/// milliseconds, so we convert via `(Instant::now(), SystemTime::now())`
+/// at snapshot time to get a stable wall-clock anchor.
+fn build_family_vital_signs(progress: &CleaveProgress) -> omegon_traits::FamilyVitalSigns {
+    let now_instant = std::time::Instant::now();
+    let now_unix_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0);
+
+    let to_unix_ms = |inst: std::time::Instant| -> u64 {
+        // Saturate at 0 if the Instant is somehow ahead of "now" — should
+        // never happen in practice but the conversion is fallible.
+        let elapsed_ms = now_instant
+            .checked_duration_since(inst)
+            .map(|d| d.as_millis() as u64)
+            .unwrap_or(0);
+        now_unix_ms.saturating_sub(elapsed_ms)
+    };
+
+    let mut running = 0usize;
+    let mut pending = 0usize;
+    for child in &progress.children {
+        match child.status.as_str() {
+            "running" => running += 1,
+            "pending" => pending += 1,
+            _ => {}
+        }
+    }
+
+    let children = progress
+        .children
+        .iter()
+        .map(|c| omegon_traits::ChildVitalSigns {
+            label: c.label.clone(),
+            status: c.status.clone(),
+            started_at_unix_ms: c.started_at.map(to_unix_ms),
+            last_activity_unix_ms: c.last_activity_at.map(to_unix_ms),
+            duration_secs: c.duration_secs,
+            last_tool: c.last_tool.clone(),
+            last_turn: c.last_turn,
+            tokens_in: c.tokens_in,
+            tokens_out: c.tokens_out,
+        })
+        .collect();
+
+    omegon_traits::FamilyVitalSigns {
+        run_id: progress.run_id.clone(),
+        active: progress.active,
+        total_children: progress.total_children,
+        completed: progress.completed,
+        failed: progress.failed,
+        running,
+        pending,
+        total_tokens_in: progress.total_tokens_in,
+        total_tokens_out: progress.total_tokens_out,
+        children,
+    }
+}
+
 fn should_cleanup_workspace(result: &cleave::orchestrator::CleaveResult) -> bool {
     result
         .state
@@ -1281,6 +1360,133 @@ mod tests {
             feature.event_sender_slot().lock().unwrap().is_none(),
             "slot should still be empty"
         );
+    }
+
+    #[test]
+    fn build_family_vital_signs_snapshots_progress_state() {
+        // Construct a CleaveProgress with a mix of statuses and partial
+        // per-child fields and confirm the snapshot helper produces a
+        // typed FamilyVitalSigns with the right derived counts and
+        // children in plan order.
+        let mut prog = CleaveProgress::default();
+        prog.run_id = "test-run".into();
+        prog.active = true;
+        prog.total_children = 3;
+        prog.completed = 1;
+        prog.failed = 0;
+        prog.total_tokens_in = 1500;
+        prog.total_tokens_out = 750;
+        prog.children = vec![
+            ChildProgress {
+                label: "alpha".into(),
+                status: "completed".into(),
+                duration_secs: Some(12.5),
+                supervision_mode: None,
+                pid: None,
+                last_tool: Some("commit".into()),
+                last_turn: Some(8),
+                started_at: Some(std::time::Instant::now()),
+                last_activity_at: Some(std::time::Instant::now()),
+                tokens_in: 800,
+                tokens_out: 400,
+                runtime: None,
+            },
+            ChildProgress {
+                label: "beta".into(),
+                status: "running".into(),
+                duration_secs: None,
+                supervision_mode: None,
+                pid: Some(42_u32),
+                last_tool: Some("write".into()),
+                last_turn: Some(3),
+                started_at: Some(std::time::Instant::now()),
+                last_activity_at: Some(std::time::Instant::now()),
+                tokens_in: 700,
+                tokens_out: 350,
+                runtime: None,
+            },
+            ChildProgress {
+                label: "gamma".into(),
+                status: "pending".into(),
+                duration_secs: None,
+                supervision_mode: None,
+                pid: None,
+                last_tool: None,
+                last_turn: None,
+                started_at: None,
+                last_activity_at: None,
+                tokens_in: 0,
+                tokens_out: 0,
+                runtime: None,
+            },
+        ];
+
+        let signs = build_family_vital_signs(&prog);
+        assert_eq!(signs.run_id, "test-run");
+        assert!(signs.active);
+        assert_eq!(signs.total_children, 3);
+        assert_eq!(signs.completed, 1);
+        assert_eq!(signs.failed, 0);
+        // Derived counts from the children list
+        assert_eq!(signs.running, 1, "one child in running status");
+        assert_eq!(signs.pending, 1, "one child in pending status");
+        assert_eq!(signs.total_tokens_in, 1500);
+        assert_eq!(signs.total_tokens_out, 750);
+        assert_eq!(signs.children.len(), 3);
+        assert_eq!(signs.children[0].label, "alpha");
+        assert_eq!(signs.children[0].status, "completed");
+        assert_eq!(signs.children[0].duration_secs, Some(12.5));
+        assert!(signs.children[0].started_at_unix_ms.is_some());
+        assert_eq!(signs.children[1].label, "beta");
+        assert_eq!(signs.children[1].duration_secs, None);
+        assert_eq!(signs.children[2].label, "gamma");
+        assert_eq!(signs.children[2].started_at_unix_ms, None);
+        assert_eq!(signs.children[2].last_activity_unix_ms, None);
+    }
+
+    #[tokio::test]
+    async fn event_slot_routes_family_vital_signs() {
+        // Wire a real broadcast channel into the slot and assert that
+        // FamilyVitalSignsUpdated reaches a subscribed receiver.
+        let dir = tempfile::tempdir().unwrap();
+        let feature = CleaveFeature::new(dir.path(), vec![]);
+        let (tx, mut rx) = broadcast::channel::<AgentEvent>(8);
+        *feature.event_sender_slot().lock().unwrap() = Some(tx);
+
+        let signs = omegon_traits::FamilyVitalSigns {
+            run_id: "test".into(),
+            active: true,
+            total_children: 1,
+            completed: 0,
+            failed: 0,
+            running: 1,
+            pending: 0,
+            total_tokens_in: 0,
+            total_tokens_out: 0,
+            children: vec![omegon_traits::ChildVitalSigns {
+                label: "alpha".into(),
+                status: "running".into(),
+                started_at_unix_ms: Some(1),
+                last_activity_unix_ms: Some(2),
+                duration_secs: None,
+                last_tool: Some("bash".into()),
+                last_turn: Some(1),
+                tokens_in: 0,
+                tokens_out: 0,
+            }],
+        };
+        feature.emit_decomposition_event(AgentEvent::FamilyVitalSignsUpdated {
+            signs: signs.clone(),
+        });
+
+        match rx.recv().await.unwrap() {
+            AgentEvent::FamilyVitalSignsUpdated { signs: got } => {
+                assert_eq!(got.run_id, "test");
+                assert_eq!(got.children.len(), 1);
+                assert_eq!(got.children[0].label, "alpha");
+            }
+            other => panic!("expected FamilyVitalSignsUpdated, got {other:?}"),
+        }
     }
 
     #[tokio::test]

--- a/core/crates/omegon/src/ipc/connection.rs
+++ b/core/crates/omegon/src/ipc/connection.rs
@@ -820,6 +820,11 @@ fn project_event(ev: &AgentEvent) -> Option<IpcEventPayload> {
         AgentEvent::SystemNotification { message } => Some(IpcEventPayload::SystemNotification {
             message: message.clone(),
         }),
+        AgentEvent::FamilyVitalSignsUpdated { signs } => {
+            Some(IpcEventPayload::FamilyVitalSignsUpdated {
+                signs: signs.clone(),
+            })
+        }
         AgentEvent::HarnessStatusChanged { .. } => Some(IpcEventPayload::HarnessChanged),
         AgentEvent::SessionReset => Some(IpcEventPayload::SessionReset),
         // Internal-only events — not projected to IPC
@@ -846,6 +851,7 @@ fn event_name(ev: &IpcEventPayload) -> &'static str {
         IpcEventPayload::DecompositionStarted { .. } => "decomposition.started",
         IpcEventPayload::DecompositionChildCompleted { .. } => "decomposition.child_completed",
         IpcEventPayload::DecompositionCompleted { .. } => "decomposition.completed",
+        IpcEventPayload::FamilyVitalSignsUpdated { .. } => "family.vital_signs",
         IpcEventPayload::HarnessChanged => "harness.changed",
         IpcEventPayload::StateChanged { .. } => "state.changed",
         IpcEventPayload::SystemNotification { .. } => "system.notification",

--- a/core/crates/omegon/src/web/ws.rs
+++ b/core/crates/omegon/src/web/ws.rs
@@ -1798,6 +1798,32 @@ fn serialize_agent_event(event: &AgentEvent) -> Value {
             "event_name": "decomposition.completed",
             "merged": merged,
         }),
+        AgentEvent::FamilyVitalSignsUpdated { signs } => json!({
+            "type": "family_vital_signs",
+            "event_name": "family.vital_signs",
+            "signs": {
+                "run_id": signs.run_id,
+                "active": signs.active,
+                "total_children": signs.total_children,
+                "completed": signs.completed,
+                "failed": signs.failed,
+                "running": signs.running,
+                "pending": signs.pending,
+                "total_tokens_in": signs.total_tokens_in,
+                "total_tokens_out": signs.total_tokens_out,
+                "children": signs.children.iter().map(|c| json!({
+                    "label": c.label,
+                    "status": c.status,
+                    "started_at_unix_ms": c.started_at_unix_ms,
+                    "last_activity_unix_ms": c.last_activity_unix_ms,
+                    "duration_secs": c.duration_secs,
+                    "last_tool": c.last_tool,
+                    "last_turn": c.last_turn,
+                    "tokens_in": c.tokens_in,
+                    "tokens_out": c.tokens_out,
+                })).collect::<Vec<_>>(),
+            },
+        }),
         AgentEvent::SystemNotification { message } => json!({
             "type": "system_notification",
             "event_name": "system.notification",
@@ -2330,6 +2356,30 @@ mod tests {
                 success: true,
             },
             AgentEvent::DecompositionCompleted { merged: true },
+            AgentEvent::FamilyVitalSignsUpdated {
+                signs: omegon_traits::FamilyVitalSigns {
+                    run_id: "test-run".into(),
+                    active: true,
+                    total_children: 2,
+                    completed: 1,
+                    failed: 0,
+                    running: 1,
+                    pending: 0,
+                    total_tokens_in: 100,
+                    total_tokens_out: 50,
+                    children: vec![omegon_traits::ChildVitalSigns {
+                        label: "alpha".into(),
+                        status: "completed".into(),
+                        started_at_unix_ms: Some(1_700_000_000_000),
+                        last_activity_unix_ms: Some(1_700_000_005_000),
+                        duration_secs: Some(5.0),
+                        last_tool: Some("bash".into()),
+                        last_turn: Some(3),
+                        tokens_in: 60,
+                        tokens_out: 30,
+                    }],
+                },
+            },
             AgentEvent::SystemNotification {
                 message: "test".into(),
             },
@@ -2338,7 +2388,82 @@ mod tests {
             let json = serialize_agent_event(event);
             assert!(json["type"].is_string(), "event should have a type field");
         }
-        assert_eq!(events.len(), 15, "should cover all 15 AgentEvent variants");
+        assert_eq!(events.len(), 16, "should cover all 16 AgentEvent variants");
+    }
+
+    #[test]
+    fn serialize_family_vital_signs_renders_full_tree() {
+        let event = AgentEvent::FamilyVitalSignsUpdated {
+            signs: omegon_traits::FamilyVitalSigns {
+                run_id: "run-42".into(),
+                active: true,
+                total_children: 3,
+                completed: 1,
+                failed: 0,
+                running: 1,
+                pending: 1,
+                total_tokens_in: 1000,
+                total_tokens_out: 500,
+                children: vec![
+                    omegon_traits::ChildVitalSigns {
+                        label: "auth".into(),
+                        status: "completed".into(),
+                        started_at_unix_ms: Some(1_700_000_000_000),
+                        last_activity_unix_ms: Some(1_700_000_010_000),
+                        duration_secs: Some(10.0),
+                        last_tool: Some("commit".into()),
+                        last_turn: Some(5),
+                        tokens_in: 600,
+                        tokens_out: 300,
+                    },
+                    omegon_traits::ChildVitalSigns {
+                        label: "api".into(),
+                        status: "running".into(),
+                        started_at_unix_ms: Some(1_700_000_005_000),
+                        last_activity_unix_ms: Some(1_700_000_012_000),
+                        duration_secs: None,
+                        last_tool: Some("write".into()),
+                        last_turn: Some(2),
+                        tokens_in: 400,
+                        tokens_out: 200,
+                    },
+                    omegon_traits::ChildVitalSigns {
+                        label: "ui".into(),
+                        status: "pending".into(),
+                        started_at_unix_ms: None,
+                        last_activity_unix_ms: None,
+                        duration_secs: None,
+                        last_tool: None,
+                        last_turn: None,
+                        tokens_in: 0,
+                        tokens_out: 0,
+                    },
+                ],
+            },
+        };
+        let json = serialize_agent_event(&event);
+        assert_eq!(json["type"], "family_vital_signs");
+        assert_eq!(json["event_name"], "family.vital_signs");
+        assert_eq!(json["signs"]["run_id"], "run-42");
+        assert_eq!(json["signs"]["active"], true);
+        assert_eq!(json["signs"]["total_children"], 3);
+        assert_eq!(json["signs"]["completed"], 1);
+        assert_eq!(json["signs"]["running"], 1);
+        assert_eq!(json["signs"]["pending"], 1);
+        assert_eq!(json["signs"]["total_tokens_in"], 1000);
+        assert_eq!(json["signs"]["children"].as_array().unwrap().len(), 3);
+        assert_eq!(json["signs"]["children"][0]["label"], "auth");
+        assert_eq!(json["signs"]["children"][0]["status"], "completed");
+        assert_eq!(json["signs"]["children"][1]["status"], "running");
+        assert_eq!(
+            json["signs"]["children"][1]["duration_secs"],
+            serde_json::Value::Null
+        );
+        assert_eq!(json["signs"]["children"][2]["status"], "pending");
+        assert_eq!(
+            json["signs"]["children"][2]["started_at_unix_ms"],
+            serde_json::Value::Null
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Adds the L3 family-tree rollup event the L1–L3 instrumentation pass has been building toward. Cleave runs now emit a typed \`AgentEvent::FamilyVitalSignsUpdated { signs }\` on every internal progress event, carrying run-level shape (\`run_id\`, \`active\`, derived \`completed\`/\`failed\`/\`running\`/\`pending\` counts, cumulative tokens) plus a per-child digest (label, status, started/last_activity unix ms, duration, last_tool, last_turn, tokens).
- New \`FamilyVitalSigns\` and \`ChildVitalSigns\` types in \`omegon-traits\`. Matching \`IpcEventPayload::FamilyVitalSignsUpdated\` (wire name \`family.vital_signs\`).
- Web dashboard JSON gets a \`family_vital_signs\` message type with the full tree.

## Why

This is the L3 layer in the process → pod → family → cluster instrumentation hierarchy. Subscribers that want a coherent tree view (Auspex, the eventual TUI cleave dashboard) now consume one event instead of stitching together \`DecompositionStarted\` + \`DecompositionChildCompleted\` themselves. The per-child digest is the cleave-side analog of the L2 streak counters that landed in #26.

The audit confirmed the data was already there in \`CleaveProgress\` — including timestamps, last-tool, last-turn, per-child token rollups — it just had no path to consumers. This PR is the path.

## Design notes

- **Snapshot on every internal progress event.** The progress sink callback in \`CleaveFeature::execute_run\` (the same closure that emits \`DecompositionChildCompleted\` from #25) now also snapshots and emits \`FamilyVitalSignsUpdated\` after every progress event. The cleave orchestrator fires a handful of progress events per child per minute, not thousands per second, so no rate-limiting is needed.
- **\`Instant\` → unix milliseconds at snapshot time.** The internal \`CleaveProgress::ChildProgress\` uses \`std::time::Instant\` for timestamps (relative monotonic clock). The public type uses absolute unix milliseconds. Conversion captures \`(Instant::now, SystemTime::now)\` once and back-calculates each child's timestamp from the elapsed delta. Stable wall clock for consumers.
- **Derived counts.** \`CleaveProgress\` only tracks the terminal \`completed\` / \`failed\` totals directly. The snapshot helper derives \`running\` and \`pending\` from the children list at snapshot time.
- **Reuses the slot from #25.** No new plumbing — the \`CleaveEventSlot\` pattern from the previous PR is the path. Adding more event types is now a one-line emission inside the same closure.

## What's *not* in this PR

- **Inter-child file conflict detection.** The audit confirmed \`ChildState\` only knows the *intended* scope, not the runtime mutation set; would need to be built from scratch (stdout parsing / shared log / post-hoc git diff). Deferred.
- **\`active_delegates\` field on \`HarnessStatus\`.** Hook still unfilled. Wiring it to \`FamilyVitalSigns\` is mechanical but a separate branch.
- **Periodic timer-based emission.** This PR only emits on internal progress events. A clock-based heartbeat (\"family alive even though no child changed status\") would need a tokio task spawned alongside the orchestrator. Straightforward but separate.

## Test plan

- [x] \`cargo check -p omegon\` — clean (only the 6 pre-existing warnings)
- [x] \`cargo test -p omegon --bin omegon\` — **1511 passed, 0 failed, 1 ignored**
- [x] \`build_family_vital_signs_snapshots_progress_state\` in \`features/cleave.rs\` — constructs a \`CleaveProgress\` with mixed statuses, confirms derived counts and per-child fields round-trip correctly through the snapshot helper
- [x] \`event_slot_routes_family_vital_signs\` — emits the new event through the broadcast slot wired in #25 and asserts a subscribed receiver gets it
- [x] \`serialize_family_vital_signs_renders_full_tree\` in \`web/ws.rs\` — full tree fixture asserts the JSON shape including null handling for pending children with no \`started_at_unix_ms\`
- [x] \`serialize_all_event_types\` extended to exercise the new variant (event count assertion bumped 15 → 16)

🤖 Generated with [Claude Code](https://claude.com/claude-code)