### PR TITLE
refactor(cleave): route AgentEvent emission through BusRequest::EmitAgentEvent

### DIFF
--- a/core/crates/omegon-traits/src/lib.rs
+++ b/core/crates/omegon-traits/src/lib.rs
@@ -1314,6 +1314,72 @@ pub enum BusRequest {
         content: String,
         source: String,
     },
+    /// Emit an `AgentEvent` on the runtime's broadcast channel.
+    ///
+    /// Features that need to fire events from inside long-running tool
+    /// executions (e.g. cleave's decomposition lifecycle, family vital
+    /// signs) push these through a [`BusRequestSink`] handed in by the
+    /// runtime — they never touch the broadcast channel directly. Keeps
+    /// features decoupled from the transport layer while still letting
+    /// them communicate state changes mid-execution.
+    EmitAgentEvent { event: AgentEvent },
+}
+
+/// A sink for features to push [`BusRequest`]s mid-execution.
+///
+/// Analogous to [`ToolProgressSink`]: callback-shaped (no tokio dep in
+/// this crate), constructed by the runtime, handed to features through
+/// shared slots so they can communicate state changes during long-running
+/// operations without holding direct broadcast access.
+///
+/// The runtime's closure inside the sink is responsible for routing each
+/// request to the appropriate handler — for example, translating
+/// [`BusRequest::EmitAgentEvent`] into a `broadcast::Sender::send` call.
+/// Features only see the typed `BusRequest` contract.
+#[derive(Clone)]
+pub struct BusRequestSink {
+    inner: Option<Arc<dyn Fn(BusRequest) + Send + Sync>>,
+}
+
+impl BusRequestSink {
+    /// A no-op sink. Requests pushed into this are silently dropped —
+    /// correct for tests, headless paths, and any context without a
+    /// live runtime.
+    pub fn noop() -> Self {
+        Self { inner: None }
+    }
+
+    /// Wrap a callback as a sink. The runtime constructs one of these
+    /// at startup with a closure that routes each `BusRequest` variant
+    /// to its appropriate handler.
+    pub fn from_fn<F>(f: F) -> Self
+    where
+        F: Fn(BusRequest) + Send + Sync + 'static,
+    {
+        Self {
+            inner: Some(Arc::new(f)),
+        }
+    }
+
+    /// Push a request. No-op if the sink is inactive.
+    pub fn send(&self, request: BusRequest) {
+        if let Some(cb) = &self.inner {
+            cb(request);
+        }
+    }
+
+    /// Whether anyone is actually listening.
+    pub fn is_active(&self) -> bool {
+        self.inner.is_some()
+    }
+}
+
+impl std::fmt::Debug for BusRequestSink {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("BusRequestSink")
+            .field("active", &self.is_active())
+            .finish()
+    }
 }
 
 /// Notification severity level.

--- a/core/crates/omegon/src/features/cleave.rs
+++ b/core/crates/omegon/src/features/cleave.rs
@@ -17,24 +17,31 @@ use async_trait::async_trait;
 use serde_json::{Value, json};
 
 use omegon_traits::{
-    AgentEvent, BusEvent, BusRequest, CommandDefinition, CommandResult, ContentBlock, Feature,
-    ToolDefinition, ToolResult,
+    AgentEvent, BusEvent, BusRequest, BusRequestSink, CommandDefinition, CommandResult,
+    ContentBlock, Feature, ToolDefinition, ToolResult,
 };
-use tokio::sync::broadcast;
 
-/// Shared slot for the AgentEvent broadcast sender.
+/// Shared slot for the runtime-supplied [`BusRequestSink`].
 ///
-/// CleaveFeature needs to emit `AgentEvent::Decomposition*` events to
-/// surface tree state changes to consumers (web dashboard, IPC / Auspex,
-/// TUI). The features layer is constructed in `setup.rs` *before* the
+/// CleaveFeature needs to emit `AgentEvent::Decomposition*` and
+/// `AgentEvent::FamilyVitalSignsUpdated` events to surface tree state
+/// changes to consumers (web dashboard, IPC / Auspex, eventual TUI).
+/// The features layer is constructed in `setup.rs` *before* the runtime's
 /// broadcast channel exists in `main.rs`, so we hand out a shared slot
-/// at feature-construction time and let main.rs write the sender into
-/// it once the channel is up.
+/// at feature-construction time and let main.rs install a typed
+/// `BusRequestSink` into it once the channel is up.
 ///
-/// Until the slot is populated, decomposition emissions are silently
-/// dropped — this is correct for tests and for any code path that
-/// constructs the feature without a live event bus.
-pub type CleaveEventSlot = Arc<Mutex<Option<broadcast::Sender<AgentEvent>>>>;
+/// Going through `BusRequestSink` (rather than holding a
+/// `broadcast::Sender<AgentEvent>` directly) keeps the cleave feature
+/// decoupled from the transport layer — the runtime is the only thing
+/// that touches the broadcast channel, and it routes incoming
+/// `BusRequest::EmitAgentEvent` requests there. Features only see the
+/// typed `BusRequest` contract.
+///
+/// Until the slot is populated, emissions are silently dropped — correct
+/// for tests and for any code path that constructs the feature without
+/// a live runtime.
+pub type CleaveEventSlot = Arc<Mutex<Option<BusRequestSink>>>;
 
 use crate::cleave::{
     self, CleavePlan,
@@ -478,9 +485,10 @@ pub struct CleaveFeature {
     pub inventory: Option<std::sync::Arc<tokio::sync::RwLock<crate::routing::ProviderInventory>>>,
     /// Startup-approved secret env inherited by child runs.
     session_secret_env: Vec<(String, String)>,
-    /// Slot holding the AgentEvent broadcast sender once the runtime has
-    /// constructed it. See [`CleaveEventSlot`] for the rationale.
-    event_sender: CleaveEventSlot,
+    /// Slot holding the runtime-supplied `BusRequestSink` once the
+    /// runtime has constructed it. See [`CleaveEventSlot`] for the
+    /// rationale.
+    bus_request_sink: CleaveEventSlot,
 }
 
 impl CleaveFeature {
@@ -492,27 +500,27 @@ impl CleaveFeature {
             child_cancel_tokens: Arc::new(Mutex::new(HashMap::new())),
             inventory: None,
             session_secret_env,
-            event_sender: Arc::new(Mutex::new(None)),
+            bus_request_sink: Arc::new(Mutex::new(None)),
         };
         feature.refresh_progress_from_workspace_state();
         feature
     }
 
-    /// Hand out a clone of the event-sender slot so the runtime can write
-    /// the broadcast `Sender<AgentEvent>` into it once the channel exists.
+    /// Hand out a clone of the bus-request slot so the runtime can install
+    /// a typed [`BusRequestSink`] once the broadcast channel exists.
     /// Must be called *before* `bus.register(Box::new(feature))` consumes
     /// the typed `CleaveFeature`.
     pub fn event_sender_slot(&self) -> CleaveEventSlot {
-        Arc::clone(&self.event_sender)
+        Arc::clone(&self.bus_request_sink)
     }
 
-    /// Send a decomposition event on the broadcast channel if a sender is
-    /// installed. Silently dropped otherwise — tests and headless runs
-    /// don't have an event bus and shouldn't fail because of it.
+    /// Push an `AgentEvent` through the runtime's `BusRequestSink` if one
+    /// is installed. Silently dropped otherwise — tests and headless runs
+    /// don't have a runtime sink and shouldn't fail because of it.
     fn emit_decomposition_event(&self, event: AgentEvent) {
-        if let Ok(slot) = self.event_sender.lock() {
-            if let Some(tx) = slot.as_ref() {
-                let _ = tx.send(event);
+        if let Ok(slot) = self.bus_request_sink.lock() {
+            if let Some(sink) = slot.as_ref() {
+                sink.send(BusRequest::EmitAgentEvent { event });
             }
         }
     }
@@ -794,6 +802,17 @@ impl CleaveFeature {
                 // Update internal cleave progress state first.
                 apply_progress_event(&shared, event);
 
+                // Snapshot the bus sink once per callback so we don't
+                // hold the slot lock across emissions. The sink itself
+                // is `Clone` (Arc-backed) so cloning is cheap.
+                let sink_snapshot = event_slot
+                    .lock()
+                    .ok()
+                    .and_then(|slot| slot.as_ref().cloned());
+                let Some(sink) = sink_snapshot else {
+                    return;
+                };
+
                 // ── Decomposition lifecycle event 2 of 3 ──────────────
                 // Per-child terminal transitions get surfaced as
                 // DecompositionChildCompleted. The four terminal statuses
@@ -806,14 +825,12 @@ impl CleaveFeature {
                         ChildProgressStatus::Completed
                             | ChildProgressStatus::MergedAfterFailure
                     );
-                    if let Ok(slot) = event_slot.lock() {
-                        if let Some(tx) = slot.as_ref() {
-                            let _ = tx.send(AgentEvent::DecompositionChildCompleted {
-                                label: child.clone(),
-                                success,
-                            });
-                        }
-                    }
+                    sink.send(BusRequest::EmitAgentEvent {
+                        event: AgentEvent::DecompositionChildCompleted {
+                            label: child.clone(),
+                            success,
+                        },
+                    });
                 }
 
                 // ── Family vital signs (L3 rollup) ─────────────────────
@@ -823,13 +840,11 @@ impl CleaveFeature {
                 // orchestrator doesn't fire ProgressEvents at high
                 // frequency (a handful per child per minute) so no
                 // rate-limiting is needed here.
-                if let Ok(slot) = event_slot.lock() {
-                    if let Some(tx) = slot.as_ref() {
-                        if let Ok(progress_guard) = shared.lock() {
-                            let signs = build_family_vital_signs(&progress_guard);
-                            let _ = tx.send(AgentEvent::FamilyVitalSignsUpdated { signs });
-                        }
-                    }
+                if let Ok(progress_guard) = shared.lock() {
+                    let signs = build_family_vital_signs(&progress_guard);
+                    sink.send(BusRequest::EmitAgentEvent {
+                        event: AgentEvent::FamilyVitalSignsUpdated { signs },
+                    });
                 }
             })
         };
@@ -1444,14 +1459,29 @@ mod tests {
         assert_eq!(signs.children[2].last_activity_unix_ms, None);
     }
 
+    /// Test helper: build a `BusRequestSink` that forwards
+    /// `BusRequest::EmitAgentEvent` requests onto a broadcast channel,
+    /// returning the receiver so the test can assert what arrived.
+    fn test_sink_with_receiver() -> (BusRequestSink, tokio::sync::broadcast::Receiver<AgentEvent>)
+    {
+        let (tx, rx) = tokio::sync::broadcast::channel::<AgentEvent>(8);
+        let sink = BusRequestSink::from_fn(move |request| {
+            if let BusRequest::EmitAgentEvent { event } = request {
+                let _ = tx.send(event);
+            }
+        });
+        (sink, rx)
+    }
+
     #[tokio::test]
     async fn event_slot_routes_family_vital_signs() {
-        // Wire a real broadcast channel into the slot and assert that
-        // FamilyVitalSignsUpdated reaches a subscribed receiver.
+        // Install a BusRequestSink wrapping a broadcast channel into the
+        // slot and assert that FamilyVitalSignsUpdated reaches a subscribed
+        // receiver via the BusRequest::EmitAgentEvent pathway.
         let dir = tempfile::tempdir().unwrap();
         let feature = CleaveFeature::new(dir.path(), vec![]);
-        let (tx, mut rx) = broadcast::channel::<AgentEvent>(8);
-        *feature.event_sender_slot().lock().unwrap() = Some(tx);
+        let (sink, mut rx) = test_sink_with_receiver();
+        *feature.event_sender_slot().lock().unwrap() = Some(sink);
 
         let signs = omegon_traits::FamilyVitalSigns {
             run_id: "test".into(),
@@ -1491,15 +1521,16 @@ mod tests {
 
     #[tokio::test]
     async fn event_slot_routes_emissions_when_populated() {
-        // Install a broadcast sender into the slot and verify all three
-        // decomposition variants reach a subscribed receiver. This is the
-        // mechanism the cleave run path uses; the call sites in execute_run
-        // are reviewed manually since they require a real subprocess
-        // dispatch to exercise end-to-end.
+        // Install a BusRequestSink into the slot and verify all three
+        // decomposition variants reach a subscribed receiver via the
+        // BusRequest::EmitAgentEvent pathway. The mechanism the cleave
+        // run path uses; the call sites in execute_run are reviewed
+        // manually since they require a real subprocess dispatch to
+        // exercise end-to-end.
         let dir = tempfile::tempdir().unwrap();
         let feature = CleaveFeature::new(dir.path(), vec![]);
-        let (tx, mut rx) = broadcast::channel::<AgentEvent>(8);
-        *feature.event_sender_slot().lock().unwrap() = Some(tx);
+        let (sink, mut rx) = test_sink_with_receiver();
+        *feature.event_sender_slot().lock().unwrap() = Some(sink);
 
         feature.emit_decomposition_event(AgentEvent::DecompositionStarted {
             children: vec!["alpha".into(), "beta".into()],

--- a/core/crates/omegon/src/loop.rs
+++ b/core/crates/omegon/src/loop.rs
@@ -1355,6 +1355,9 @@ pub async fn run(
                         tracing::debug!(source, "auto-store fact skipped: {e}");
                     }
                 }
+                omegon_traits::BusRequest::EmitAgentEvent { event } => {
+                    let _ = events.send(event);
+                }
             }
         }
 
@@ -1456,6 +1459,9 @@ pub async fn run(
                 {
                     tracing::debug!(source, "post-loop auto-store fact skipped: {e}");
                 }
+            }
+            omegon_traits::BusRequest::EmitAgentEvent { event } => {
+                let _ = events.send(event);
             }
         }
     }

--- a/core/crates/omegon/src/main.rs
+++ b/core/crates/omegon/src/main.rs
@@ -405,6 +405,28 @@ enum PluginAction {
     },
 }
 
+/// Build a typed `BusRequestSink` that the runtime hands to features
+/// (currently just cleave) so they can communicate with the broadcast
+/// channel via the `BusRequest` contract instead of holding a
+/// `broadcast::Sender<AgentEvent>` directly.
+///
+/// Today the only variant the sink translates is
+/// `BusRequest::EmitAgentEvent`, which forwards onto the broadcast
+/// channel. Other `BusRequest` variants pushed through here are dropped
+/// silently — features can still surface them through the conventional
+/// `Vec<BusRequest>` return path from `on_event`. As more long-running
+/// features need mid-execution communication, additional variants get
+/// handled here.
+fn build_runtime_bus_request_sink(
+    events_tx: tokio::sync::broadcast::Sender<AgentEvent>,
+) -> omegon_traits::BusRequestSink {
+    omegon_traits::BusRequestSink::from_fn(move |request| {
+        if let omegon_traits::BusRequest::EmitAgentEvent { event } = request {
+            let _ = events_tx.send(event);
+        }
+    })
+}
+
 fn parse_csv_env(name: &str) -> Vec<String> {
     std::env::var(name)
         .ok()
@@ -709,10 +731,12 @@ async fn run_embedded_command(control_port: u16, strict_port: bool) -> anyhow::R
     // ─── Event channel (shared with web dashboard) ──────────────────────
     let (events_tx, _) = broadcast::channel::<AgentEvent>(256);
 
-    // Hand the broadcast sender to the cleave feature so it can emit
-    // AgentEvent::Decomposition* events from inside its tool execution path.
+    // Install a typed BusRequestSink into the cleave feature's slot so
+    // it can emit AgentEvents from inside its tool execution path. The
+    // sink routes BusRequest::EmitAgentEvent to the broadcast channel —
+    // the cleave feature itself never touches the broadcast directly.
     if let Ok(mut slot) = agent.cleave_event_slot.lock() {
-        *slot = Some(events_tx.clone());
+        *slot = Some(build_runtime_bus_request_sink(events_tx.clone()));
     }
 
     // ─── Web control plane ──────────────────────────────────────────────
@@ -1311,10 +1335,12 @@ async fn run_interactive_command(cli: &Cli) -> anyhow::Result<()> {
         *shared_tx = Some(command_tx.clone());
     }
 
-    // Hand the broadcast sender to the cleave feature so it can emit
-    // AgentEvent::Decomposition* events from inside its tool execution path.
+    // Install a typed BusRequestSink into the cleave feature's slot so
+    // it can emit AgentEvents from inside its tool execution path. The
+    // sink routes BusRequest::EmitAgentEvent to the broadcast channel —
+    // the cleave feature itself never touches the broadcast directly.
     if let Ok(mut slot) = agent.cleave_event_slot.lock() {
-        *slot = Some(events_tx.clone());
+        *slot = Some(build_runtime_bus_request_sink(events_tx.clone()));
     }
 
     let pending_compact = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
@@ -2301,6 +2327,9 @@ async fn run_interactive_command(cli: &Cli) -> anyhow::Result<()> {
                                 tracing::debug!(source, "auto-store fact skipped: {e}");
                             }
                         }
+                        omegon_traits::BusRequest::EmitAgentEvent { event } => {
+                            let _ = events_tx.send(event);
+                        }
                     }
                 }
             }
@@ -3130,10 +3159,12 @@ async fn run_agent_command(cli: &Cli, usage_json: Option<PathBuf>) -> anyhow::Re
     // ─── Event channel ──────────────────────────────────────────────────
     let (events_tx, mut events_rx) = broadcast::channel::<AgentEvent>(256);
 
-    // Hand the broadcast sender to the cleave feature so it can emit
-    // AgentEvent::Decomposition* events from inside its tool execution path.
+    // Install a typed BusRequestSink into the cleave feature's slot so
+    // it can emit AgentEvents from inside its tool execution path. The
+    // sink routes BusRequest::EmitAgentEvent to the broadcast channel —
+    // the cleave feature itself never touches the broadcast directly.
     if let Ok(mut slot) = agent.cleave_event_slot.lock() {
-        *slot = Some(events_tx.clone());
+        *slot = Some(build_runtime_bus_request_sink(events_tx.clone()));
     }
 
     let benchmark_summary = std::sync::Arc::new(std::sync::Mutex::new(BenchmarkUsageSummary {


### PR DESCRIPTION
## Summary

- New \`BusRequest::EmitAgentEvent { event }\` variant + \`BusRequestSink\` callback type. Features push events through the typed sink; the runtime is the only thing that touches the broadcast channel.
- Refactors \`CleaveFeature\` to use the new path. The feature no longer imports \`tokio::sync::broadcast\` at all.
- Pays down the architectural-seam debt called out in #25's PR body.

## Why

\#25 wired cleave's decomposition events by stashing a \`broadcast::Sender<AgentEvent>\` directly inside \`CleaveFeature\` via a shared slot. That worked but features didn't previously hold broadcast access — they communicated with the runtime through typed \`BusRequest\` returns. The slot pattern crossed that seam.

This PR keeps the slot but puts a typed \`BusRequestSink\` in it instead of the raw broadcast \`Sender\`. The cleave feature only sees the typed contract; the runtime translates \`EmitAgentEvent\` to \`broadcast::send\` inside its own closure. Same outward behavior, restored architecture.

## Design notes

- **\`BusRequestSink\` is exactly analogous to \`ToolProgressSink\`.** Same shape (callback-backed, no tokio dep in the trait crate, \`from_fn\` constructor, \`send\` / \`is_active\` / \`noop\` API). Same lifecycle (runtime constructs it; feature holds a clone via shared slot).
- **The runtime sink in \`main.rs\` only handles \`EmitAgentEvent\` today.** Other \`BusRequest\` variants pushed through the sink are dropped silently — features can still surface them through the conventional \`Vec<BusRequest>\` return path from \`on_event\`. Additional variants get handled here as more long-running features need mid-execution communication. The pattern scales without re-architecting.
- **Three \`BusRequest\` exhaustive matches needed an \`EmitAgentEvent\` arm**: \`loop.rs:1310\` (main turn drain), \`loop.rs:1433\` (post-loop drain), \`main.rs:2283\` (TUI command-result drain). Each one just calls \`events.send(event)\`.
- **Tests use a new \`test_sink_with_receiver\` helper** that builds a \`BusRequestSink\` wrapping a broadcast channel, returning the receiver for assertions. Same coverage as the original tests, transport-agnostic.

## Test plan

- [x] \`cargo check -p omegon\` — clean (only the 6 pre-existing warnings)
- [x] \`cargo test -p omegon --bin omegon features::cleave\` — **32/32 passing**, including the two updated event-slot tests
- [x] \`cargo test -p omegon --bin omegon\` — **1511 passed**, 0 failed, 1 ignored
- [x] Verified \`use tokio::sync::broadcast\` no longer appears anywhere in \`features/cleave.rs\`

## Out of scope

- Adapting other features. Cleave is currently the only feature that needs mid-execution event emission. If/when delegate, mcp, or another long-running feature wants the same access, they hold a \`BusRequestSink\` of their own through the same slot pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)