### PR TITLE
fix(armory): tolerate broken-pipe race when child closes stdin early

### DIFF
--- a/core/crates/omegon/src/plugins/armory_feature.rs
+++ b/core/crates/omegon/src/plugins/armory_feature.rs
@@ -183,11 +183,14 @@ impl ArmoryFeature {
             .spawn()
             .map_err(|e| anyhow::anyhow!("failed to spawn {cmd} {script_str}: {e}"))?;
 
-        // Write args to stdin then close
-        if let Some(mut stdin) = child.stdin.take() {
-            stdin.write_all(input.as_bytes()).await?;
-            stdin.shutdown().await?;
-        }
+        // Write args to stdin then close. We tolerate broken-pipe errors:
+        // a fast script that doesn't actually read its stdin (e.g.
+        // `echo 'hello'`) will close the read end of the pipe before
+        // we finish writing, which is harmless — the child has already
+        // moved on to producing its output. Propagating that error here
+        // would manifest as a flaky test on busy CI runners (the race
+        // is wall-clock dependent).
+        write_stdin_best_effort(child.stdin.take(), input.as_bytes()).await;
 
         // Wait with timeout + cancellation
         let wait_fut = child.wait_with_output();
@@ -258,10 +261,9 @@ impl ArmoryFeature {
             .spawn()
             .map_err(|e| anyhow::anyhow!("failed to spawn {runtime} run: {e}"))?;
 
-        if let Some(mut stdin) = child.stdin.take() {
-            stdin.write_all(input.as_bytes()).await?;
-            stdin.shutdown().await?;
-        }
+        // Same broken-pipe tolerance as execute_script — see the comment
+        // there for the rationale.
+        write_stdin_best_effort(child.stdin.take(), input.as_bytes()).await;
 
         let wait_fut = child.wait_with_output();
         tokio::pin!(wait_fut);
@@ -279,6 +281,23 @@ impl ArmoryFeature {
 
         parse_tool_output(&tool.name, &output)
     }
+}
+
+/// Write `input` to a child process's stdin and close it, tolerating
+/// broken-pipe errors (which are benign and racy: a fast child that
+/// doesn't actually read its stdin will have closed the read end before
+/// we finish writing). All other I/O errors are silently dropped — if
+/// the child can't receive its arguments, that will surface as a tool
+/// error from the script's own behavior, not from this function.
+async fn write_stdin_best_effort(
+    stdin: Option<tokio::process::ChildStdin>,
+    input: &[u8],
+) {
+    let Some(mut stdin) = stdin else {
+        return;
+    };
+    let _ = stdin.write_all(input).await;
+    let _ = stdin.shutdown().await;
 }
 
 #[async_trait]


### PR DESCRIPTION
## Summary

- Fixes the intermittent \`plugins::armory_feature::tests::execute_script_*\` failures with \`broken pipe (os error 32)\` panics.
- Both \`execute_script\` and \`execute_oci\` in \`armory_feature.rs\` had identical bug-prone stdin patterns. New \`write_stdin_best_effort\` helper handles both.

## Why

The race: a fast bash script that doesn't actually read its stdin (e.g. \`echo 'plain text result'\`) closes the read end of the pipe before \`stdin.write_all().await?; stdin.shutdown().await?\` finishes, which surfaces as a broken-pipe error from the \`?\` operator. The test then unwraps the \`Err\` and panics. On a fast machine the child usually waits long enough to receive the input first; on a contended pool it doesn't.

Wall-clock dependent → flaky.

I called out the flake in the assessment after #27 — saw it on two of three full-suite runs but never in isolation. The 15 armory tests reliably pass when run alone because the test pool isn't contended.

## Fix

New private \`write_stdin_best_effort\` helper that performs the same write+shutdown sequence but discards I/O errors. Both call sites use the helper. Broken-pipe here is benign and racy — if the child genuinely can't receive its arguments, that surfaces as a tool error from the script's own behavior (missing args, parse failure, etc.), not from this plumbing function. Inline comments document the rationale so future maintainers don't re-introduce the strict error propagation.

## Test plan

- [x] \`cargo test -p omegon --bin omegon plugins::armory_feature\` — **15/15 passing**
- [x] \`cargo test -p omegon --bin omegon\` — **1511 passed, 0 failed, 1 ignored**
- [x] Two clean back-to-back full runs after the fix (where one of three was failing before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)