### PR TITLE
feat(local_inference): stream Ollama tokens through ToolProgressSink

### DIFF
--- a/core/crates/omegon/src/tools/local_inference.rs
+++ b/core/crates/omegon/src/tools/local_inference.rs
@@ -4,14 +4,25 @@
 //! Communicates with Ollama's OpenAI-compatible API at localhost:11434.
 
 use async_trait::async_trait;
-use omegon_traits::{ContentBlock, ToolDefinition, ToolProvider, ToolResult};
+use futures_util::StreamExt;
+use omegon_traits::{
+    ContentBlock, PartialToolResult, ProgressUnits, ToolDefinition, ToolProgress, ToolProgressSink,
+    ToolProvider, ToolResult,
+};
 use serde::Deserialize;
 use serde_json::{Value, json};
 use std::env;
 use std::process::Command;
+use std::time::{Duration, Instant};
 use tokio_util::sync::CancellationToken;
 
 const DEFAULT_URL: &str = "http://localhost:11434";
+
+/// Minimum interval between content-bearing streaming partials, mirroring
+/// the bash runner's flush rate. Token streams from local models can fire
+/// at hundreds of tokens per second on small models — without this we'd
+/// flood the broadcast channel for no benefit.
+const STREAM_FLUSH_INTERVAL: Duration = Duration::from_millis(150);
 
 fn base_url() -> String {
     env::var("LOCAL_INFERENCE_URL").unwrap_or_else(|_| DEFAULT_URL.to_string())
@@ -78,6 +89,145 @@ impl LocalInferenceProvider {
             .map(|c| c.message.content.clone())
             .unwrap_or_default();
         Ok(content)
+    }
+
+    /// Streaming variant of [`chat_completion`]. Sets `stream: true` on
+    /// the OpenAI-compatible request, parses Server-Sent Events from the
+    /// response body, and pushes rate-limited [`PartialToolResult`]s into
+    /// the supplied [`ToolProgressSink`] as tokens arrive.
+    ///
+    /// On the wire each chunk looks like:
+    ///
+    /// ```text
+    /// data: {"id":"...","choices":[{"delta":{"content":"hello"}}]}
+    ///
+    /// data: {"id":"...","choices":[{"delta":{"content":" world"}}]}
+    ///
+    /// data: [DONE]
+    ///
+    /// ```
+    ///
+    /// We accumulate `delta.content` strings into the response buffer
+    /// and emit a partial whenever the rate limiter allows. Token count
+    /// is approximated as "deltas observed", which is a slight
+    /// undercount for multi-token deltas but accurate enough for the
+    /// progress display ("how much has the model produced so far?").
+    async fn chat_completion_streaming(
+        &self,
+        model: &str,
+        prompt: &str,
+        system: Option<&str>,
+        temperature: f32,
+        max_tokens: u32,
+        sink: &ToolProgressSink,
+    ) -> anyhow::Result<String> {
+        let url = format!("{}/v1/chat/completions", base_url());
+        let mut messages = Vec::new();
+        if let Some(sys) = system {
+            messages.push(json!({"role": "system", "content": sys}));
+        }
+        messages.push(json!({"role": "user", "content": prompt}));
+
+        let body = json!({
+            "model": model,
+            "messages": messages,
+            "temperature": temperature,
+            "max_tokens": max_tokens,
+            "stream": true,
+        });
+
+        let resp = self.client.post(&url).json(&body).send().await?;
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let text = resp.text().await.unwrap_or_default();
+            anyhow::bail!("Chat completion (streaming) failed ({status}): {text}");
+        }
+
+        let started = Instant::now();
+        let max_tokens_u64 = u64::from(max_tokens);
+        let sink_active = sink.is_active();
+        let mut accumulated = String::new();
+        let mut deltas_seen: u64 = 0;
+        let mut last_flush = Instant::now();
+
+        // SSE chunks may not align with line boundaries — buffer the
+        // partial bytes between chunks until we see a `\n\n` separator.
+        let mut sse_buffer = String::new();
+        let mut byte_stream = resp.bytes_stream();
+
+        while let Some(chunk) = byte_stream.next().await {
+            let chunk = chunk?;
+            sse_buffer.push_str(&String::from_utf8_lossy(&chunk));
+
+            // Process every complete SSE event in the buffer. Events are
+            // delimited by `\n\n`. Anything left over stays in the buffer
+            // for the next chunk.
+            loop {
+                let Some(end) = sse_buffer.find("\n\n") else {
+                    break;
+                };
+                let event = sse_buffer[..end].to_string();
+                sse_buffer.drain(..end + 2);
+
+                for line in event.lines() {
+                    let Some(payload) = line.strip_prefix("data: ") else {
+                        continue;
+                    };
+                    if payload == "[DONE]" {
+                        // End of stream — flush a final partial below.
+                        continue;
+                    }
+                    let parsed: Result<StreamingChatChunk, _> = serde_json::from_str(payload);
+                    let Ok(chunk_obj) = parsed else {
+                        // Skip malformed chunks rather than aborting the
+                        // whole call. Ollama occasionally sends keep-alive
+                        // garbage that doesn't fit the schema; the rest
+                        // of the stream is still useful.
+                        continue;
+                    };
+                    if let Some(choice) = chunk_obj.choices.first() {
+                        if let Some(content) = choice.delta.content.as_deref() {
+                            if !content.is_empty() {
+                                accumulated.push_str(content);
+                                deltas_seen += 1;
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Rate-limited partial emission. Same pattern as bash:
+            // 150ms minimum between flushes, sink-aware so we skip the
+            // string clone when nobody's listening.
+            if sink_active && last_flush.elapsed() >= STREAM_FLUSH_INTERVAL {
+                last_flush = Instant::now();
+                sink.send(PartialToolResult {
+                    tail: accumulated.clone(),
+                    progress: ToolProgress {
+                        elapsed_ms: started.elapsed().as_millis() as u64,
+                        heartbeat: false,
+                        phase: Some(format!("generating ({model})")),
+                        units: Some(ProgressUnits {
+                            current: deltas_seen,
+                            // Total is the model's max_tokens cap, not
+                            // the actual token count it'll produce — the
+                            // model usually stops well before. Still
+                            // gives consumers a sane upper bound for
+                            // progress bars.
+                            total: Some(max_tokens_u64),
+                            unit: "tokens".to_string(),
+                        }),
+                        tally: None,
+                    },
+                    details: json!({
+                        "model": model,
+                        "max_tokens": max_tokens,
+                    }),
+                });
+            }
+        }
+
+        Ok(accumulated)
     }
 
     async fn ollama_status(&self) -> String {
@@ -174,6 +324,22 @@ struct ChatChoice {
 #[derive(Deserialize)]
 struct ChatMessage {
     content: String,
+}
+
+#[derive(Deserialize)]
+struct StreamingChatChunk {
+    choices: Vec<StreamingChoice>,
+}
+
+#[derive(Deserialize)]
+struct StreamingChoice {
+    delta: StreamingDelta,
+}
+
+#[derive(Deserialize)]
+struct StreamingDelta {
+    #[serde(default)]
+    content: Option<String>,
 }
 
 #[async_trait]
@@ -310,6 +476,64 @@ impl ToolProvider for LocalInferenceProvider {
             _ => anyhow::bail!("Unknown tool: {tool_name}"),
         }
     }
+
+    /// Sink-aware override that routes `ask_local_model` through the
+    /// streaming chat-completion path when a consumer is attached.
+    /// `list_local_models` and `manage_ollama` are inherently single-shot
+    /// HTTP calls and fall back to the buffered `execute` path.
+    async fn execute_with_sink(
+        &self,
+        tool_name: &str,
+        call_id: &str,
+        args: Value,
+        cancel: CancellationToken,
+        sink: ToolProgressSink,
+    ) -> anyhow::Result<ToolResult> {
+        // Only ask_local_model benefits from streaming. Skip the
+        // streaming dispatch entirely if no sink is attached so the
+        // non-streaming path stays the default for consumers that
+        // don't need live token output.
+        if tool_name != "ask_local_model" || !sink.is_active() {
+            return self.execute(tool_name, call_id, args, cancel).await;
+        }
+
+        let prompt = args.get("prompt").and_then(|v| v.as_str()).unwrap_or("");
+        let system = args.get("system").and_then(|v| v.as_str());
+        let temperature = args
+            .get("temperature")
+            .and_then(|v| v.as_f64())
+            .unwrap_or(0.3) as f32;
+        let max_tokens = args
+            .get("max_tokens")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(2048) as u32;
+
+        let model = if let Some(m) = args.get("model").and_then(|v| v.as_str()) {
+            m.to_string()
+        } else {
+            self.auto_select_model()
+                .await
+                .unwrap_or_else(|| "qwen3:8b".into())
+        };
+
+        match self
+            .chat_completion_streaming(&model, prompt, system, temperature, max_tokens, &sink)
+            .await
+        {
+            Ok(response) => Ok(ToolResult {
+                content: vec![ContentBlock::Text {
+                    text: format!("[Model: {model}]\n\n{response}"),
+                }],
+                details: json!({"model": model}),
+            }),
+            Err(e) => Ok(ToolResult {
+                content: vec![ContentBlock::Text {
+                    text: format!("Local model error: {e}"),
+                }],
+                details: json!({"error": true}),
+            }),
+        }
+    }
 }
 
 /// Execute local inference tools with standard CoreTools signature.
@@ -343,5 +567,39 @@ mod tests {
         // Without env var, should return default
         let url = base_url();
         assert!(url.contains("11434") || env::var("LOCAL_INFERENCE_URL").is_ok());
+    }
+
+    #[test]
+    fn streaming_chat_chunk_parses_openai_format() {
+        // Verify the SSE chunk deserializer accepts the OpenAI-compatible
+        // shape Ollama emits. Each chunk has `choices[0].delta.content`
+        // which we extract and accumulate.
+        let payload = r#"{"id":"chatcmpl-123","object":"chat.completion.chunk","created":1700000000,"model":"qwen3:8b","choices":[{"index":0,"delta":{"content":"hello"},"finish_reason":null}]}"#;
+        let chunk: StreamingChatChunk = serde_json::from_str(payload).unwrap();
+        assert_eq!(chunk.choices.len(), 1);
+        assert_eq!(chunk.choices[0].delta.content.as_deref(), Some("hello"));
+    }
+
+    #[test]
+    fn streaming_chat_chunk_handles_empty_delta() {
+        // OpenAI sends an initial chunk with `delta: {"role": "assistant"}`
+        // and a final chunk with `delta: {}` followed by [DONE]. Both
+        // should deserialize cleanly with `content` as None.
+        let initial = r#"{"choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]}"#;
+        let chunk: StreamingChatChunk = serde_json::from_str(initial).unwrap();
+        assert!(chunk.choices[0].delta.content.is_none());
+
+        let final_chunk = r#"{"choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}"#;
+        let chunk: StreamingChatChunk = serde_json::from_str(final_chunk).unwrap();
+        assert!(chunk.choices[0].delta.content.is_none());
+    }
+
+    #[test]
+    fn streaming_chat_chunk_skips_unrelated_fields() {
+        // Real Ollama responses include extra fields beyond what we
+        // model. The deserializer should ignore them.
+        let payload = r#"{"id":"x","object":"chat.completion.chunk","model":"qwen","system_fingerprint":"fp_abc","choices":[{"index":0,"delta":{"content":"world","role":null},"logprobs":null,"finish_reason":null}],"usage":null}"#;
+        let chunk: StreamingChatChunk = serde_json::from_str(payload).unwrap();
+        assert_eq!(chunk.choices[0].delta.content.as_deref(), Some("world"));
     }
 }


### PR DESCRIPTION
## Summary

- Second L1 runner to grow streaming. \`ask_local_model\` previously sent \`stream: false\` to Ollama and buffered the full response — multi-second to multi-minute calls appeared as a single tool segment with no live progress.
- New \`chat_completion_streaming\` method parses the OpenAI-compatible SSE chunk stream incrementally and pushes rate-limited partials into the \`ToolProgressSink\` as tokens arrive.
- New \`execute_with_sink\` override routes \`ask_local_model\` through the streaming path *only when a consumer is attached*. Other tools (\`list_local_models\`, \`manage_ollama\`) fall back to the buffered path since they're inherently single-shot HTTP calls.

## Why

After bash, local_inference is the highest-leverage L1 runner: it's the one that produces tokens at a meaningful rate over a meaningful duration on a real model. The audit explicitly called this out as the next L1 worth doing once the streaming infrastructure existed.

## Design notes

- **Reuses the bash flush cadence (150ms).** Token streams from small models can fire at hundreds of tokens/sec — without the rate limit we'd flood the broadcast channel for no benefit.
- **\`units.total\` is set to \`max_tokens\`** rather than the actual token count the model will produce. The model usually stops well before max_tokens, but it gives consumers a sane upper bound for progress bars without requiring an additional Ollama call.
- **Phase label is \`\"generating ({model})\"\`** — gives operators a sense of which model is responding without parsing the partial's details.
- **SSE buffering handles cross-chunk events.** A single TCP chunk may contain a partial SSE event; the buffer accumulates bytes between chunks until \`\\n\\n\` separators appear, then drains complete events one at a time. Malformed chunks are skipped (Ollama occasionally sends keep-alive garbage that doesn't fit the schema).
- **Sink-aware short-circuit.** \`execute_with_sink\` checks \`sink.is_active()\` and falls back to the buffered \`execute\` path if no consumer is listening. Headless / test paths get the original behavior with zero overhead.

## Test plan

- [x] \`cargo check -p omegon\` — clean
- [x] \`cargo test -p omegon --bin omegon tools::local_inference\` — 5/5 passing (3 new SSE deserializer tests)
- [x] \`cargo test -p omegon --bin omegon\` — **1514 passed, 0 failed, 1 ignored**
- [x] \`streaming_chat_chunk_parses_openai_format\` — typical chunk shape
- [x] \`streaming_chat_chunk_handles_empty_delta\` — initial role chunk + final empty chunk deserialize cleanly
- [x] \`streaming_chat_chunk_skips_unrelated_fields\` — verifies field-tolerance against a real-shaped Ollama payload with \`system_fingerprint\`, \`logprobs\`, \`usage\`
- [ ] **Live HTTP path is not unit-tested** — Ollama isn't available in CI. The deserializer + dispatch logic are exercised in isolation; the actual byte-stream loop is reviewed by inspection.

## L1 status after this PR

| Runner | Streaming | Notes |
|---|---|---|
| bash | ✓ | shipped #23/#24 |
| local_inference | ✓ | this PR |
| validate | ✗ | sidecar, not a runner — see #26 PR body |
| change/write/edit/read | ✗ | inherently short / single-shot |
| web_search/render | ✗ | HTTP request/response, no stream to surface |
| mcp | ⏳ | next branch — depends on per-server progress notification support |

🤖 Generated with [Claude Code](https://claude.com/claude-code)