### PR TITLE
feat(tui): TUI render-quality pass — live progress, table alignment, edit diffs, token annotations, clipboard retention

### DIFF
--- a/core/crates/omegon/src/clipboard.rs
+++ b/core/crates/omegon/src/clipboard.rs
@@ -1,0 +1,277 @@
+//! Clipboard paste retention.
+//!
+//! Clipboard image pastes (the `tui::pull_clipboard_image` path on
+//! macOS via `osascript`, on Linux via `wl-paste` / `xclip`) are
+//! written to the system temp directory under filenames like
+//! `omegon-clipboard-{pid}-{counter}.{ext}`. Without explicit cleanup,
+//! they accumulate forever — the operator screenshot that motivated
+//! this module showed a four-month-old paste backlog in `/tmp`.
+//!
+//! This module provides a deterministic prune sweep that:
+//!
+//! 1. Walks the system temp directory.
+//! 2. Filters to filenames matching the `omegon-clipboard-` prefix
+//!    (no recursive descent, no other patterns — only files this
+//!    process's clipboard path actually creates).
+//! 3. Deletes any matching file whose modification time is older
+//!    than the configured retention threshold.
+//!
+//! Sweep timing:
+//!
+//! - **Session start** (called from `main.rs`): once per launched
+//!   instance, using `Settings.clipboard_retention_hours` as the
+//!   threshold. This is the default cleanup point.
+//! - **On demand** via the `/clipboard prune` slash command: same
+//!   logic, runs immediately.
+//!
+//! Concurrency: multiple omegon processes share the same temp dir
+//! and may write clipboard pastes concurrently. The prune intentionally
+//! does NOT check whether a file's pid is still alive — a 24h-old
+//! paste is stale regardless of which process owns it. Cross-process
+//! safety comes from `std::fs::remove_file`'s atomic semantics: if
+//! another process is mid-read, the file gets unlinked but the
+//! reader's open handle keeps working.
+
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime};
+
+/// Filename prefix that identifies an omegon clipboard paste. Must
+/// stay in sync with the `format!("omegon-clipboard-{pid}-{counter}.{ext}")`
+/// strings in `tui::mod::pull_clipboard_image`.
+const CLIPBOARD_PREFIX: &str = "omegon-clipboard-";
+
+/// Result of a single sweep.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct PruneStats {
+    /// Files matching the clipboard prefix that were considered.
+    pub scanned: usize,
+    /// Files actually deleted because they were older than the threshold.
+    pub deleted: usize,
+    /// Files skipped because they were newer than the threshold.
+    pub skipped_recent: usize,
+    /// Files where reading metadata or deleting failed (logged, not fatal).
+    pub errors: usize,
+}
+
+impl PruneStats {
+    /// Human-readable one-liner for logging or surfacing in the
+    /// `/clipboard prune` slash command output.
+    pub fn summary(&self) -> String {
+        format!(
+            "clipboard prune: deleted {}, kept {} recent, {} error(s) ({} scanned)",
+            self.deleted, self.skipped_recent, self.errors, self.scanned
+        )
+    }
+}
+
+/// Prune clipboard pastes in the system temp directory older than
+/// `retention`. A `retention` of `Duration::ZERO` disables the sweep
+/// entirely (operator opt-out via `clipboard_retention_hours = 0`).
+///
+/// Returns a [`PruneStats`] summarizing what was touched. Errors on
+/// individual files are recorded in `errors` and do not abort the
+/// sweep — one unreadable file shouldn't block cleanup of the rest.
+pub fn prune_old_pastes(retention: Duration) -> std::io::Result<PruneStats> {
+    prune_old_pastes_in(&std::env::temp_dir(), retention)
+}
+
+/// Same as [`prune_old_pastes`] but operates on a caller-supplied
+/// directory. Exists so tests can target a tempdir instead of the
+/// real system temp directory.
+pub fn prune_old_pastes_in(
+    dir: &Path,
+    retention: Duration,
+) -> std::io::Result<PruneStats> {
+    let mut stats = PruneStats::default();
+    if retention.is_zero() {
+        // Operator-disabled sweep. Scan the directory anyway so we
+        // report a meaningful "0 deleted, N skipped" line, but never
+        // delete anything.
+        let entries = match std::fs::read_dir(dir) {
+            Ok(e) => e,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(stats),
+            Err(err) => return Err(err),
+        };
+        for entry in entries.flatten() {
+            if is_clipboard_file(&entry.path()) {
+                stats.scanned += 1;
+                stats.skipped_recent += 1;
+            }
+        }
+        return Ok(stats);
+    }
+
+    let now = SystemTime::now();
+    let entries = match std::fs::read_dir(dir) {
+        Ok(e) => e,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(stats),
+        Err(err) => return Err(err),
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !is_clipboard_file(&path) {
+            continue;
+        }
+        stats.scanned += 1;
+
+        let metadata = match entry.metadata() {
+            Ok(m) => m,
+            Err(_) => {
+                stats.errors += 1;
+                continue;
+            }
+        };
+        let modified = match metadata.modified() {
+            Ok(m) => m,
+            Err(_) => {
+                stats.errors += 1;
+                continue;
+            }
+        };
+        let age = now.duration_since(modified).unwrap_or(Duration::ZERO);
+        if age < retention {
+            stats.skipped_recent += 1;
+            continue;
+        }
+
+        match std::fs::remove_file(&path) {
+            Ok(()) => stats.deleted += 1,
+            Err(_) => stats.errors += 1,
+        }
+    }
+    Ok(stats)
+}
+
+/// Filter for files this module is allowed to touch. Match by:
+/// - filename (not path) starts with the literal `omegon-clipboard-`
+///   prefix
+/// - is a regular file (not a directory or symlink target)
+///
+/// Anything else in the temp directory is invisible to the prune sweep,
+/// even if it happens to be old. The match is intentionally narrow so
+/// we never delete files this module didn't create.
+fn is_clipboard_file(path: &Path) -> bool {
+    if !path.is_file() {
+        return false;
+    }
+    path.file_name()
+        .and_then(|n| n.to_str())
+        .is_some_and(|n| n.starts_with(CLIPBOARD_PREFIX))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn touch(dir: &Path, name: &str, age: Duration) -> PathBuf {
+        let path = dir.join(name);
+        fs::write(&path, b"test paste").unwrap();
+        let mtime = SystemTime::now() - age;
+        // Use filetime via libc-free std API: set_modified is on File on
+        // recent Rust, but the simpler portable path is the `filetime`
+        // crate. Since we don't want a new dep, fall back to manipulating
+        // the file's mtime via the std API on platforms that support it.
+        let f = fs::OpenOptions::new()
+            .write(true)
+            .open(&path)
+            .unwrap();
+        f.set_modified(mtime).unwrap();
+        path
+    }
+
+    #[test]
+    fn prune_deletes_files_older_than_retention() {
+        let tmp = tempfile::tempdir().unwrap();
+        let old = touch(tmp.path(), "omegon-clipboard-123-0.png", Duration::from_secs(48 * 3600));
+        let recent = touch(tmp.path(), "omegon-clipboard-123-1.png", Duration::from_secs(60));
+        let unrelated = touch(tmp.path(), "some-other-file.png", Duration::from_secs(48 * 3600));
+
+        let stats = prune_old_pastes_in(tmp.path(), Duration::from_secs(24 * 3600)).unwrap();
+
+        assert_eq!(stats.scanned, 2);
+        assert_eq!(stats.deleted, 1);
+        assert_eq!(stats.skipped_recent, 1);
+        assert_eq!(stats.errors, 0);
+        assert!(!old.exists(), "48h-old clipboard paste should be deleted");
+        assert!(recent.exists(), "1m-old clipboard paste should be kept");
+        assert!(
+            unrelated.exists(),
+            "unrelated files must NOT be touched by the sweep"
+        );
+    }
+
+    #[test]
+    fn prune_with_zero_retention_is_a_noop() {
+        // Operator opt-out: clipboard_retention_hours = 0 disables the
+        // sweep entirely. Files of any age are scanned but skipped.
+        let tmp = tempfile::tempdir().unwrap();
+        let old = touch(
+            tmp.path(),
+            "omegon-clipboard-1-0.png",
+            Duration::from_secs(365 * 24 * 3600),
+        );
+        let stats = prune_old_pastes_in(tmp.path(), Duration::ZERO).unwrap();
+        assert_eq!(stats.deleted, 0);
+        assert_eq!(stats.skipped_recent, 1);
+        assert!(old.exists(), "zero-retention sweep must not delete anything");
+    }
+
+    #[test]
+    fn prune_handles_missing_directory_gracefully() {
+        // Tests can run before the temp dir exists or in environments
+        // where it was just removed. The sweep should return an empty
+        // stats struct rather than erroring out.
+        let nowhere = std::path::PathBuf::from("/var/empty/this-does-not-exist");
+        let stats = prune_old_pastes_in(&nowhere, Duration::from_secs(3600)).unwrap();
+        assert_eq!(stats, PruneStats::default());
+    }
+
+    #[test]
+    fn prune_only_matches_omegon_clipboard_prefix() {
+        let tmp = tempfile::tempdir().unwrap();
+        // These should NOT be considered clipboard files even though
+        // they're old. Anything outside the omegon-clipboard- prefix
+        // is invisible to the sweep.
+        for name in [
+            "screenshot.png",
+            "clipboard-12-0.png",            // missing omegon- prefix
+            "omegon-other-12-0.png",         // wrong middle word
+            "OMEGON-CLIPBOARD-12-0.png",     // case-sensitive
+            "prefix-omegon-clipboard-1.png", // prefix in middle, not start
+        ] {
+            touch(tmp.path(), name, Duration::from_secs(48 * 3600));
+        }
+        let stats = prune_old_pastes_in(tmp.path(), Duration::from_secs(3600)).unwrap();
+        assert_eq!(stats.scanned, 0);
+        assert_eq!(stats.deleted, 0);
+
+        // All five files should still exist.
+        for name in [
+            "screenshot.png",
+            "clipboard-12-0.png",
+            "omegon-other-12-0.png",
+            "OMEGON-CLIPBOARD-12-0.png",
+            "prefix-omegon-clipboard-1.png",
+        ] {
+            assert!(
+                tmp.path().join(name).exists(),
+                "non-clipboard file {name:?} must NOT be deleted"
+            );
+        }
+    }
+
+    #[test]
+    fn prune_stats_summary_is_human_readable() {
+        let stats = PruneStats {
+            scanned: 5,
+            deleted: 3,
+            skipped_recent: 2,
+            errors: 0,
+        };
+        assert_eq!(
+            stats.summary(),
+            "clipboard prune: deleted 3, kept 2 recent, 0 error(s) (5 scanned)"
+        );
+    }
+}

--- a/core/crates/omegon/src/features/clipboard.rs
+++ b/core/crates/omegon/src/features/clipboard.rs
@@ -1,0 +1,157 @@
+//! Clipboard paste retention feature — exposes `/clipboard prune` for
+//! manual on-demand sweeps of stale clipboard image pastes from the
+//! system temp directory.
+//!
+//! The automatic 24h sweep at session start lives in `main.rs`; this
+//! feature is the operator's manual override surface. It uses the
+//! same `clipboard::prune_old_pastes` helper so the rules stay
+//! consistent across both call sites.
+
+use async_trait::async_trait;
+use omegon_traits::{BusEvent, BusRequest, CommandDefinition, CommandResult, Feature};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use crate::clipboard;
+use crate::settings::Settings;
+
+pub struct ClipboardFeature {
+    /// Shared settings handle so the prune subcommand reads the
+    /// operator's current `clipboard_retention_hours` value rather
+    /// than a stale snapshot.
+    settings: Arc<Mutex<Settings>>,
+}
+
+impl ClipboardFeature {
+    pub fn new(settings: Arc<Mutex<Settings>>) -> Self {
+        Self { settings }
+    }
+
+    /// Resolve the configured retention window from settings, falling
+    /// back to the 24h default if the lock is poisoned (shouldn't
+    /// happen, but better to sweep with the default than to silently
+    /// no-op).
+    fn current_retention(&self) -> Duration {
+        let hours = self
+            .settings
+            .lock()
+            .map(|s| s.clipboard_retention_hours)
+            .unwrap_or(24);
+        Duration::from_secs(hours.saturating_mul(3600))
+    }
+}
+
+#[async_trait]
+impl Feature for ClipboardFeature {
+    fn name(&self) -> &str {
+        "clipboard"
+    }
+
+    fn commands(&self) -> Vec<CommandDefinition> {
+        vec![CommandDefinition {
+            name: "clipboard".into(),
+            description: "Manage clipboard paste retention (subcommands: prune)".into(),
+            subcommands: vec!["prune".into()],
+        }]
+    }
+
+    fn handle_command(&mut self, name: &str, args: &str) -> CommandResult {
+        if name != "clipboard" {
+            return CommandResult::NotHandled;
+        }
+        let sub = args.split_whitespace().next().unwrap_or("");
+        match sub {
+            "prune" | "" => {
+                let retention = self.current_retention();
+                match clipboard::prune_old_pastes(retention) {
+                    Ok(stats) => {
+                        let hours = retention.as_secs() / 3600;
+                        let header = if retention.is_zero() {
+                            "Clipboard prune: retention is set to 0 (disabled). \
+                             No files will be deleted. Set \
+                             `clipboard_retention_hours` to a positive value to \
+                             enable automatic cleanup."
+                                .to_string()
+                        } else {
+                            format!(
+                                "Clipboard prune: retention = {hours}h\n{}",
+                                stats.summary()
+                            )
+                        };
+                        CommandResult::Display(header)
+                    }
+                    Err(e) => CommandResult::Display(format!(
+                        "Clipboard prune failed: {e}"
+                    )),
+                }
+            }
+            other => CommandResult::Display(format!(
+                "Unknown /clipboard subcommand: {other:?}. Try `/clipboard prune`."
+            )),
+        }
+    }
+
+    fn on_event(&mut self, _event: &BusEvent) -> Vec<BusRequest> {
+        vec![]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::settings::Settings;
+
+    #[test]
+    fn clipboard_feature_registers_prune_subcommand() {
+        let settings = Arc::new(Mutex::new(Settings::default()));
+        let feature = ClipboardFeature::new(settings);
+        let cmds = feature.commands();
+        assert_eq!(cmds.len(), 1);
+        assert_eq!(cmds[0].name, "clipboard");
+        assert!(cmds[0].subcommands.iter().any(|s| s == "prune"));
+    }
+
+    #[test]
+    fn clipboard_feature_returns_not_handled_for_other_commands() {
+        let settings = Arc::new(Mutex::new(Settings::default()));
+        let mut feature = ClipboardFeature::new(settings);
+        let result = feature.handle_command("usage", "");
+        assert!(matches!(result, CommandResult::NotHandled));
+    }
+
+    #[test]
+    fn clipboard_feature_prune_runs_with_default_retention() {
+        // The prune subcommand should always return a Display result
+        // (success or "failed" message), never NotHandled. We can't
+        // assert specific deletion counts without setting up a fake
+        // temp dir, but we can verify the command path doesn't panic
+        // and produces operator-readable output.
+        let settings = Arc::new(Mutex::new(Settings::default()));
+        let mut feature = ClipboardFeature::new(settings);
+        let result = feature.handle_command("clipboard", "prune");
+        match result {
+            CommandResult::Display(text) => {
+                assert!(
+                    text.contains("Clipboard prune"),
+                    "should produce a clipboard prune report: {text}"
+                );
+            }
+            other => panic!("expected Display result, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn clipboard_feature_zero_retention_emits_disabled_notice() {
+        let mut settings = Settings::default();
+        settings.clipboard_retention_hours = 0;
+        let settings = Arc::new(Mutex::new(settings));
+        let mut feature = ClipboardFeature::new(settings);
+        let CommandResult::Display(text) = feature.handle_command("clipboard", "prune") else {
+            panic!("expected Display result");
+        };
+        assert!(
+            text.contains("disabled"),
+            "should explain that retention is disabled: {text}"
+        );
+    }
+}

--- a/core/crates/omegon/src/features/mod.rs
+++ b/core/crates/omegon/src/features/mod.rs
@@ -23,6 +23,7 @@ pub mod adapter;
 pub mod auth;
 pub mod auto_compact;
 pub mod cleave;
+pub mod clipboard;
 pub mod context;
 pub mod delegate;
 pub mod harness_settings;

--- a/core/crates/omegon/src/main.rs
+++ b/core/crates/omegon/src/main.rs
@@ -21,6 +21,7 @@ mod bridge;
 pub mod bus;
 mod cleave;
 mod cleave_smoke;
+mod clipboard;
 mod context;
 mod control_actions;
 mod embedding;
@@ -1261,6 +1262,32 @@ async fn run_interactive_command(cli: &Cli) -> anyhow::Result<()> {
             model = %s.model, thinking = %s.thinking.as_str(),
             max_turns = s.max_turns, "settings initialized from profile"
         );
+    }
+
+    // ─── Clipboard paste retention sweep ────────────────────────────────
+    // Walk the system temp dir for `omegon-clipboard-*` files older
+    // than `Settings.clipboard_retention_hours` (default 24h, 0 to
+    // disable) and delete them. Without this sweep clipboard image
+    // pastes accumulate indefinitely — operators were seeing
+    // multi-month backlogs in `/tmp`. The sweep runs once per
+    // interactive launch, before the rest of setup so any failures
+    // here don't block startup.
+    let clipboard_retention_hours = shared_settings
+        .lock()
+        .ok()
+        .map(|s| s.clipboard_retention_hours)
+        .unwrap_or(24);
+    let clipboard_retention =
+        std::time::Duration::from_secs(clipboard_retention_hours.saturating_mul(3600));
+    match clipboard::prune_old_pastes(clipboard_retention) {
+        Ok(stats) if stats.deleted > 0 || stats.errors > 0 => {
+            tracing::info!("{}", stats.summary());
+        }
+        Ok(_) => {
+            // Nothing to clean — stay quiet on the common path so we
+            // don't spam the log on every launch.
+        }
+        Err(e) => tracing::warn!(error = %e, "clipboard prune failed"),
     }
 
     // ─── Shared setup ───────────────────────────────────────────────────

--- a/core/crates/omegon/src/settings.rs
+++ b/core/crates/omegon/src/settings.rs
@@ -336,6 +336,24 @@ pub struct Settings {
     /// Defaults to true. Set to false to restore terminal-native text selection.
     #[serde(default = "default_mouse")]
     pub mouse: bool,
+
+    /// How long clipboard pastes are retained on disk before automatic
+    /// deletion at session start, in hours. Default 24h. Set to 0 to
+    /// disable automatic deletion entirely. The setting also feeds the
+    /// `/clipboard prune` slash command for on-demand sweeps.
+    ///
+    /// Clipboard pastes are written to the system temp directory by
+    /// `tui::mod::pull_clipboard_image` and named
+    /// `omegon-clipboard-{pid}-{counter}.{ext}`. The matching prune
+    /// logic in `clipboard::prune_old_pastes` walks that directory at
+    /// session start and removes anything matching that pattern whose
+    /// modification time is older than `clipboard_retention_hours`.
+    #[serde(default = "default_clipboard_retention_hours")]
+    pub clipboard_retention_hours: u64,
+}
+
+fn default_clipboard_retention_hours() -> u64 {
+    24
 }
 
 /// Tool card display mode in the conversation view.
@@ -573,6 +591,7 @@ impl Default for Settings {
             update_channel: default_update_channel(),
             provider_connected: true, // optimistic default — set false when NullBridge
             mouse: true,
+            clipboard_retention_hours: default_clipboard_retention_hours(),
         }
     }
 }

--- a/core/crates/omegon/src/setup.rs
+++ b/core/crates/omegon/src/setup.rs
@@ -451,6 +451,17 @@ impl AgentSetup {
         // ─── Usage advisory (/usage from captured provider telemetry) ───
         bus.register(Box::new(features::usage::UsageFeature::new()));
 
+        // ─── Clipboard paste retention (/clipboard prune) ────────────────
+        // Manual on-demand sweep surface for clipboard image pastes.
+        // The automatic 24h sweep at session start lives in main.rs;
+        // this feature is the operator's override for forcing a sweep
+        // mid-session. Both call paths share `clipboard::prune_old_pastes`.
+        if let Some(ref settings) = settings {
+            bus.register(Box::new(features::clipboard::ClipboardFeature::new(
+                settings.clone(),
+            )));
+        }
+
         // ─── Model budget (tier switching + thinking) ───────────────────
         if let Some(ref settings) = settings {
             bus.register(Box::new(features::model_budget::ModelBudget::new(

--- a/core/crates/omegon/src/tui/conv_widget.rs
+++ b/core/crates/omegon/src/tui/conv_widget.rs
@@ -450,6 +450,7 @@ mod tests {
                     is_error: false,
                     complete: true,
                     expanded: false,
+                    live_partial: None,
                 },
             },
         ];

--- a/core/crates/omegon/src/tui/conv_widget.rs
+++ b/core/crates/omegon/src/tui/conv_widget.rs
@@ -451,6 +451,7 @@ mod tests {
                     complete: true,
                     expanded: false,
                     live_partial: None,
+                    started_at: None,
                 },
             },
         ];

--- a/core/crates/omegon/src/tui/conversation.rs
+++ b/core/crates/omegon/src/tui/conversation.rs
@@ -5,7 +5,7 @@
 
 use super::conv_widget::ConvState;
 use super::image::ImageCache;
-use super::segments::{Segment, SegmentContent, SegmentExportMode, SegmentMeta};
+use super::segments::{Segment, SegmentContent, SegmentExportMode, SegmentMeta, TokenUsage};
 
 /// Tab variant — conversation or extension widget
 #[derive(Debug, Clone)]
@@ -374,6 +374,40 @@ impl ConversationView {
         }
     }
 
+    /// Walk back through segments belonging to a given turn and stamp
+    /// the provider-reported actual token counts onto each one. Called
+    /// from the `AgentEvent::TurnEnd` handler in `tui/mod.rs` once the
+    /// real numbers arrive. Segments emitted earlier in the turn (tool
+    /// cards, assistant text, etc.) all share the same turn id via
+    /// `current_meta()` and pick up the stamp here so the title-bar
+    /// token annotation appears across the whole turn at once.
+    ///
+    /// Walks back from the tail rather than the head because turn-end
+    /// stamps usually only need to touch a handful of recent segments.
+    /// Stops at the first segment whose `turn` is older than the
+    /// target — segments are ordered chronologically so anything older
+    /// than the target turn won't have new stamps to apply.
+    pub fn stamp_turn_tokens(&mut self, turn: u32, tokens: TokenUsage) {
+        for seg in self.segments.iter_mut().rev() {
+            match seg.meta.turn {
+                Some(t) if t == turn => {
+                    seg.meta.actual_tokens = Some(tokens);
+                }
+                Some(t) if t < turn => {
+                    // Older turn — and since segments are chronological,
+                    // anything before this is also older. Stop walking.
+                    break;
+                }
+                _ => {
+                    // No turn id (rare — pre-turn-tracking segments) or
+                    // a future turn (shouldn't happen). Skip and keep
+                    // walking back.
+                }
+            }
+        }
+        self.conv_state.invalidate();
+    }
+
     // ─── Scroll ─────────────────────────────────────────────────
 
     pub fn scroll_up(&mut self, amount: u16) {
@@ -615,6 +649,52 @@ mod tests {
     use super::*;
     use crate::tui::theme::Alpharius;
     use ratatui::prelude::*;
+
+    #[test]
+    fn stamp_turn_tokens_walks_back_and_stamps_matching_segments() {
+        // Build a conversation with three segments across two turns:
+        //   - turn 1: tool card
+        //   - turn 2: tool card
+        //   - turn 2: assistant text
+        // Then stamp turn 2 with token usage and confirm only the
+        // turn-2 segments get the actual_tokens field set.
+        let mut cv = ConversationView::new();
+
+        cv.push_tool_start("t1", "bash", Some("ls"), Some("ls"));
+        cv.stamp_meta(SegmentMeta {
+            turn: Some(1),
+            ..SegmentMeta::default()
+        });
+
+        cv.push_tool_start("t2", "read", Some("file.rs"), Some("file.rs"));
+        cv.stamp_meta(SegmentMeta {
+            turn: Some(2),
+            ..SegmentMeta::default()
+        });
+
+        cv.append_streaming("hello");
+        cv.stamp_meta(SegmentMeta {
+            turn: Some(2),
+            ..SegmentMeta::default()
+        });
+
+        cv.stamp_turn_tokens(2, TokenUsage { input: 500, output: 100 });
+
+        // Turn 1 segment: untouched
+        assert!(
+            cv.segments[0].meta.actual_tokens.is_none(),
+            "turn 1 segment must NOT be stamped with turn 2's tokens"
+        );
+        // Turn 2 segments: stamped
+        assert_eq!(
+            cv.segments[1].meta.actual_tokens,
+            Some(TokenUsage { input: 500, output: 100 })
+        );
+        assert_eq!(
+            cv.segments[2].meta.actual_tokens,
+            Some(TokenUsage { input: 500, output: 100 })
+        );
+    }
 
     #[test]
     fn user_message_creates_segments() {

--- a/core/crates/omegon/src/tui/conversation.rs
+++ b/core/crates/omegon/src/tui/conversation.rs
@@ -282,6 +282,29 @@ impl ConversationView {
         self.conv_state.auto_scroll_to_bottom();
     }
 
+    /// Stash the latest streaming partial onto the open tool card with
+    /// the given id. Called from the `AgentEvent::ToolUpdate` handler;
+    /// runners (bash, local_inference, mcp) push these as work happens.
+    /// Silently no-op if the card is already complete or not found —
+    /// late or stale updates shouldn't crash anything.
+    pub fn push_tool_update(&mut self, id: &str, partial: omegon_traits::PartialToolResult) {
+        for seg in self.segments.iter_mut().rev() {
+            if let SegmentContent::ToolCard {
+                id: tool_id,
+                complete: c,
+                live_partial: lp,
+                ..
+            } = &mut seg.content
+                && tool_id == id
+                && !*c
+            {
+                *lp = Some(partial);
+                self.conv_state.invalidate();
+                return;
+            }
+        }
+    }
+
     pub fn push_tool_end(&mut self, id: &str, is_error: bool, result_text: Option<&str>) {
         for seg in self.segments.iter_mut().rev() {
             if let SegmentContent::ToolCard {
@@ -290,6 +313,7 @@ impl ConversationView {
                 is_error: e,
                 result_summary: r,
                 detail_result: dr,
+                live_partial: lp,
                 ..
             } = &mut seg.content
                 && tool_id == id
@@ -297,6 +321,9 @@ impl ConversationView {
             {
                 *c = true;
                 *e = is_error;
+                // The completed-result render path takes over now; the
+                // last in-flight partial is stale.
+                *lp = None;
                 *r = result_text.and_then(|text| {
                     let line = text
                         .lines()

--- a/core/crates/omegon/src/tui/instruments.rs
+++ b/core/crates/omegon/src/tui/instruments.rs
@@ -27,9 +27,19 @@ fn panel_bg(t: &dyn Theme) -> Color {
 }
 
 /// Write `text` left-to-right starting at `(x, y)`, clipped to `max_x`.
-/// Each character advances by its CJK-aware cell width (wide chars consume 2 cells;
-/// the second cell is blanked so subsequent characters land in the right column).
-/// Returns the x position after the last written character.
+/// Each character advances by its display cell width. Wide chars consume 2
+/// cells and the overflow cell is blanked so subsequent characters land in
+/// the right column. Returns the x position after the last written character.
+///
+/// **Width function**: uses `UnicodeWidthChar::width()` (non-CJK) rather
+/// than `width_cjk()`. The instruments panel renders Western tool glyphs
+/// (`◇`, `▶`, `▸`, `⚙`, etc.) which are East-Asian-Width=Ambiguous —
+/// `width_cjk()` reports them as 2 cells but most Western terminals
+/// render them in 1 cell. Using `width()` keeps the renderer's cell
+/// math in sync with the actual rendered width and with
+/// `widgets::visible_width()`, which is what the surrounding layout
+/// math uses. Mixing the two produced a 1-cell off-by-one that pushed
+/// names like `read` off-axis (the original "◇  read" extra-space bug).
 fn render_str_colored<F>(
     text: &str,
     x: u16,
@@ -47,7 +57,7 @@ where
         if cur_x >= max_x {
             break;
         }
-        let w = UnicodeWidthChar::width_cjk(ch).unwrap_or(1) as u16;
+        let w = UnicodeWidthChar::width(ch).unwrap_or(1) as u16;
         if cur_x.saturating_add(w) > max_x {
             break;
         }
@@ -127,6 +137,10 @@ fn strip_terminal_control(input: &str) -> String {
     out
 }
 
+/// Truncate `input` to at most `max_width` display cells. Uses
+/// `UnicodeWidthChar::width()` (non-CJK) for the same reason as
+/// `render_str_colored` above — keeps the cell math consistent with
+/// `widgets::visible_width()` and the surrounding layout code.
 fn truncate_display_width(input: &str, max_width: usize) -> String {
     if max_width == 0 {
         return String::new();
@@ -134,7 +148,7 @@ fn truncate_display_width(input: &str, max_width: usize) -> String {
     let mut out = String::new();
     let mut used = 0usize;
     for ch in input.chars() {
-        let w = UnicodeWidthChar::width_cjk(ch).unwrap_or(1);
+        let w = UnicodeWidthChar::width(ch).unwrap_or(1);
         if used + w > max_width {
             break;
         }
@@ -173,46 +187,69 @@ fn intensity_color(intensity: f64) -> Color {
 }
 
 /// Compact glyph+label for the instrument panel. Keeps tool rows readable
-/// even in narrow terminals. Format: "⌘ label" — 2-char glyph prefix + short name.
+/// even in narrow terminals. Format: "{glyph} {label}" — single-cell glyph
+/// prefix + space + short name.
+///
+/// **Glyph constraints** (load-bearing — drift here breaks layout):
+///
+/// 1. **Single-cell width.** Every glyph must measure 1 cell under
+///    `UnicodeWidthChar::width()` so the renderer's cell math stays in
+///    sync with `widgets::visible_width()`. Wide chars (e.g. `⌛` U+231B
+///    HOURGLASS, `⏱` U+23F1 STOPWATCH) push the name column off-axis.
+///
+/// 2. **Not in the Unicode emoji set.** Even a `width()`-of-1 character
+///    can be rendered as a 2-cell emoji glyph by the terminal if the
+///    font has emoji-presentation for that codepoint. Several previously
+///    used glyphs (`⚙` U+2699 GEAR, `⚿` U+269F SQUARED KEY, `▪` U+25AA,
+///    `▫` U+25AB, `▶` U+25B6, `▲` U+25B2) are in `Emoji=Yes` and have
+///    been replaced with non-emoji equivalents.
+///
+/// 3. **Semantically meaningful where possible.** `chronos` gets a
+///    clock-like glyph, `change` gets a delta, `bash` gets a shell prompt
+///    `>`, etc. Nebulous tools (memory recall) accept abstract glyphs.
+///
+/// The `glyph_width_and_emoji_safety` test enforces (1) at compile/test
+/// time. (2) and (3) are documented constraints — drift would need a
+/// human reviewer to catch.
 pub(crate) fn tool_short_name(name: &str) -> String {
     let (glyph, label) = match name {
         // ── Core file ops ──
-        "bash" => ("⌘", "sh"),
-        "read" | "Read" => ("◇", "read"),
-        "write" | "Write" => ("◆", "write"),
-        "edit" | "Edit" => ("✎", "edit"),
+        "bash" => (">", "sh"),                    // shell prompt — was ⌘
+        "read" | "Read" => ("◇", "read"),         // open diamond = readonly
+        "write" | "Write" => ("◆", "write"),      // filled = mutating
+        "edit" | "Edit" => ("✎", "edit"),         // U+270E (NOT U+270F which is emoji)
         "view" => ("◈", "view"),
         // ── Git / speculate ──
-        "commit" => ("⊕", "commit"),
-        "speculate_start" => ("⊘", "spec∘"),
-        "speculate_check" => ("⊘", "spec?"),
-        "speculate_commit" => ("⊘", "spec✓"),
-        "speculate_rollback" => ("⊘", "spec✗"),
-        // ── Memory ──
-        "memory_store" => ("▪", "mem+"),
-        "memory_recall" => ("▫", "recall"),
-        "memory_query" => ("▫", "memq"),
-        "memory_archive" => ("▪", "mem⌫"),
-        "memory_supersede" => ("▪", "mem↻"),
-        "memory_connect" => ("▪", "mem⊷"),
-        "memory_focus" => ("▪", "focus"),
-        "memory_release" => ("▪", "unfoc"),
-        "memory_episodes" => ("▫", "epis"),
-        "memory_compact" => ("▪", "compct"),
-        "memory_search_archive" => ("▫", "marcv"),
-        "memory_ingest_lifecycle" => ("▪", "mingt"),
+        "commit" => ("⊕", "commit"),              // add to history
+        "speculate_start" => ("⎇", "spec∘"),      // alternative key = branch — was ⊘
+        "speculate_check" => ("⎇", "spec?"),
+        "speculate_commit" => ("⎇", "spec✓"),
+        "speculate_rollback" => ("⎇", "spec✗"),
+        // ── Memory ── (▪/▫ are in the emoji set; using ▣/▢ instead)
+        "memory_store" => ("▣", "mem+"),
+        "memory_recall" => ("▢", "recall"),
+        "memory_query" => ("▢", "memq"),
+        "memory_archive" => ("▣", "mem⌫"),
+        "memory_supersede" => ("▣", "mem↻"),
+        "memory_connect" => ("▣", "mem⊷"),
+        "memory_focus" => ("▣", "focus"),
+        "memory_release" => ("▣", "unfoc"),
+        "memory_episodes" => ("▢", "epis"),
+        "memory_compact" => ("▣", "compct"),
+        "memory_search_archive" => ("▢", "marcv"),
+        "memory_ingest_lifecycle" => ("▣", "mingt"),
         // ── Design + lifecycle ──
         "design_tree" => ("△", "d.tree"),
-        "design_tree_update" => ("▲", "d.tree↑"),
+        "design_tree_update" => ("⟁", "d.tree↑"), // nested triangle — was ▲ (emoji)
         "openspec_manage" => ("◎", "opsx"),
         // ── Cleave / decomposition ──
-        "cleave_assess" => ("⟁", "assess"),
-        "cleave_run" => ("⟁", "cleave"),
+        "cleave_assess" => ("⊳", "assess"),       // math triangle — was ⟁ (now design_tree_update)
+        "cleave_run" => ("⊳", "cleave"),
         "delegate" => ("⇉", "deleg"),
         "delegate_result" => ("⇉", "d.res"),
         "delegate_status" => ("⇉", "d.stat"),
         // ── Web / render ──
-        "web_search" => ("⊕", "search"),
+        "web_search" => ("⌖", "search"),          // position indicator — was ⊕ (collided with commit)
         "codebase_search" => ("⌕", "cbase"),
         "codebase_index" => ("⌕", "cidx"),
         "render_diagram" => ("⬡", "diag"),
@@ -221,22 +258,26 @@ pub(crate) fn tool_short_name(name: &str) -> String {
         "ask_local_model" => ("⊛", "local"),
         "list_local_models" => ("⊛", "l.list"),
         "manage_ollama" => ("⊛", "ollama"),
-        // ── Settings / meta ──
-        "set_model_tier" => ("⚙", "tier"),
-        "set_thinking_level" => ("⚙", "think"),
-        "switch_to_offline_driver" => ("⚙", "offln"),
-        "manage_tools" => ("⚙", "tools"),
-        "whoami" => ("⚙", "whoami"),
-        "chronos" => ("⚙", "chrono"),
-        "change" => ("⚙", "change"),
-        // ── Auth / persona ──
-        "auth_status" => ("⚿", "auth"),
-        "harness_settings" => ("⚿", "hrnss"),
-        "switch_persona" => ("⚿", "persna"),
-        "switch_tone" => ("⚿", "tone"),
-        "list_personas" => ("⚿", "pers?"),
-        // ── Fallback: truncate ──
-        other => return other.to_string(),
+        // ── Settings / meta ── (⚙ is in the emoji set; using ⌥ for settings cluster)
+        "set_model_tier" => ("⌥", "tier"),
+        "set_thinking_level" => ("⌥", "think"),
+        "switch_to_offline_driver" => ("⌥", "offln"),
+        "manage_tools" => ("⌥", "tools"),
+        "whoami" => ("⊙", "whoami"),              // self/identity — was ⚙
+        "chronos" => ("◷", "chrono"),             // clock-quadrant — was ⚙
+        "change" => ("Δ", "change"),              // delta — was ⚙
+        // ── Auth / persona ── (⚿ is in the emoji set; using ※)
+        "auth_status" => ("※", "auth"),
+        "harness_settings" => ("※", "hrnss"),
+        "switch_persona" => ("※", "persna"),
+        "switch_tone" => ("※", "tone"),
+        "list_personas" => ("※", "pers?"),
+        // ── Fallback: prefix with a generic single-cell glyph so the
+        // panel still gets an icon column for unknown tools (the
+        // original `context_status` "no icon at all" bug). Also
+        // truncate the name to a reasonable label length to avoid
+        // immediately blowing the column.
+        other => return format!("· {other}"),
     };
     format!("{glyph} {label}")
 }
@@ -1291,12 +1332,18 @@ impl InstrumentPanel {
             clear_row(y, inner.x, inner.right(), buf, panel_bg(t));
 
             // ── Status indicator ──
+            // Same emoji-safety constraint as `tool_short_name`. The
+            // previous "▶" running glyph (U+25B6) and "⚡" upstream-
+            // exhausted glyph (U+26A1) are both in the Unicode emoji
+            // set. Replaced with `▷` (U+25B7) and `↯` (U+21AF), both
+            // single-cell, neither in the emoji set. The other glyphs
+            // (`✓`, `↺`, `✗`, `○`) are already safe.
             let (ind_ch, ind_color) = match child.status.as_str() {
-                "running" => ("▶ ", Color::Rgb(232, 186, 104)),
+                "running" => ("▷ ", Color::Rgb(232, 186, 104)),
                 "completed" => ("✓ ", Color::Rgb(42, 180, 200)),
                 "merged_after_failure" => ("↺ ", Color::Rgb(214, 170, 40)),
                 "failed" => ("✗ ", Color::Rgb(224, 72, 72)),
-                "upstream_exhausted" => ("⚡ ", Color::Rgb(214, 170, 40)),
+                "upstream_exhausted" => ("↯ ", Color::Rgb(214, 170, 40)),
                 _ => ("○ ", Color::Rgb(40, 56, 72)), // pending / unknown
             };
             let mut x = inner.x;
@@ -1333,8 +1380,18 @@ impl InstrumentPanel {
             }
 
             // ── Activity: tool or turn (dim) ──
+            // Note the explicit space after the arrow. The previous
+            // version was `format!("→{tool}")` and relied on
+            // `render_str_colored` reserving 2 cells for `→` (under
+            // the old `width_cjk` measurement) to produce a visual
+            // gap via the wide-char overflow blank. After fixing the
+            // width function to non-CJK `width()` (which correctly
+            // measures `→` as 1 cell on Western terminals), that
+            // accidental gap disappeared. The space is now explicit
+            // in the source, which both renders correctly and matches
+            // operator expectations.
             let activity = if let Some(ref tool) = child.last_tool {
-                format!("→{tool}")
+                format!("→ {tool}")
             } else if let Some(turn) = child.last_turn {
                 format!("T{turn}")
             } else if child.status == "running" {
@@ -1467,10 +1524,15 @@ impl InstrumentPanel {
                 (1.0 - age / 120.0).max(0.0)
             };
 
+            // Indicator glyphs are subject to the same emoji-safety
+            // constraint as `tool_short_name` — see that function's
+            // doc comment. `▶` U+25B6 (the previous "running"
+            // indicator) is in the Unicode emoji set; `▷` U+25B7 is
+            // not. `✗` U+2717, `▸` U+25B8 are both safe.
             let indicator = if tool.is_error {
                 "✗ "
             } else if tool.running {
-                "▶ "
+                "▷ "
             } else if age < 2.0 {
                 "▸ "
             } else {
@@ -1537,12 +1599,21 @@ impl InstrumentPanel {
             x = render_str_colored(indicator, x, y, inner.right(), panel_bg(t), buf, |_| {
                 ind_color
             });
+            // Truncate-with-ellipsis logic. The previous version had an
+            // off-by-one: it always truncated to `name_w - 1` and only
+            // added `…` when `width > name_w`, so a name whose width
+            // exactly equalled `name_w` was silently chopped by one
+            // character with no visual indicator (the original
+            // "context_statu" bug). Rewritten to:
+            //   - if it fits, render as-is
+            //   - if it doesn't, truncate to `name_w - 1` and append `…`
+            //     so the total displayed width is exactly `name_w`
             let short = tool_short_name(&tool.name);
-            let display_name = truncate_display_width(&short, name_w.saturating_sub(1));
             let display_name = if visible_width(&short) > name_w {
-                format!("{}…", display_name)
+                let truncated = truncate_display_width(&short, name_w.saturating_sub(1));
+                format!("{truncated}…")
             } else {
-                display_name
+                short.clone()
             };
             x = render_str_colored(&display_name, x, y, inner.right(), panel_bg(t), buf, |_| {
                 name_color
@@ -1581,31 +1652,29 @@ impl InstrumentPanel {
                 x += 1;
             }
             // Bar character degrades with recency — three visual channels:
-            // fill length (how much bar), color (teal intensity), character (signal density)
+            // fill length (how much bar), color (teal intensity), character
+            // (signal density). The empty track is rendered with spaces
+            // (NOT dots) so the boundary between filled and empty is
+            // always visually distinct — the previous version used '·'
+            // for both the fading-echo bar AND the empty track, producing
+            // an indistinguishable row of dots at low recency.
             let bar_char = if recency > 0.7 {
-                '≋'
-            }
-            // strong — just fired
-            else if recency > 0.3 {
-                '≈'
-            }
-            // recent — decaying
-            else if recency > 0.05 {
-                '∿'
-            }
-            // fading echo
-            else {
-                '·'
-            }; // nearly silent
+                '≋' // strong — just fired
+            } else if recency > 0.3 {
+                '≈' // recent — decaying
+            } else if recency > 0.05 {
+                '∿' // fading echo
+            } else {
+                '·' // nearly silent
+            };
             for i in 0..bar_w {
                 if x >= inner.right() {
                     break;
                 }
-                let ch = if i < bar_filled { bar_char } else { '·' };
-                let c = if i < bar_filled {
-                    bar_color
+                let (ch, c) = if i < bar_filled {
+                    (bar_char, bar_color)
                 } else {
-                    Color::Rgb(16, 28, 36)
+                    (' ', panel_bg(t))
                 };
                 if let Some(cell) = buf.cell_mut(Position::new(x, y)) {
                     cell.set_char(ch);
@@ -1988,6 +2057,118 @@ mod tests {
     fn tool_short_name_compacts_codebase_search() {
         assert_eq!(tool_short_name("codebase_search"), "⌕ cbase");
         assert_eq!(tool_short_name("codebase_index"), "⌕ cidx");
+    }
+
+    #[test]
+    fn tool_short_name_glyphs_are_single_cell_and_well_formed() {
+        // Every entry in the tool_short_name table must satisfy the
+        // layout invariants documented at the top of that function:
+        //
+        //   1. The leading glyph is exactly 1 display cell under
+        //      `UnicodeWidthChar::width()` (non-CJK). This keeps the
+        //      panel's name column on-axis.
+        //   2. The result is "{glyph} {label}" — a glyph, a single
+        //      space, and a non-empty label. No bare names slip
+        //      through.
+        //
+        // The list below is the canonical set of tool names known to
+        // the panel. If you add a new branch to `tool_short_name`,
+        // add the name here so this test exercises it.
+        //
+        // Emoji-presentation safety (constraint 2 in the doc comment)
+        // is NOT enforced here automatically because we don't have
+        // the Unicode emoji table at hand in tests; reviewers must
+        // catch drift on additions. The doc comment lists the known
+        // emoji-set codepoints we deliberately avoid.
+        let known = [
+            // core
+            "bash", "read", "write", "edit", "view",
+            // git/speculate
+            "commit", "speculate_start", "speculate_check",
+            "speculate_commit", "speculate_rollback",
+            // memory
+            "memory_store", "memory_recall", "memory_query",
+            "memory_archive", "memory_supersede", "memory_connect",
+            "memory_focus", "memory_release", "memory_episodes",
+            "memory_compact", "memory_search_archive",
+            "memory_ingest_lifecycle",
+            // design + lifecycle
+            "design_tree", "design_tree_update", "openspec_manage",
+            // cleave
+            "cleave_assess", "cleave_run", "delegate",
+            "delegate_result", "delegate_status",
+            // web/render
+            "web_search", "codebase_search", "codebase_index",
+            "render_diagram", "generate_image_local",
+            // local inference
+            "ask_local_model", "list_local_models", "manage_ollama",
+            // settings/meta
+            "set_model_tier", "set_thinking_level",
+            "switch_to_offline_driver", "manage_tools",
+            "whoami", "chronos", "change",
+            // auth/persona
+            "auth_status", "harness_settings", "switch_persona",
+            "switch_tone", "list_personas",
+        ];
+        for name in known {
+            let result = tool_short_name(name);
+            let mut chars = result.chars();
+            let glyph = chars
+                .next()
+                .unwrap_or_else(|| panic!("tool_short_name({name:?}) returned empty"));
+            let glyph_width = unicode_width::UnicodeWidthChar::width(glyph).unwrap_or(0);
+            assert_eq!(
+                glyph_width, 1,
+                "tool_short_name({name:?}) leading glyph {glyph:?} (U+{:04X}) must be 1 cell wide, got {glyph_width}",
+                glyph as u32
+            );
+            let after_glyph = chars.next();
+            assert_eq!(
+                after_glyph,
+                Some(' '),
+                "tool_short_name({name:?}) must have a space separator after the glyph"
+            );
+            let label: String = chars.collect();
+            assert!(
+                !label.is_empty(),
+                "tool_short_name({name:?}) must have a non-empty label after the glyph + space"
+            );
+        }
+    }
+
+    #[test]
+    fn tool_short_name_unknown_tool_falls_back_to_glyph_prefix() {
+        // The fallback for tools not in the hardcoded match must still
+        // produce a glyph + space + name (the original "context_status
+        // has no icon" bug). Without a fallback prefix, the tools
+        // panel had a misaligned column for unknown tools.
+        let result = tool_short_name("context_status");
+        let mut chars = result.chars();
+        let glyph = chars.next().unwrap();
+        assert_eq!(
+            unicode_width::UnicodeWidthChar::width(glyph).unwrap_or(0),
+            1,
+            "fallback glyph must be single-cell"
+        );
+        assert_eq!(chars.next(), Some(' '));
+        let label: String = chars.collect();
+        assert_eq!(label, "context_status");
+    }
+
+    #[test]
+    fn truncate_display_width_uses_non_cjk_widths_for_ambiguous_glyphs() {
+        // The previous implementation used `UnicodeWidthChar::width_cjk()`,
+        // which reports East-Asian-Width=Ambiguous codepoints as 2 cells.
+        // The instruments panel renders Western glyphs that the terminal
+        // draws in 1 cell — `width_cjk` produced a 1-cell off-by-one
+        // that pushed the name column off-axis (the original "◇  read"
+        // bug). This test pins the non-CJK choice in place.
+        // ◇ U+25C7 is East-Asian-Width=Ambiguous: width_cjk()=2, width()=1.
+        let result = truncate_display_width("◇ read", 6);
+        assert_eq!(
+            result, "◇ read",
+            "ambiguous-width glyphs must be measured as single-cell so the full name fits in 6 columns"
+        );
     }
 
     #[test]

--- a/core/crates/omegon/src/tui/mod.rs
+++ b/core/crates/omegon/src/tui/mod.rs
@@ -773,6 +773,7 @@ impl App {
             thinking_level: Some(self.footer_data.thinking_level.clone()),
             turn: Some(self.turn),
             est_tokens: Some(self.footer_data.estimated_tokens as u32),
+            actual_tokens: None, // stamped on TurnEnd via stamp_turn_tokens
             context_percent: Some(self.footer_data.context_percent),
             persona: self
                 .plugin_registry
@@ -4418,6 +4419,23 @@ impl App {
                         (tokens as f32 / ctx_window as f32 * 100.0).min(100.0);
                 }
                 self.footer_data.provider_telemetry = provider_telemetry;
+
+                // Stamp the provider-reported actual tokens onto every
+                // segment that belongs to this turn so the title-bar
+                // annotation (`↑input ↓output` next to the timestamp)
+                // shows up across all of them at once. Tool cards,
+                // assistant text, and any other segment created during
+                // the turn share the same `meta.turn` from
+                // `current_meta()` and pick up the stamp here.
+                if actual_input_tokens > 0 || actual_output_tokens > 0 {
+                    self.conversation.stamp_turn_tokens(
+                        turn,
+                        segments::TokenUsage {
+                            input: actual_input_tokens,
+                            output: actual_output_tokens,
+                        },
+                    );
+                }
             }
             AgentEvent::MessageChunk { text } => {
                 let was_streaming = self.conversation.is_streaming();

--- a/core/crates/omegon/src/tui/mod.rs
+++ b/core/crates/omegon/src/tui/mod.rs
@@ -4732,6 +4732,14 @@ impl App {
             AgentEvent::MessageAbort => {
                 self.conversation.abort_streaming();
             }
+            AgentEvent::ToolUpdate { id, partial } => {
+                // Stash the latest streaming partial onto the matching
+                // open tool card. The conversation segment renderer
+                // picks it up via `live_partial` and displays the live
+                // tail / progress / heartbeat in place of the empty
+                // result section while the tool is still in flight.
+                self.conversation.push_tool_update(&id, partial);
+            }
             _ => {}
         }
     }

--- a/core/crates/omegon/src/tui/segments.rs
+++ b/core/crates/omegon/src/tui/segments.rs
@@ -73,6 +73,44 @@ fn apply_rows_bg(area: Rect, start_row: u16, row_count: u16, bg: Color, buf: &mu
 // Segment — rich metadata wrapper + typed content
 // ═══════════════════════════════════════════════════════════════════════════
 
+/// Provider-reported actual token counts for the turn that produced
+/// (or contains) a given segment. Stamped onto `SegmentMeta` after a
+/// `TurnEnd` event arrives, by walking back through segments whose
+/// `turn` matches the just-ended turn id. Renderers display this next
+/// to the timestamp on segments that involved an LLM call so the
+/// timeline carries token cost as canon — operators don't have to
+/// glance at the inference panel to see what each turn's segments
+/// actually cost.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct TokenUsage {
+    pub input: u64,
+    pub output: u64,
+}
+
+impl TokenUsage {
+    /// Render as a compact title-bar annotation: `↑1.2k ↓340`. Numbers
+    /// > 1000 are shortened with a `k` suffix; smaller numbers render
+    /// as-is. The arrows are non-emoji single-cell glyphs (the same
+    /// constraint as the instruments-panel pass).
+    pub fn format_compact(&self) -> String {
+        format!(
+            "↑{} ↓{}",
+            format_token_count(self.input),
+            format_token_count(self.output)
+        )
+    }
+}
+
+fn format_token_count(n: u64) -> String {
+    if n >= 1_000_000 {
+        format!("{:.1}M", n as f64 / 1_000_000.0)
+    } else if n >= 1_000 {
+        format!("{:.1}k", n as f64 / 1_000.0)
+    } else {
+        n.to_string()
+    }
+}
+
 /// Metadata captured at segment creation time. Every segment carries this
 /// regardless of type. Fields are Optional — populated when available,
 /// never blocking construction.
@@ -92,6 +130,13 @@ pub struct SegmentMeta {
     pub turn: Option<u32>,
     /// Estimated token cost of this segment (input + output).
     pub est_tokens: Option<u32>,
+    /// Provider-reported actual tokens for the turn this segment
+    /// belongs to. Stamped after `TurnEnd` arrives with the real
+    /// counts; `None` until then. Different from `est_tokens` (the
+    /// local heuristic) — `actual_tokens` reflects the provider's
+    /// authoritative billing numbers and is what the title-bar
+    /// annotation displays.
+    pub actual_tokens: Option<TokenUsage>,
     /// Context window fill percentage at time of generation.
     pub context_percent: Option<f32>,
     /// Active persona ID, if any.
@@ -554,6 +599,38 @@ impl Segment {
                     .as_ref()
                     .map(|r| wrapped_rows(r, inner_width).min(if *expanded { 220 } else { 12 }))
                     .unwrap_or(0);
+                // Diff section rows: edit/change tools render a real
+                // colored diff in place of the boring "Successfully
+                // replaced" result text. The estimate is the sum of
+                // (old + new) lines per block plus chrome (summary +
+                // optional file headers + truncation marker), capped
+                // at the same collapsed/expanded budget as the result
+                // section. The actual rendering is bounded by
+                // `max_diff_lines` (8 collapsed, 200 expanded).
+                let compact_diff_rows: u16 =
+                    if matches!(name.as_str(), "edit" | "change") {
+                        detail_args
+                            .as_deref()
+                            .and_then(|args| build_edit_diff_blocks(name, args))
+                            .map(|blocks| {
+                                let multi = blocks.len() > 1;
+                                let total: usize = blocks
+                                    .iter()
+                                    .map(|b| {
+                                        let header = if multi { 1 } else { 0 };
+                                        header
+                                            + b.old_text.lines().count()
+                                            + b.new_text.lines().count()
+                                    })
+                                    .sum();
+                                // +1 summary line, +1 truncation marker (worst case)
+                                let with_chrome = total + 2;
+                                with_chrome.min(if *expanded { 200 } else { 12 }) as u16
+                            })
+                            .unwrap_or(0)
+                    } else {
+                        0
+                    };
                 // Live section rows: only relevant while the tool is
                 // still in flight. Always at least one row (the status
                 // header) when incomplete; tail rows on top when a
@@ -573,12 +650,18 @@ impl Segment {
                 };
                 let live_separator_rows =
                     u16::from(compact_arg_rows > 0 && compact_live_rows > 0);
+                // The diff section replaces the result section when
+                // present, so we use whichever is larger to over-
+                // estimate (under-estimating clips content; over-
+                // estimating just allocates a slightly larger temp
+                // buffer that the `last_used` scan will trim).
+                let body_rows = compact_diff_rows.max(compact_result_rows);
                 let result_separator_rows =
-                    u16::from(compact_arg_rows > 0 && compact_result_rows > 0);
+                    u16::from(compact_arg_rows > 0 && body_rows > 0);
                 compact_arg_rows
                     + compact_live_rows
                     + live_separator_rows
-                    + compact_result_rows
+                    + body_rows
                     + result_separator_rows
                     + 4
             }
@@ -729,12 +812,39 @@ fn format_timestamp(timestamp: Option<std::time::SystemTime>) -> Option<String> 
 }
 
 fn top_right_timestamp<'a>(meta: &SegmentMeta, t: &dyn Theme) -> Option<Line<'a>> {
-    format_timestamp(meta.timestamp).map(|stamp| {
-        Line::from(Span::styled(
+    let timestamp = format_timestamp(meta.timestamp);
+    let tokens = meta.actual_tokens;
+    if timestamp.is_none() && tokens.is_none() {
+        return None;
+    }
+    // Combined right-rail title: `↑1.2k ↓340 · 14:32`. The token
+    // annotation comes from `meta.actual_tokens` which is stamped
+    // onto every segment in a turn after `TurnEnd` arrives — see
+    // `ConversationView::stamp_turn_tokens`. Segments without an LLM
+    // call (system notifications, lifecycle events, user prompts)
+    // never get tokens and only show the timestamp.
+    let mut spans: Vec<Span<'a>> = Vec::new();
+    if let Some(tokens) = tokens {
+        spans.push(Span::styled(
+            tokens.format_compact(),
+            Style::default()
+                .fg(t.accent_muted())
+                .add_modifier(Modifier::DIM),
+        ));
+        if timestamp.is_some() {
+            spans.push(Span::styled(
+                " · ",
+                Style::default().fg(t.dim()).add_modifier(Modifier::DIM),
+            ));
+        }
+    }
+    if let Some(stamp) = timestamp {
+        spans.push(Span::styled(
             stamp,
             Style::default().fg(t.dim()).add_modifier(Modifier::DIM),
-        ))
-    })
+        ));
+    }
+    Some(Line::from(spans))
 }
 
 fn tool_title_line(
@@ -891,10 +1001,22 @@ fn render_assistant_text(
         ]));
     }
 
-    // Assistant text with markdown structural highlighting
+    // Assistant text with markdown structural highlighting.
+    //
+    // Pre-pass: materialize lines into a Vec so we can compute shared
+    // table column widths via `compute_table_widths` before rendering.
+    // The widths array is parallel to `text_lines` — entries are
+    // `Some(widths)` for lines belonging to a markdown table block,
+    // `None` otherwise. The rendering loop below looks up its row's
+    // shared widths so every row in a table block aligns with its
+    // neighbors instead of computing per-row widths in isolation
+    // (which produced the column-shred failure mode in
+    // codebase_search results and other table-bearing tool output).
+    let text_lines: Vec<&str> = split_preserving_trailing_empty_lines(text);
+    let table_widths_per_line = compute_table_widths(&text_lines, area.width as usize);
     let mut in_code_fence = false;
     let mut table_state = TableState::None;
-    for line in split_preserving_trailing_empty_lines(text) {
+    for (idx, line) in text_lines.iter().enumerate() {
         let trimmed = line.trim();
         if trimmed.starts_with("```") {
             in_code_fence = !in_code_fence;
@@ -908,14 +1030,16 @@ fn render_assistant_text(
                 line.to_string(),
                 Style::default().fg(t.accent_muted()).bg(bg),
             )));
-        } else if is_table_line(trimmed) {
+        } else if let Some(target_widths) = table_widths_per_line[idx].as_ref() {
+            // Pre-pass marked this as a table line — render with the
+            // shared widths from its block.
             let is_header = matches!(table_state, TableState::None);
             if is_table_separator(trimmed) || matches!(table_state, TableState::Header) {
                 table_state = TableState::Body;
             } else {
                 table_state = TableState::Header;
             }
-            lines.push(render_table_line(trimmed, is_header, area.width, t));
+            lines.push(render_table_line(trimmed, is_header, target_widths, t));
         } else {
             table_state = TableState::None;
             let line = super::widgets::highlight_line(line, t);
@@ -1067,10 +1191,13 @@ fn render_tool_card(
         name.replace('_', " ")
     };
 
+    // `▶` U+25B6 is in the Unicode emoji set — replaced with `▷` U+25B7
+    // for the same reason as the instruments-panel pass. Both `✗` and
+    // `▸` are already safe.
     let (status_icon, status_color, border_color, bg) = if is_error {
         ("✗", t.error(), t.error(), t.tool_error_bg())
     } else if !complete {
-        ("▶", t.warning(), t.warning(), t.tool_success_bg())
+        ("▷", t.warning(), t.warning(), t.tool_success_bg())
     } else {
         ("▸", t.accent_muted(), t.accent_muted(), t.tool_success_bg())
     };
@@ -1084,23 +1211,47 @@ fn render_tool_card(
         timestamp.as_deref(),
     );
 
+    // Right-aligned title combines the provider-reported token usage
+    // (when known) with the timestamp. Format:
+    //
+    //     ↑1.2k ↓340 · 14:32
+    //
+    // The tokens come from `meta.actual_tokens` which is stamped on
+    // every segment in a turn after `TurnEnd` arrives — see
+    // `ConversationView::stamp_turn_tokens`. Segments without an LLM
+    // call (system notifications, lifecycle events) never get
+    // `actual_tokens` populated and only show the timestamp.
+    let right_title_spans: Vec<Span<'_>> = {
+        let mut spans: Vec<Span<'_>> = Vec::new();
+        if let Some(tokens) = meta.actual_tokens {
+            spans.push(Span::styled(
+                tokens.format_compact(),
+                Style::default()
+                    .fg(t.accent_muted())
+                    .add_modifier(Modifier::DIM),
+            ));
+            if timestamp.is_some() {
+                spans.push(Span::styled(
+                    " · ",
+                    Style::default().fg(t.dim()).add_modifier(Modifier::DIM),
+                ));
+            }
+        }
+        if let Some(stamp) = timestamp.as_deref() {
+            spans.push(Span::styled(
+                stamp.to_string(),
+                Style::default().fg(t.dim()).add_modifier(Modifier::DIM),
+            ));
+        }
+        spans
+    };
+
     let card_block = Block::default()
         .borders(Borders::ALL)
         .border_type(BorderType::Rounded)
         .border_style(Style::default().fg(border_color).bg(bg))
         .title_top(title)
-        .title_top(
-            timestamp
-                .as_deref()
-                .map(|stamp| {
-                    Line::from(Span::styled(
-                        stamp.to_string(),
-                        Style::default().fg(t.dim()).add_modifier(Modifier::DIM),
-                    ))
-                })
-                .unwrap_or_else(Line::default)
-                .right_aligned(),
-        )
+        .title_top(Line::from(right_title_spans).right_aligned())
         .padding(Padding::horizontal(1))
         .style(Style::default().bg(bg));
 
@@ -1254,10 +1405,137 @@ fn render_tool_card(
         }
     }
 
-    // ── Result section with distinct background ─────────────────
-    let pre_result_line_count = lines.len();
+    // ── Edit/change diff section ────────────────────────────────
+    // For mutating-file tools (`edit`, `change`), the standard result
+    // text is just "Successfully replaced text in {path}" — useless
+    // for an operator who wants to see what actually changed.
+    // Replace it with a colored line-by-line diff computed from the
+    // tool's args (`oldText` / `newText`), which the renderer already
+    // has access to via `detail_args`. The diff rendered here is the
+    // intent — what the agent ASKED for — not the post-validation
+    // result. On a successful edit they're equivalent; on a failed
+    // edit the validation error is rendered separately below.
     let mut result_row_fills: Vec<(u16, Color)> = Vec::new();
-    if let Some(result) = detail_result {
+    let diff_blocks: Option<Vec<EditDiffBlock>> = if matches!(name, "edit" | "change") {
+        detail_args.and_then(|args| build_edit_diff_blocks(name, args))
+    } else {
+        None
+    };
+    if let Some(blocks) = diff_blocks {
+        if !lines.is_empty() {
+            let sep_color = if is_error { t.error() } else { t.border_dim() };
+            lines.push(Line::from(Span::styled(
+                "─".repeat(card_inner.width as usize),
+                Style::default().fg(sep_color).bg(bg),
+            )));
+            result_row_fills.push((lines.len().saturating_sub(1) as u16, bg));
+        }
+        let max_diff_lines = if expanded { 200 } else { 8 };
+        let mut emitted = 0usize;
+        let removed_style = Style::default().fg(t.error()).bg(bg);
+        let added_style = Style::default().fg(t.success()).bg(bg);
+        let header_style = Style::default()
+            .fg(t.accent_muted())
+            .bg(bg)
+            .add_modifier(Modifier::BOLD);
+        let summary_style = Style::default().fg(t.muted()).bg(bg);
+
+        // Per-block summary line: total +N -M across all diff blocks
+        // (one per file in the change tool's case). The summary is
+        // always the first line in the diff section so the operator
+        // gets a quick read at the top.
+        let total_added: usize = blocks
+            .iter()
+            .map(|b| b.new_text.lines().count())
+            .sum();
+        let total_removed: usize = blocks
+            .iter()
+            .map(|b| b.old_text.lines().count())
+            .sum();
+        lines.push(Line::from(vec![
+            Span::styled(
+                format!("Δ {} edit(s) · ", blocks.len()),
+                summary_style,
+            ),
+            Span::styled(format!("+{total_added}"), added_style),
+            Span::styled(" / ", summary_style),
+            Span::styled(format!("-{total_removed}"), removed_style),
+            Span::styled(
+                if expanded { "" } else { "  (expand for full diff)" },
+                summary_style,
+            ),
+        ]));
+        result_row_fills.push((lines.len().saturating_sub(1) as u16, bg));
+
+        // Per-block diff body. Each block is preceded by a `▸ {file}`
+        // header (only when there's more than one block) so the
+        // operator can tell which file each hunk belongs to.
+        let multi_block = blocks.len() > 1;
+        'outer: for block in &blocks {
+            if multi_block {
+                if emitted >= max_diff_lines {
+                    break;
+                }
+                lines.push(Line::from(Span::styled(
+                    format!("▸ {}", block.file),
+                    header_style,
+                )));
+                result_row_fills.push((lines.len().saturating_sub(1) as u16, bg));
+                emitted += 1;
+            }
+            for line in block.old_text.lines() {
+                if emitted >= max_diff_lines {
+                    break 'outer;
+                }
+                lines.push(Line::from(Span::styled(
+                    format!("- {line}"),
+                    removed_style,
+                )));
+                result_row_fills.push((lines.len().saturating_sub(1) as u16, bg));
+                emitted += 1;
+            }
+            for line in block.new_text.lines() {
+                if emitted >= max_diff_lines {
+                    break 'outer;
+                }
+                lines.push(Line::from(Span::styled(
+                    format!("+ {line}"),
+                    added_style,
+                )));
+                result_row_fills.push((lines.len().saturating_sub(1) as u16, bg));
+                emitted += 1;
+            }
+        }
+
+        // Truncation marker if we capped before showing the whole diff.
+        let total_diff_lines: usize = blocks
+            .iter()
+            .map(|b| {
+                let header = if multi_block { 1 } else { 0 };
+                header + b.old_text.lines().count() + b.new_text.lines().count()
+            })
+            .sum();
+        if total_diff_lines > emitted {
+            lines.push(Line::from(Span::styled(
+                format!("… {} more diff line(s)", total_diff_lines - emitted),
+                summary_style,
+            )));
+            result_row_fills.push((lines.len().saturating_sub(1) as u16, bg));
+        }
+
+        // If the tool actually erred, surface the error result text
+        // below the diff so the operator sees both intent and outcome.
+        if is_error {
+            if let Some(err_text) = detail_result {
+                lines.push(Line::from(Span::styled(
+                    err_text.lines().next().unwrap_or(err_text).to_string(),
+                    Style::default().fg(t.error()).bg(bg),
+                )));
+                result_row_fills.push((lines.len().saturating_sub(1) as u16, bg));
+            }
+        }
+    } else if let Some(result) = detail_result {
+        let pre_result_line_count = lines.len();
         if !lines.is_empty() {
             // Separator line — matches card border color (red on error)
             let sep_color = if is_error { t.error() } else { t.border_dim() };
@@ -1316,12 +1594,19 @@ fn render_tool_card(
             };
 
             let mut table_state = TableState::None;
-            let has_table_lines = result_lines.iter().any(|line| is_table_line(line.trim()));
+            let visible_lines = &result_lines[..show];
+            let has_table_lines = visible_lines.iter().any(|line| is_table_line(line.trim()));
 
             if !is_error && has_table_lines {
-                for line in result_lines[..show].iter().copied() {
+                // Pre-pass to compute shared per-column widths across
+                // each table block — see `compute_table_widths` for the
+                // rationale (the column-shred bug in codebase_search
+                // results).
+                let table_widths_per_line =
+                    compute_table_widths(visible_lines, card_inner.width as usize);
+                for (idx, line) in visible_lines.iter().copied().enumerate() {
                     let trimmed = line.trim();
-                    if is_table_line(trimmed) {
+                    if let Some(target_widths) = table_widths_per_line[idx].as_ref() {
                         let is_header = matches!(table_state, TableState::None);
                         if is_table_separator(trimmed) || matches!(table_state, TableState::Header)
                         {
@@ -1330,7 +1615,7 @@ fn render_tool_card(
                             table_state = TableState::Header;
                         }
                         let row_bg = bg;
-                        lines.push(render_table_line(trimmed, is_header, card_inner.width, t));
+                        lines.push(render_table_line(trimmed, is_header, target_widths, t));
                         result_row_fills.push((lines.len().saturating_sub(1) as u16, row_bg));
                     } else {
                         table_state = TableState::None;
@@ -1574,6 +1859,78 @@ enum TableState {
     Body,
 }
 
+/// One file's worth of edit-diff data for the `edit` / `change` tool
+/// rendering path. The renderer pulls these out of the tool's args
+/// (which it has via `detail_args`) and synthesizes a colored line-by-
+/// line diff in place of the boring "Successfully replaced text" result.
+#[derive(Debug, Clone)]
+struct EditDiffBlock {
+    file: String,
+    old_text: String,
+    new_text: String,
+}
+
+/// Parse `detail_args` JSON for an `edit` or `change` tool call and
+/// extract one or more `EditDiffBlock`s. Returns `None` for tools whose
+/// args don't carry the expected `oldText`/`newText` fields (which is
+/// also the bail-out for non-edit/non-change tools and for malformed
+/// payloads — in both cases the renderer falls back to the standard
+/// result text rendering).
+///
+/// Tool arg shapes:
+/// - **edit**: `{ "path": "...", "oldText": "...", "newText": "..." }`
+///   → one `EditDiffBlock`
+/// - **change**: `{ "edits": [{ "file": "...", "oldText": "...",
+///   "newText": "..." }, ...] }` → one block per edit, in order
+fn build_edit_diff_blocks(name: &str, args: &str) -> Option<Vec<EditDiffBlock>> {
+    let parsed: serde_json::Value = serde_json::from_str(args).ok()?;
+    match name {
+        "edit" => {
+            let path = parsed
+                .get("path")
+                .or_else(|| parsed.get("file"))
+                .and_then(|v| v.as_str())
+                .unwrap_or("(unknown file)")
+                .to_string();
+            let old_text = parsed.get("oldText").and_then(|v| v.as_str())?.to_string();
+            let new_text = parsed.get("newText").and_then(|v| v.as_str())?.to_string();
+            Some(vec![EditDiffBlock {
+                file: path,
+                old_text,
+                new_text,
+            }])
+        }
+        "change" => {
+            let edits = parsed.get("edits")?.as_array()?;
+            let blocks: Vec<EditDiffBlock> = edits
+                .iter()
+                .filter_map(|edit| {
+                    let file = edit
+                        .get("file")
+                        .or_else(|| edit.get("path"))
+                        .and_then(|v| v.as_str())?
+                        .to_string();
+                    let old_text =
+                        edit.get("oldText").and_then(|v| v.as_str())?.to_string();
+                    let new_text =
+                        edit.get("newText").and_then(|v| v.as_str())?.to_string();
+                    Some(EditDiffBlock {
+                        file,
+                        old_text,
+                        new_text,
+                    })
+                })
+                .collect();
+            if blocks.is_empty() {
+                None
+            } else {
+                Some(blocks)
+            }
+        }
+        _ => None,
+    }
+}
+
 /// Detect markdown table lines: `| cell | cell |` or `|---|---|`
 fn is_table_line(line: &str) -> bool {
     let trimmed = line.trim();
@@ -1590,8 +1947,111 @@ fn is_table_separator(line: &str) -> bool {
             .all(|c| c == '|' || c == '-' || c == ':' || c == ' ')
 }
 
-/// Render a markdown table line with cell highlighting.
-fn render_table_line<'a>(line: &str, is_header: bool, max_width: u16, t: &dyn Theme) -> Line<'a> {
+/// Pre-compute per-column target widths for every markdown table block
+/// in `lines`, returning a parallel `Vec` aligned with the input where
+/// each entry is `Some(widths)` if the line belongs to a table block and
+/// `None` otherwise.
+///
+/// Why this exists: `render_table_line` was originally called per-row
+/// with no cross-row coordination, so each row computed its own column
+/// widths from its own cell contents. Body rows with long content (e.g.
+/// codebase_search Preview cells) got their last column truncated
+/// independently, while the header row computed shorter widths from its
+/// short labels — the columns didn't line up and the table looked
+/// shredded. This pass collects every consecutive run of table lines
+/// into a "block", computes the max-per-column across the block, then
+/// shrinks the last column to fit `available_width` if the total
+/// overflows. All rows in the same block render with the same target
+/// widths, so columns align.
+///
+/// `available_width` is the inner card width in cells. Returns one
+/// `Vec<usize>` (column widths) per table line; non-table lines map to
+/// `None`. Separator rows participate in column-count detection but
+/// not in width measurement (they're all dashes).
+fn compute_table_widths(
+    lines: &[&str],
+    available_width: usize,
+) -> Vec<Option<Vec<usize>>> {
+    let mut result: Vec<Option<Vec<usize>>> = vec![None; lines.len()];
+    let mut i = 0;
+    while i < lines.len() {
+        if !is_table_line(lines[i].trim()) {
+            i += 1;
+            continue;
+        }
+        // Find the end of this table block (consecutive table lines).
+        let start = i;
+        let mut end = i;
+        while end < lines.len() && is_table_line(lines[end].trim()) {
+            end += 1;
+        }
+
+        // Compute per-column max widths across all non-separator rows
+        // in the block. Separator rows are all dashes and would
+        // misreport the width as 3+ cells of `---`, so we skip them
+        // for measurement but they still participate in rendering.
+        let mut col_widths: Vec<usize> = Vec::new();
+        for line in &lines[start..end] {
+            let trimmed = line.trim();
+            if is_table_separator(trimmed) {
+                continue;
+            }
+            let cells: Vec<&str> = trimmed.split('|').filter(|s| !s.is_empty()).collect();
+            for (idx, cell) in cells.iter().enumerate() {
+                let w = cell.trim().chars().count().max(1);
+                if idx >= col_widths.len() {
+                    col_widths.push(w);
+                } else if w > col_widths[idx] {
+                    col_widths[idx] = w;
+                }
+            }
+        }
+
+        // Constrain to fit available width. Chrome math:
+        //   per-cell rendered width = " content " = (target_w + 2) cells
+        //   inter-cell pipes = (N - 1) cells
+        //   outer pipes = 2 cells
+        //   total = sum(target_w) + 3 * N + 1
+        // → content budget = available_width - 3*N - 1
+        // If the total content overflows the budget, shrink the LAST
+        // column (typically Preview / longest content) down to whatever
+        // fits, with a minimum of 8 cells so it stays useful. We don't
+        // distribute the overflow across columns because the operator
+        // generally cares more about File/Lines/Type/Score being
+        // legible than the Preview cell being complete.
+        let cell_count = col_widths.len();
+        if cell_count > 0 {
+            let chrome = cell_count.saturating_mul(3).saturating_add(1);
+            let content_budget = available_width.saturating_sub(chrome);
+            let total: usize = col_widths.iter().sum();
+            if total > content_budget {
+                let last_idx = cell_count - 1;
+                let other_total: usize = col_widths.iter().take(last_idx).sum();
+                let last_budget = content_budget.saturating_sub(other_total).max(8);
+                col_widths[last_idx] = last_budget;
+            }
+        }
+
+        // Apply the same widths to every line in the block.
+        for idx in start..end {
+            result[idx] = Some(col_widths.clone());
+        }
+        i = end;
+    }
+    result
+}
+
+/// Render a markdown table line with cell highlighting using
+/// pre-computed shared column widths from `compute_table_widths`. The
+/// caller is responsible for ensuring `target_widths` reflects the
+/// max-per-column across all rows in the same table block — passing
+/// per-row-derived widths breaks alignment.
+fn render_table_line<'a>(
+    line: &str,
+    is_header: bool,
+    target_widths: &[usize],
+    t: &dyn Theme,
+) -> Line<'a> {
     let trimmed = line.trim();
     let row_bg = if is_header {
         t.card_bg()
@@ -1599,31 +2059,7 @@ fn render_table_line<'a>(line: &str, is_header: bool, max_width: u16, t: &dyn Th
         t.surface_bg()
     };
     let cells: Vec<&str> = trimmed.split('|').filter(|s| !s.is_empty()).collect();
-    let cell_count = cells.len();
-
-    let available_width = max_width.saturating_sub(2) as usize;
-    let separator_count = cell_count.saturating_sub(1);
-    let separator_width = separator_count;
-    let padding_width = cell_count.saturating_mul(2);
-    let mut content_budget = available_width.saturating_sub(separator_width + padding_width);
-    if content_budget < cell_count {
-        content_budget = cell_count;
-    }
-
-    let base_widths: Vec<usize> = cells
-        .iter()
-        .map(|cell| cell.trim().chars().count().max(1))
-        .collect();
-    let mut target_widths = base_widths.clone();
-
-    let total_content_width: usize = base_widths.iter().sum();
-    if total_content_width > content_budget && cell_count > 0 {
-        let preview_idx = cell_count - 1;
-        let fixed_other: usize = base_widths.iter().take(preview_idx).sum();
-        let min_preview = if is_header { "Preview".len() } else { 12 };
-        let preview_budget = content_budget.saturating_sub(fixed_other).max(min_preview);
-        target_widths[preview_idx] = preview_budget;
-    }
+    let cell_count = target_widths.len().max(cells.len());
 
     // Separator row: |---|---| → render as a thin rule sized to the content budget.
     if is_table_separator(trimmed) {
@@ -1644,12 +2080,17 @@ fn render_table_line<'a>(line: &str, is_header: bool, max_width: u16, t: &dyn Th
         return Line::from(spans);
     }
 
+    // Iterate by the shared column count from `target_widths`, not by
+    // the row's own cell count. Rows with fewer cells than the block's
+    // max get padded with empty cells; rows with more get truncated.
+    // Both cases keep columns aligned across the table block, which
+    // is the whole point of the pre-pass that produces target_widths.
     let pipe = Style::default().fg(t.border()).bg(row_bg);
     let mut spans: Vec<Span<'a>> = Vec::new();
     spans.push(Span::styled("│", pipe));
-    for (i, cell) in cells.iter().enumerate() {
-        let width = target_widths.get(i).copied().unwrap_or(1);
-        let cell_text = truncate_table_cell(cell.trim(), width);
+    for (i, &width) in target_widths.iter().enumerate() {
+        let cell_raw = cells.get(i).copied().unwrap_or("").trim();
+        let cell_text = truncate_table_cell(cell_raw, width);
         if is_header {
             spans.push(Span::styled(
                 format!(" {:width$} ", cell_text, width = width),
@@ -1674,7 +2115,7 @@ fn render_table_line<'a>(line: &str, is_header: bool, max_width: u16, t: &dyn Th
             }
             spans.push(Span::styled(" ", Style::default().bg(row_bg)));
         }
-        if i < cells.len() - 1 {
+        if i + 1 < cell_count {
             spans.push(Span::styled("│", pipe));
         }
     }
@@ -1758,6 +2199,24 @@ fn render_lifecycle(icon: &str, text: &str, area: Rect, buf: &mut Buffer, t: &dy
 
 /// Render a placeholder for an image (used when StatefulProtocol isn't available).
 /// The actual image rendering happens in conv_widget.rs via ratatui-image.
+///
+/// Visual choices:
+/// - **Frame**: doubled-line border in `accent_muted` rather than the
+///   default `border_dim`/rounded combo. The image content gets composited
+///   on top of this rectangle in a second pass; if the image happens to
+///   share colors with the surrounding TUI surface (light screenshots,
+///   pasted UI captures, etc.) the doubled frame makes the segment
+///   bounds unambiguous.
+/// - **Glyph**: `▦` U+25A6 SQUARE WITH ORTHOGONAL CROSSHATCH FILL.
+///   Single-cell, not in the Unicode emoji set. The previous `📎`
+///   U+1F4CE PAPERCLIP is an emoji-presentation codepoint and is
+///   forbidden by the same constraint that drove the instruments-panel
+///   glyph audit.
+/// - **Title**: full disk path (`path.display()`) rather than just
+///   `file_name()`. Operators need to know where on disk the file
+///   lives — especially for clipboard-paste files like
+///   `omegon-clipboard-78315-16.png` whose names are uninformative
+///   without their parent directory.
 fn render_image_placeholder(
     path: &std::path::Path,
     alt: &str,
@@ -1769,18 +2228,26 @@ fn render_image_placeholder(
         return;
     }
 
-    let filename = path.file_name().and_then(|n| n.to_str()).unwrap_or("image");
+    // Title: full disk path (or alt text if the caller supplied one).
+    // The previous behavior used only the filename which left
+    // operators guessing about the parent directory.
+    let path_str = path.display().to_string();
     let label = if alt.is_empty() || alt == "clipboard paste" {
-        format!(" 📎 {filename} ")
+        format!(" ▦ {path_str} ")
     } else {
-        format!(" 📎 {alt} ")
+        format!(" ▦ {alt} — {path_str} ")
     };
 
     let block = Block::default()
         .borders(Borders::ALL)
-        .border_type(BorderType::Rounded)
-        .border_style(Style::default().fg(t.border_dim()))
-        .title(Span::styled(label, Style::default().fg(t.accent_muted())))
+        .border_type(BorderType::Double)
+        .border_style(Style::default().fg(t.accent_muted()))
+        .title(Span::styled(
+            label,
+            Style::default()
+                .fg(t.accent_muted())
+                .add_modifier(Modifier::BOLD),
+        ))
         .style(Style::default().bg(t.surface_bg()));
 
     // The block is the placeholder — the actual image is rendered on top
@@ -1839,6 +2306,382 @@ mod tests {
             }
         }
         None
+    }
+
+    #[test]
+    fn token_usage_format_compact_uses_k_and_m_suffixes() {
+        assert_eq!(
+            TokenUsage { input: 0, output: 0 }.format_compact(),
+            "↑0 ↓0"
+        );
+        assert_eq!(
+            TokenUsage { input: 999, output: 1 }.format_compact(),
+            "↑999 ↓1"
+        );
+        assert_eq!(
+            TokenUsage { input: 1_234, output: 567 }.format_compact(),
+            "↑1.2k ↓567"
+        );
+        assert_eq!(
+            TokenUsage { input: 12_500, output: 1_000 }.format_compact(),
+            "↑12.5k ↓1.0k"
+        );
+        assert_eq!(
+            TokenUsage { input: 1_500_000, output: 250_000 }.format_compact(),
+            "↑1.5M ↓250.0k"
+        );
+    }
+
+    #[test]
+    fn tool_card_title_renders_token_annotation_when_meta_carries_tokens() {
+        // The title-bar right-aligned area should show
+        // `↑input ↓output · timestamp` when the segment carries
+        // actual_tokens (stamped after TurnEnd).
+        let meta = SegmentMeta {
+            timestamp: Some(std::time::SystemTime::UNIX_EPOCH),
+            actual_tokens: Some(TokenUsage {
+                input: 1_500,
+                output: 240,
+            }),
+            ..SegmentMeta::default()
+        };
+        let seg = Segment {
+            meta,
+            content: SegmentContent::ToolCard {
+                id: "1".into(),
+                name: "bash".into(),
+                args_summary: None,
+                detail_args: Some("echo hi".into()),
+                result_summary: None,
+                detail_result: Some("hi".into()),
+                is_error: false,
+                complete: true,
+                expanded: false,
+                live_partial: None,
+                started_at: None,
+            },
+        };
+        let (area, mut buf) = make_buf(80, 8);
+        seg.render(area, &mut buf, &Alpharius);
+        let text = buf_text(&buf, area);
+        assert!(
+            text.contains("↑1.5k"),
+            "tool card title should show input token count: {text}"
+        );
+        assert!(
+            text.contains("↓240"),
+            "tool card title should show output token count: {text}"
+        );
+    }
+
+    #[test]
+    fn tool_card_title_omits_token_annotation_when_meta_has_none() {
+        // Segments that don't yet have actual_tokens stamped (in-flight,
+        // pre-TurnEnd) should NOT show the annotation, just the
+        // timestamp on the right rail.
+        let seg = Segment {
+            meta: SegmentMeta {
+                timestamp: Some(std::time::SystemTime::UNIX_EPOCH),
+                actual_tokens: None,
+                ..SegmentMeta::default()
+            },
+            content: SegmentContent::ToolCard {
+                id: "1".into(),
+                name: "bash".into(),
+                args_summary: None,
+                detail_args: Some("echo hi".into()),
+                result_summary: None,
+                detail_result: Some("hi".into()),
+                is_error: false,
+                complete: true,
+                expanded: false,
+                live_partial: None,
+                started_at: None,
+            },
+        };
+        let (area, mut buf) = make_buf(80, 8);
+        seg.render(area, &mut buf, &Alpharius);
+        let text = buf_text(&buf, area);
+        assert!(
+            !text.contains("↑") && !text.contains("↓"),
+            "no token annotation should appear when actual_tokens is None: {text}"
+        );
+    }
+
+    #[test]
+    fn assistant_text_segment_renders_token_annotation_too() {
+        // The same right-rail combine logic via top_right_timestamp.
+        let seg = Segment {
+            meta: SegmentMeta {
+                timestamp: Some(std::time::SystemTime::UNIX_EPOCH),
+                actual_tokens: Some(TokenUsage {
+                    input: 12_345,
+                    output: 678,
+                }),
+                ..SegmentMeta::default()
+            },
+            content: SegmentContent::AssistantText {
+                text: "ok".into(),
+                thinking: String::new(),
+                complete: true,
+            },
+        };
+        let (area, mut buf) = make_buf(80, 6);
+        seg.render(area, &mut buf, &Alpharius);
+        let text = buf_text(&buf, area);
+        assert!(
+            text.contains("↑12.3k"),
+            "assistant segment title should show input tokens: {text}"
+        );
+        assert!(
+            text.contains("↓678"),
+            "assistant segment title should show output tokens: {text}"
+        );
+    }
+
+    #[test]
+    fn edit_tool_card_renders_colored_diff_in_place_of_boring_result() {
+        // The edit tool's text result is just "Successfully replaced
+        // text in {path}". The renderer should swap that for a real
+        // line-by-line diff built from the args' oldText/newText.
+        let args = serde_json::json!({
+            "path": "src/lib.rs",
+            "oldText": "fn old() {\n    println!(\"old\");\n}",
+            "newText": "fn new() {\n    println!(\"new\");\n    println!(\"extra\");\n}",
+        })
+        .to_string();
+        let seg = Segment {
+            meta: SegmentMeta::default(),
+            content: SegmentContent::ToolCard {
+                id: "1".into(),
+                name: "edit".into(),
+                args_summary: None,
+                detail_args: Some(args),
+                result_summary: None,
+                detail_result: Some("Successfully replaced text in src/lib.rs".into()),
+                is_error: false,
+                complete: true,
+                expanded: true,
+                live_partial: None,
+                started_at: None,
+            },
+        };
+        let (area, mut buf) = make_buf(80, 20);
+        seg.render(area, &mut buf, &Alpharius);
+        let text = buf_text(&buf, area);
+
+        // Diff summary line: total +N -M counts.
+        assert!(
+            text.contains("+4") && text.contains("-3"),
+            "diff summary should report 4 additions and 3 removals: {text}"
+        );
+
+        // Diff body: removed lines prefixed with `-`, added with `+`.
+        assert!(
+            text.contains("- fn old() {"),
+            "removed line should appear with - prefix: {text}"
+        );
+        assert!(
+            text.contains("+ fn new() {"),
+            "added line should appear with + prefix: {text}"
+        );
+        assert!(
+            text.contains("+ "),
+            "diff section should have added lines: {text}"
+        );
+
+        // The boring "Successfully replaced" text should NOT leak into
+        // the rendering — the diff replaces it.
+        assert!(
+            !text.contains("Successfully replaced"),
+            "diff renderer should replace the boring result text: {text}"
+        );
+    }
+
+    #[test]
+    fn change_tool_card_renders_per_file_diff_blocks_with_headers() {
+        // The change tool can edit multiple files in one call. Each
+        // file gets a header row above its diff hunk.
+        let args = serde_json::json!({
+            "edits": [
+                {
+                    "file": "src/a.rs",
+                    "oldText": "let a = 1;",
+                    "newText": "let a = 2;",
+                },
+                {
+                    "file": "src/b.rs",
+                    "oldText": "let b = 1;",
+                    "newText": "let b = 2;\nlet c = 3;",
+                },
+            ],
+        })
+        .to_string();
+        let seg = Segment {
+            meta: SegmentMeta::default(),
+            content: SegmentContent::ToolCard {
+                id: "1".into(),
+                name: "change".into(),
+                args_summary: None,
+                detail_args: Some(args),
+                result_summary: None,
+                detail_result: Some("Changed 2 files".into()),
+                is_error: false,
+                complete: true,
+                expanded: true,
+                live_partial: None,
+                started_at: None,
+            },
+        };
+        let (area, mut buf) = make_buf(80, 24);
+        seg.render(area, &mut buf, &Alpharius);
+        let text = buf_text(&buf, area);
+
+        // Multi-file: per-file headers with the ▸ glyph and the path.
+        assert!(text.contains("▸ src/a.rs"), "first file header missing: {text}");
+        assert!(text.contains("▸ src/b.rs"), "second file header missing: {text}");
+        // Summary line: 2 edits, +3 added, -2 removed
+        assert!(
+            text.contains("2 edit") && text.contains("+3") && text.contains("-2"),
+            "summary should report 2 edits, +3 / -2: {text}"
+        );
+        // Per-file diff content
+        assert!(text.contains("- let a = 1;"));
+        assert!(text.contains("+ let a = 2;"));
+        assert!(text.contains("- let b = 1;"));
+        assert!(text.contains("+ let b = 2;"));
+        assert!(text.contains("+ let c = 3;"));
+    }
+
+    #[test]
+    fn collapsed_edit_card_truncates_diff_with_marker() {
+        // Collapsed edit cards cap at 8 diff lines and append a
+        // truncation marker showing how many were dropped.
+        let old_text = (0..30)
+            .map(|i| format!("old line {i}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let new_text = (0..30)
+            .map(|i| format!("new line {i}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let args = serde_json::json!({
+            "path": "big.rs",
+            "oldText": old_text,
+            "newText": new_text,
+        })
+        .to_string();
+        let seg = Segment {
+            meta: SegmentMeta::default(),
+            content: SegmentContent::ToolCard {
+                id: "1".into(),
+                name: "edit".into(),
+                args_summary: None,
+                detail_args: Some(args),
+                result_summary: None,
+                detail_result: Some("Successfully replaced text in big.rs".into()),
+                is_error: false,
+                complete: true,
+                expanded: false, // collapsed
+                live_partial: None,
+                started_at: None,
+            },
+        };
+        let (area, mut buf) = make_buf(80, 20);
+        seg.render(area, &mut buf, &Alpharius);
+        let text = buf_text(&buf, area);
+        assert!(
+            text.contains("more diff line"),
+            "collapsed cards should show a truncation marker: {text}"
+        );
+        assert!(
+            text.contains("expand for full diff"),
+            "collapsed cards should hint at expansion in the summary: {text}"
+        );
+    }
+
+    #[test]
+    fn build_edit_diff_blocks_handles_edit_and_change_shapes() {
+        // edit shape: single block from path/oldText/newText
+        let edit_args = r#"{"path":"a.rs","oldText":"x","newText":"y"}"#;
+        let edit_blocks = build_edit_diff_blocks("edit", edit_args).unwrap();
+        assert_eq!(edit_blocks.len(), 1);
+        assert_eq!(edit_blocks[0].file, "a.rs");
+        assert_eq!(edit_blocks[0].old_text, "x");
+        assert_eq!(edit_blocks[0].new_text, "y");
+
+        // change shape: array of edits
+        let change_args = r#"{"edits":[{"file":"a.rs","oldText":"1","newText":"2"},{"file":"b.rs","oldText":"3","newText":"4"}]}"#;
+        let change_blocks = build_edit_diff_blocks("change", change_args).unwrap();
+        assert_eq!(change_blocks.len(), 2);
+        assert_eq!(change_blocks[0].file, "a.rs");
+        assert_eq!(change_blocks[1].file, "b.rs");
+
+        // Non-edit/change tool: returns None even with valid JSON
+        assert!(build_edit_diff_blocks("read", r#"{"path":"a.rs"}"#).is_none());
+
+        // Malformed JSON: returns None
+        assert!(build_edit_diff_blocks("edit", "not json").is_none());
+
+        // Edit with missing oldText/newText: returns None
+        assert!(build_edit_diff_blocks("edit", r#"{"path":"a.rs"}"#).is_none());
+    }
+
+    #[test]
+    fn image_placeholder_renders_full_disk_path_without_emoji_glyph() {
+        let seg = Segment::image(
+            std::path::PathBuf::from("/tmp/omegon-clipboard-78315-16.png"),
+            "",
+        );
+        let (area, mut buf) = make_buf(80, 14);
+        seg.render(area, &mut buf, &Alpharius);
+        let text = buf_text(&buf, area);
+
+        // Full disk path is in the title, not just the filename.
+        assert!(
+            text.contains("/tmp/omegon-clipboard-78315-16.png"),
+            "image segment must show the full disk path: {text}"
+        );
+
+        // No emoji glyphs — paperclip U+1F4CE was the previous default
+        // and is in the Unicode emoji set.
+        assert!(
+            !text.contains('\u{1F4CE}'),
+            "image segment must not use the emoji paperclip glyph"
+        );
+
+        // Doubled-line frame characters (BorderType::Double) for visual
+        // separation from the image content composited in pass two.
+        assert!(
+            text.contains('╔') || text.contains('╗') || text.contains('═'),
+            "image segment should use a doubled-line frame for visual contrast: {text}"
+        );
+
+        // Single-cell crosshatch glyph in the title prefix, in place of
+        // the paperclip.
+        assert!(
+            text.contains('▦'),
+            "image segment title should use the ▦ thumbnail glyph: {text}"
+        );
+    }
+
+    #[test]
+    fn image_placeholder_renders_alt_text_with_path_when_provided() {
+        let seg = Segment::image(
+            std::path::PathBuf::from("/var/captures/screenshot.png"),
+            "tui screenshot",
+        );
+        let (area, mut buf) = make_buf(80, 14);
+        seg.render(area, &mut buf, &Alpharius);
+        let text = buf_text(&buf, area);
+        assert!(
+            text.contains("tui screenshot"),
+            "alt text should appear when provided: {text}"
+        );
+        assert!(
+            text.contains("/var/captures/screenshot.png"),
+            "full disk path should appear alongside alt text: {text}"
+        );
     }
 
     #[test]
@@ -2109,17 +2952,50 @@ mod tests {
             !text.contains("**2 result(s)**"),
             "bold markers should not leak literally into the rendered card: {text}"
         );
-        assert!(
-            text.contains("│ File │ Lines │ Type │ Score │ Preview │"),
-            "header row should render as a structured table: {text}"
-        );
+        // Header cells should all be present, separated by pipes,
+        // regardless of exact padding (which is determined by the
+        // cross-row max from `compute_table_widths`).
+        for header_cell in ["File", "Lines", "Type", "Score", "Preview"] {
+            assert!(
+                text.contains(header_cell),
+                "header should contain cell {header_cell:?}: {text}"
+            );
+        }
         assert!(
             text.contains("├") || text.contains("┼"),
             "separator row should render box drawing characters: {text}"
         );
-        assert!(
-            text.contains("│ src/app.rs │ 10-20 │ code │ 45.38 │ fn render() │"),
-            "body row should render as a structured table: {text}"
+        // Body cells likewise — and crucially, the rows must align
+        // across the table block. Both body rows must render with the
+        // same column structure even though `src/lib.rs` has shorter
+        // content than `src/app.rs`. The previous per-row width
+        // computation broke this.
+        for body_cell in [
+            "src/app.rs", "10-20", "45.38", "fn render()",
+            "src/lib.rs", "1-9", "11.20", "helper",
+        ] {
+            assert!(
+                text.contains(body_cell),
+                "body should contain cell {body_cell:?}: {text}"
+            );
+        }
+        // Cross-row alignment check: both body rows should start at
+        // the same screen column (i.e. render with the same number of
+        // leading characters before the first cell). Find both row
+        // start positions and compare them.
+        let row1_start = text
+            .find("src/app.rs")
+            .expect("first body row should be present");
+        let row2_start = text
+            .find("src/lib.rs")
+            .expect("second body row should be present");
+        // Walk back to the most recent newline to find the column
+        // offset for each row. They must be equal.
+        let col1 = row1_start - text[..row1_start].rfind('\n').map(|i| i + 1).unwrap_or(0);
+        let col2 = row2_start - text[..row2_start].rfind('\n').map(|i| i + 1).unwrap_or(0);
+        assert_eq!(
+            col1, col2,
+            "body rows must start at the same column for cross-row alignment: row1 col={col1} row2 col={col2}"
         );
     }
 
@@ -2216,17 +3092,22 @@ mod tests {
         let (area, mut buf) = make_buf(40, 10);
         seg.render(area, &mut buf, &Alpharius);
         let text = buf_text(&buf, area);
+        // Cell content checks (padding is determined by shared column
+        // widths from compute_table_widths and shouldn't be locked in
+        // by tests).
+        for cell in ["Name", "Value", "foo", "bar"] {
+            assert!(
+                text.contains(cell),
+                "table should contain cell {cell:?}: {text}"
+            );
+        }
         assert!(
-            text.contains("│ Name │ Value │"),
-            "header row should render as a table: {text}"
+            text.contains("│"),
+            "table should render with box-drawing pipes: {text}"
         );
         assert!(
             text.contains("├") || text.contains("┼"),
             "separator row should render box drawing characters: {text}"
-        );
-        assert!(
-            text.contains("│ foo │ bar │"),
-            "body row should render as a table: {text}"
         );
     }
 
@@ -2247,13 +3128,28 @@ mod tests {
             text.contains("Here are the strongest matches:"),
             "leading prose should remain visible: {text}"
         );
-        assert!(
-            text.contains("│ File │ Score │"),
-            "table header should still render structurally inside surrounding prose: {text}"
-        );
-        assert!(
-            text.contains("│ src/app.rs │ 45.38 │"),
-            "table body should still render structurally inside surrounding prose: {text}"
+        for cell in ["File", "Score", "src/app.rs", "45.38", "src/lib.rs", "11.20"] {
+            assert!(
+                text.contains(cell),
+                "table should contain cell {cell:?}: {text}"
+            );
+        }
+        // Cross-row alignment check: both body rows must start at the
+        // same column. Header `File` is 4 chars; body `src/app.rs` is
+        // 10 chars. The pre-pass widens the File column to 10 across
+        // the whole block, so the header gets padding and both body
+        // rows align with each other.
+        let row1 = text
+            .find("src/app.rs")
+            .expect("first body row should be present");
+        let row2 = text
+            .find("src/lib.rs")
+            .expect("second body row should be present");
+        let col1 = row1 - text[..row1].rfind('\n').map(|i| i + 1).unwrap_or(0);
+        let col2 = row2 - text[..row2].rfind('\n').map(|i| i + 1).unwrap_or(0);
+        assert_eq!(
+            col1, col2,
+            "body rows must align across the table block: row1 col={col1} row2 col={col2}"
         );
         assert!(
             text.contains("Use "),
@@ -2500,17 +3396,17 @@ mod tests {
         let (area, mut buf) = make_buf(60, 12);
         seg.render(area, &mut buf, &Alpharius);
         let text = buf_text(&buf, area);
-        assert!(
-            text.contains("│ Name │ Value │ Notes │"),
-            "header row should render with aligned separator syntax: {text}"
-        );
+        // Aligned-separator markdown (`:----:`) should still parse as
+        // a table — the separator-detection logic accepts colons.
+        for cell in ["Name", "Value", "Notes", "foo", "bar", "baz"] {
+            assert!(
+                text.contains(cell),
+                "table should contain cell {cell:?}: {text}"
+            );
+        }
         assert!(
             text.contains("├") || text.contains("┼"),
             "aligned separator row should still render box drawing characters: {text}"
-        );
-        assert!(
-            text.contains("│ foo │ bar │ baz │"),
-            "body row should render with aligned separator syntax: {text}"
         );
     }
 
@@ -2927,7 +3823,11 @@ mod tests {
 
     #[test]
     fn table_line_renders() {
-        let line = render_table_line("| Name | Value |", true, 80, &Alpharius);
+        // render_table_line now takes pre-computed shared widths from
+        // compute_table_widths instead of computing per-row widths.
+        let widths = vec![10, 10];
+        let line =
+            render_table_line("| Name | Value |", true, &widths, &Alpharius);
         let text: String = line.spans.iter().map(|s| s.content.to_string()).collect();
         assert!(
             text.contains("Name"),
@@ -2938,14 +3838,14 @@ mod tests {
             "should contain box drawing separator: {text}"
         );
 
-        let body = render_table_line("| foo | bar |", false, 80, &Alpharius);
+        let body = render_table_line("| foo | bar |", false, &widths, &Alpharius);
         let body_text: String = body.spans.iter().map(|s| s.content.to_string()).collect();
         assert!(
             body_text.contains("foo"),
             "body should contain cell text: {body_text}"
         );
 
-        let sep = render_table_line("|---|---|", false, 80, &Alpharius);
+        let sep = render_table_line("|---|---|", false, &widths, &Alpharius);
         let sep_text: String = sep.spans.iter().map(|s| s.content.to_string()).collect();
         assert!(
             sep_text.contains("─"),
@@ -2955,6 +3855,104 @@ mod tests {
             sep_text.contains("┼"),
             "separator should have cross: {sep_text}"
         );
+    }
+
+    #[test]
+    fn compute_table_widths_aligns_columns_across_rows() {
+        // The headline failure mode this fix addresses: a header with
+        // narrow cells (`File`/`Lines`/`Score`) followed by a body row
+        // with very long content in the last column (Preview). The old
+        // per-row computation derived widths from the header's short
+        // cells, leaving no budget for the body's long content; the
+        // body row got truncated independently and rendered out of
+        // alignment. With the pre-pass, every row in the same block
+        // shares the same widths.
+        let lines = vec![
+            "| File | Lines | Score | Preview |",
+            "|------|-------|-------|---------|",
+            "| `core/crates/omegon/src/tui/segments.rs` | 1234-1456 | 9.13 | pub struct Segment { /* very long preview content here */ } |",
+        ];
+        let widths_per_line = compute_table_widths(&lines, 90);
+
+        // All three lines should be marked as belonging to the same
+        // table block.
+        assert!(widths_per_line[0].is_some());
+        assert!(widths_per_line[1].is_some());
+        assert!(widths_per_line[2].is_some());
+
+        // All three should share the SAME widths array (column
+        // alignment is the whole point).
+        let h = widths_per_line[0].as_ref().unwrap();
+        let s = widths_per_line[1].as_ref().unwrap();
+        let b = widths_per_line[2].as_ref().unwrap();
+        assert_eq!(h, s, "header and separator should share widths");
+        assert_eq!(h, b, "header and body should share widths");
+
+        // The first three columns should reflect the body row's actual
+        // content (longer than the header's), not the header's
+        // labels — that's the cross-row max we're computing.
+        assert!(
+            h[0] >= "`core/crates/omegon/src/tui/segments.rs`".chars().count(),
+            "File column should accommodate the body's long file path: {h:?}"
+        );
+        assert!(h[1] >= "1234-1456".chars().count());
+        assert!(h[2] >= "9.13".chars().count());
+
+        // The last column (Preview) should have been shrunk to fit the
+        // available budget rather than blowing past the card width.
+        let total: usize = h.iter().sum();
+        let chrome = h.len() * 3 + 1;
+        assert!(
+            total + chrome <= 90,
+            "rendered widths must fit available_width=90: total={total} chrome={chrome} widths={h:?}"
+        );
+    }
+
+    #[test]
+    fn compute_table_widths_returns_none_for_non_table_lines() {
+        let lines = vec![
+            "Some prose before a table",
+            "| col1 | col2 |",
+            "|------|------|",
+            "| a    | b    |",
+            "More prose after",
+            "And another paragraph",
+        ];
+        let widths = compute_table_widths(&lines, 80);
+        assert!(widths[0].is_none(), "prose line is not a table");
+        assert!(widths[1].is_some(), "header line is a table");
+        assert!(widths[2].is_some(), "separator line is a table");
+        assert!(widths[3].is_some(), "body line is a table");
+        assert!(widths[4].is_none(), "trailing prose is not a table");
+        assert!(widths[5].is_none());
+    }
+
+    #[test]
+    fn compute_table_widths_handles_multiple_blocks() {
+        // Two separate table blocks with prose in between. Each block
+        // should compute its own widths independently.
+        let lines = vec![
+            "| a | b |",
+            "|---|---|",
+            "| 1 | 2 |",
+            "",
+            "intervening prose",
+            "",
+            "| longer-header | wider |",
+            "|---------------|-------|",
+            "| x             | y     |",
+        ];
+        let widths = compute_table_widths(&lines, 80);
+        let block1 = widths[0].as_ref().unwrap();
+        let block2 = widths[6].as_ref().unwrap();
+        assert_ne!(
+            block1, block2,
+            "two separate table blocks should compute independent widths"
+        );
+        // Block 1 first column = max("a", "1") = 1 char
+        assert_eq!(block1[0], 1);
+        // Block 2 first column = max("longer-header", "x") = 13 chars
+        assert_eq!(block2[0], 13);
     }
 
     #[test]

--- a/core/crates/omegon/src/tui/segments.rs
+++ b/core/crates/omegon/src/tui/segments.rs
@@ -186,6 +186,16 @@ pub enum SegmentContent {
         /// `complete` to true. `None` for tools that don't stream or
         /// before the first partial arrives.
         live_partial: Option<omegon_traits::PartialToolResult>,
+        /// Wall-clock instant captured when the tool card was created
+        /// (i.e. when `ToolStart` arrived). The renderer prefers this
+        /// over `live_partial.progress.elapsed_ms` for the displayed
+        /// timer because it ticks with every frame draw — the partial's
+        /// elapsed is captured at flush time and freezes between
+        /// partials, which looks broken to an operator watching a
+        /// long-running tool. `None` for legacy fixtures that don't
+        /// set it; the renderer falls back to the partial's value in
+        /// that case.
+        started_at: Option<std::time::Instant>,
     },
 
     /// System notification (slash command response, info message).
@@ -238,6 +248,7 @@ impl Segment {
                 complete: false,
                 expanded: false,
                 live_partial: None,
+                started_at: Some(std::time::Instant::now()),
             },
         }
     }
@@ -456,6 +467,7 @@ impl Segment {
                 complete,
                 expanded,
                 live_partial,
+                started_at,
                 ..
             } => {
                 render_tool_card(
@@ -466,6 +478,7 @@ impl Segment {
                     *complete,
                     *expanded,
                     live_partial.as_ref(),
+                    *started_at,
                     &self.meta,
                     area,
                     buf,
@@ -936,6 +949,7 @@ fn render_tool_card(
     complete: bool,
     expanded: bool,
     live_partial: Option<&omegon_traits::PartialToolResult>,
+    started_at: Option<std::time::Instant>,
     meta: &SegmentMeta,
     area: Rect,
     buf: &mut Buffer,
@@ -1183,15 +1197,26 @@ fn render_tool_card(
                 };
                 status_parts.push(label);
             }
-            if partial.progress.elapsed_ms > 0 {
-                let secs = partial.progress.elapsed_ms / 1000;
-                if secs >= 60 {
-                    status_parts.push(format!("{}m{:02}s", secs / 60, secs % 60));
-                } else {
-                    let tenths = (partial.progress.elapsed_ms % 1000) / 100;
-                    status_parts.push(format!("{secs}.{tenths}s"));
-                }
+        }
+        // Elapsed time: prefer the live wall-clock from `started_at` so
+        // the displayed timer ticks with every frame draw. Fall back to
+        // the partial's `elapsed_ms` (captured at flush time, freezes
+        // between partials) when no `started_at` is available — that's
+        // the legacy/test path where the segment doesn't carry one.
+        let elapsed_ms: Option<u64> = started_at
+            .map(|started| started.elapsed().as_millis() as u64)
+            .or_else(|| live_partial.map(|p| p.progress.elapsed_ms))
+            .filter(|ms| *ms > 0);
+        if let Some(ms) = elapsed_ms {
+            let secs = ms / 1000;
+            if secs >= 60 {
+                status_parts.push(format!("{}m{:02}s", secs / 60, secs % 60));
+            } else {
+                let tenths = (ms % 1000) / 100;
+                status_parts.push(format!("{secs}.{tenths}s"));
             }
+        }
+        if let Some(partial) = live_partial {
             if partial.progress.heartbeat {
                 status_parts.push("idle".to_string());
             }
@@ -1932,6 +1957,7 @@ mod tests {
                 complete: true,
                 expanded: false,
                 live_partial: None,
+                started_at: None,
             },
         };
         let (area, mut buf) = make_buf(80, 8);
@@ -1968,6 +1994,7 @@ mod tests {
                 complete: true,
                 expanded: false,
                 live_partial: None,
+                started_at: None,
             },
         };
         let (area, mut buf) = make_buf(90, 8);
@@ -2006,6 +2033,7 @@ mod tests {
                 complete: true,
                 expanded: false,
                 live_partial: None,
+                started_at: None,
             },
         };
         let (area, mut buf) = make_buf(80, 12);
@@ -2059,6 +2087,7 @@ mod tests {
                 complete: true,
                 expanded: false,
                 live_partial: None,
+                started_at: None,
             },
         };
         let (area, mut buf) = make_buf(100, 16);
@@ -2267,6 +2296,7 @@ mod tests {
                 complete: false,
                 expanded: false,
                 live_partial: Some(partial),
+                started_at: None,
             },
         };
         let (area, mut buf) = make_buf(80, 18);
@@ -2313,6 +2343,7 @@ mod tests {
                 complete: false,
                 expanded: false,
                 live_partial: None,
+                started_at: None,
             },
         };
         let (area, mut buf) = make_buf(80, 8);
@@ -2321,6 +2352,61 @@ mod tests {
         assert!(
             text.contains("running"),
             "in-flight card with no partial should show 'running' placeholder: {text}"
+        );
+    }
+
+    #[test]
+    fn in_flight_tool_card_uses_wall_clock_when_started_at_set() {
+        // When `started_at` is populated, the displayed elapsed timer
+        // should reflect the wall-clock since that instant — NOT the
+        // partial's `elapsed_ms` field. This is the fix for "timer
+        // freezes between partials" — bash can go 5 seconds quiet
+        // between idle heartbeats, but the displayed timer should
+        // keep ticking on every frame draw.
+        //
+        // Construct a card with `started_at` set 8 seconds in the past
+        // and a partial whose internal `elapsed_ms` says only 2 seconds
+        // (i.e. the partial was emitted early in the run and is now
+        // stale). The rendered output should show ~8s, not 2s.
+        let started_in_past =
+            std::time::Instant::now() - std::time::Duration::from_secs(8);
+        let stale_partial = omegon_traits::PartialToolResult {
+            tail: "still working".to_string(),
+            progress: omegon_traits::ToolProgress {
+                elapsed_ms: 2_000, // stale: from when the partial was emitted
+                heartbeat: false,
+                phase: None,
+                units: None,
+                tally: None,
+            },
+            details: serde_json::json!(null),
+        };
+        let seg = Segment {
+            meta: SegmentMeta::default(),
+            content: SegmentContent::ToolCard {
+                id: "1".into(),
+                name: "bash".into(),
+                args_summary: None,
+                detail_args: Some("sleep 60".into()),
+                result_summary: None,
+                detail_result: None,
+                is_error: false,
+                complete: false,
+                expanded: false,
+                live_partial: Some(stale_partial),
+                started_at: Some(started_in_past),
+            },
+        };
+        let (area, mut buf) = make_buf(80, 8);
+        seg.render(area, &mut buf, &Alpharius);
+        let text = buf_text(&buf, area);
+        assert!(
+            text.contains("8.0s") || text.contains("8.1s") || text.contains("7.9s"),
+            "wall-clock should override stale partial elapsed_ms (~8s expected, not 2.0s): {text}"
+        );
+        assert!(
+            !text.contains("2.0s"),
+            "stale partial elapsed_ms (2.0s) should NOT appear when started_at is set: {text}"
         );
     }
 
@@ -2354,6 +2440,7 @@ mod tests {
                 complete: false,
                 expanded: false,
                 live_partial: Some(partial),
+                started_at: None,
             },
         };
         let (area, mut buf) = make_buf(80, 8);
@@ -2387,6 +2474,7 @@ mod tests {
                 complete: true,
                 expanded: false,
                 live_partial: None,
+                started_at: None,
             },
         };
         let (area, mut buf) = make_buf(90, 18);
@@ -2441,6 +2529,7 @@ mod tests {
                 complete: true,
                 expanded: false,
                 live_partial: None,
+                started_at: None,
             },
         };
         let (area, mut buf) = make_buf(60, 10);
@@ -2473,6 +2562,7 @@ mod tests {
                 complete: true,
                 expanded: false,
                 live_partial: None,
+                started_at: None,
             },
         };
         let short = Segment {
@@ -2488,6 +2578,7 @@ mod tests {
                 complete: true,
                 expanded: false,
                 live_partial: None,
+                started_at: None,
             },
         };
 
@@ -2529,6 +2620,7 @@ mod tests {
                 complete: true,
                 expanded: false,
                 live_partial: None,
+                started_at: None,
             },
         };
         let (area, mut buf) = make_buf(28, 8);
@@ -2571,6 +2663,7 @@ mod tests {
                 complete: true,
                 expanded: false,
                 live_partial: None,
+                started_at: None,
             },
         };
         let short = Segment {
@@ -2586,6 +2679,7 @@ mod tests {
                 complete: true,
                 expanded: false,
                 live_partial: None,
+                started_at: None,
             },
         };
 
@@ -2625,6 +2719,7 @@ mod tests {
                 complete: true,
                 expanded: false,
                 live_partial: None,
+                started_at: None,
             },
         };
         let (area, mut buf) = make_buf(60, 8);
@@ -2656,6 +2751,7 @@ mod tests {
                 complete: false,
                 expanded: false,
                 live_partial: None,
+                started_at: None,
             },
         };
         let (area, mut buf) = make_buf(50, 8);
@@ -2714,6 +2810,7 @@ mod tests {
                 complete: true,
                 expanded: false,
                 live_partial: None,
+                started_at: None,
             },
         };
         let h = tool.height(80, &t);
@@ -2737,6 +2834,7 @@ mod tests {
                 complete: true,
                 expanded: false,
                 live_partial: None,
+                started_at: None,
             },
         };
         let h_narrow = tool.height(40, &t);
@@ -2767,6 +2865,7 @@ mod tests {
                 complete: true,
                 expanded: false,
                 live_partial: None,
+                started_at: None,
             },
         };
         let h = tool.height(80, &t);
@@ -2789,6 +2888,7 @@ mod tests {
                 complete: true,
                 expanded: false,
                 live_partial: None,
+                started_at: None,
             },
         };
         let h = tool.height(80, &t);
@@ -2876,6 +2976,7 @@ mod tests {
                 complete: true,
                 expanded: false,
                 live_partial: None,
+                started_at: None,
             },
         };
         let seg_expanded = Segment {
@@ -2891,6 +2992,7 @@ mod tests {
                 complete: true,
                 expanded: true,
                 live_partial: None,
+                started_at: None,
             },
         };
 
@@ -2919,6 +3021,7 @@ mod tests {
                 complete: true,
                 expanded: false,
                 live_partial: None,
+                started_at: None,
             },
         };
         let (area, mut buf) = make_buf(80, 12);
@@ -2952,6 +3055,7 @@ mod tests {
                 complete: true,
                 expanded: false,
                 live_partial: None,
+                started_at: None,
             },
         };
         let (area, mut buf) = make_buf(80, 10);

--- a/core/crates/omegon/src/tui/segments.rs
+++ b/core/crates/omegon/src/tui/segments.rs
@@ -180,6 +180,12 @@ pub enum SegmentContent {
         complete: bool,
         /// When true, show full result instead of truncated preview.
         expanded: bool,
+        /// Most recent partial result received from the runner while the
+        /// tool is still in flight. Populated by `ToolUpdate` events,
+        /// rendered inside the card body until `ToolEnd` flips
+        /// `complete` to true. `None` for tools that don't stream or
+        /// before the first partial arrives.
+        live_partial: Option<omegon_traits::PartialToolResult>,
     },
 
     /// System notification (slash command response, info message).
@@ -231,6 +237,7 @@ impl Segment {
                 is_error: false,
                 complete: false,
                 expanded: false,
+                live_partial: None,
             },
         }
     }
@@ -448,6 +455,7 @@ impl Segment {
                 is_error,
                 complete,
                 expanded,
+                live_partial,
                 ..
             } => {
                 render_tool_card(
@@ -457,6 +465,7 @@ impl Segment {
                     *is_error,
                     *complete,
                     *expanded,
+                    live_partial.as_ref(),
                     &self.meta,
                     area,
                     buf,
@@ -510,6 +519,8 @@ impl Segment {
                 detail_args,
                 detail_result,
                 expanded,
+                complete,
+                live_partial,
                 ..
             } => {
                 let inner_width = width.saturating_sub(4).max(1);
@@ -530,8 +541,33 @@ impl Segment {
                     .as_ref()
                     .map(|r| wrapped_rows(r, inner_width).min(if *expanded { 220 } else { 12 }))
                     .unwrap_or(0);
-                let separator_rows = u16::from(compact_arg_rows > 0 && compact_result_rows > 0);
-                compact_arg_rows + compact_result_rows + separator_rows + 4
+                // Live section rows: only relevant while the tool is
+                // still in flight. Always at least one row (the status
+                // header) when incomplete; tail rows on top when a
+                // partial with content has arrived.
+                let compact_live_rows: u16 = if !*complete {
+                    let header = 1u16;
+                    let tail = live_partial
+                        .as_ref()
+                        .map(|p| {
+                            let lines = p.tail.lines().count() as u16;
+                            lines.min(if *expanded { 50 } else { 12 })
+                        })
+                        .unwrap_or(0);
+                    header + tail
+                } else {
+                    0
+                };
+                let live_separator_rows =
+                    u16::from(compact_arg_rows > 0 && compact_live_rows > 0);
+                let result_separator_rows =
+                    u16::from(compact_arg_rows > 0 && compact_result_rows > 0);
+                compact_arg_rows
+                    + compact_live_rows
+                    + live_separator_rows
+                    + compact_result_rows
+                    + result_separator_rows
+                    + 4
             }
             SystemNotification { text } => wrapped_rows(text, width.saturating_sub(4)) + 3,
             _ => 4,
@@ -899,6 +935,7 @@ fn render_tool_card(
     is_error: bool,
     complete: bool,
     expanded: bool,
+    live_partial: Option<&omegon_traits::PartialToolResult>,
     meta: &SegmentMeta,
     area: Rect,
     buf: &mut Buffer,
@@ -1107,6 +1144,91 @@ fn render_tool_card(
         }
     }
 
+    // ── Live progress section (in-flight tools only) ────────────
+    // While the tool is still running and we don't yet have a final
+    // result, render the latest streaming partial (if any) as a tail
+    // window inside the card. This is the producer-side instrumentation
+    // from #23/#24/#31/#32 finally surfacing in the operator UI: bash
+    // line counts + tail, local_inference token counts + accumulated
+    // text, mcp progress phase + units. Without this block, in-flight
+    // tools render with an empty card body — the "anemic 17:45 with
+    // nothing to look at" failure mode.
+    let mut live_row_fills: Vec<(u16, Color)> = Vec::new();
+    if !complete {
+        let pre_live_line_count = lines.len();
+        if !lines.is_empty() {
+            let sep_color = t.border_dim();
+            lines.push(Line::from(Span::styled(
+                "─".repeat(card_inner.width as usize),
+                Style::default().fg(sep_color).bg(bg),
+            )));
+            live_row_fills.push((pre_live_line_count as u16, bg));
+        }
+
+        // Status header: ▶ {phase or "running"} · {units} · {elapsed}
+        // — built from whichever fields the partial happens to carry.
+        // Falls back to a bare "▶ running" when no partial has arrived
+        // yet, so the operator at least sees a "we're alive" line
+        // instead of a blank card.
+        let mut status_parts: Vec<String> = Vec::new();
+        let phase_label = live_partial
+            .and_then(|p| p.progress.phase.as_deref())
+            .unwrap_or("running");
+        status_parts.push(phase_label.to_string());
+        if let Some(partial) = live_partial {
+            if let Some(units) = &partial.progress.units {
+                let label = match units.total {
+                    Some(total) => format!("{}/{} {}", units.current, total, units.unit),
+                    None => format!("{} {}", units.current, units.unit),
+                };
+                status_parts.push(label);
+            }
+            if partial.progress.elapsed_ms > 0 {
+                let secs = partial.progress.elapsed_ms / 1000;
+                if secs >= 60 {
+                    status_parts.push(format!("{}m{:02}s", secs / 60, secs % 60));
+                } else {
+                    let tenths = (partial.progress.elapsed_ms % 1000) / 100;
+                    status_parts.push(format!("{secs}.{tenths}s"));
+                }
+            }
+            if partial.progress.heartbeat {
+                status_parts.push("idle".to_string());
+            }
+        }
+        let status_text = format!("▶ {}", status_parts.join(" · "));
+        lines.push(Line::from(vec![
+            Span::styled(
+                status_text,
+                Style::default().fg(t.warning()).bg(bg),
+            ),
+        ]));
+        live_row_fills.push((lines.len().saturating_sub(1) as u16, bg));
+
+        // Tail content from the latest partial. Only renders when the
+        // partial actually carries `tail` text (bash + local_inference
+        // both do; mcp progress notifications carry only phase/units
+        // and leave tail empty, which is correct).
+        if let Some(partial) = live_partial {
+            if !partial.tail.is_empty() {
+                let tail_lines: Vec<&str> = partial.tail.lines().collect();
+                let max_tail_lines = if expanded { 50 } else { 12 };
+                let take = tail_lines.len().min(max_tail_lines);
+                // Show the LAST N lines, not the first N — for streaming
+                // output the latest content is what the operator wants.
+                let start = tail_lines.len().saturating_sub(take);
+                let tail_style = Style::default().fg(t.muted()).bg(bg);
+                for line in &tail_lines[start..] {
+                    lines.push(Line::from(Span::styled(
+                        line.to_string(),
+                        tail_style,
+                    )));
+                    live_row_fills.push((lines.len().saturating_sub(1) as u16, bg));
+                }
+            }
+        }
+    }
+
     // ── Result section with distinct background ─────────────────
     let pre_result_line_count = lines.len();
     let mut result_row_fills: Vec<(u16, Color)> = Vec::new();
@@ -1280,6 +1402,13 @@ fn render_tool_card(
         .wrap(Wrap { trim: false })
         .render(card_inner, buf);
 
+    // Apply background fills for both the live (in-flight) section and
+    // the completed result section. Both share the same `bg` color in
+    // practice; keeping the two fill streams separate makes the
+    // intent obvious and lets future styling diverge them cheaply.
+    for (row, fill_bg) in live_row_fills {
+        apply_rows_bg(card_inner, row, 1, fill_bg, buf);
+    }
     for (row, fill_bg) in result_row_fills {
         apply_rows_bg(card_inner, row, 1, fill_bg, buf);
     }
@@ -1802,6 +1931,7 @@ mod tests {
                 is_error: false,
                 complete: true,
                 expanded: false,
+                live_partial: None,
             },
         };
         let (area, mut buf) = make_buf(80, 8);
@@ -1837,6 +1967,7 @@ mod tests {
                 is_error: false,
                 complete: true,
                 expanded: false,
+                live_partial: None,
             },
         };
         let (area, mut buf) = make_buf(90, 8);
@@ -1874,6 +2005,7 @@ mod tests {
                 is_error: false,
                 complete: true,
                 expanded: false,
+                live_partial: None,
             },
         };
         let (area, mut buf) = make_buf(80, 12);
@@ -1926,6 +2058,7 @@ mod tests {
                 is_error: false,
                 complete: true,
                 expanded: false,
+                live_partial: None,
             },
         };
         let (area, mut buf) = make_buf(100, 16);
@@ -2100,6 +2233,143 @@ mod tests {
     }
 
     #[test]
+    fn in_flight_tool_card_renders_live_tail_and_status_header() {
+        // Construct a still-in-flight bash card with a streaming partial
+        // carrying line counts, elapsed time, and tail content. The card
+        // should render the tail (last few lines) and a status header
+        // showing units + elapsed — replacing the empty body that the
+        // pre-streaming code would have shown for an in-flight tool.
+        let partial = omegon_traits::PartialToolResult {
+            tail: "compiling foo v0.1.0\ncompiling bar v0.2.1\ncompiling baz v0.3.4\nlinking target/debug/myapp".to_string(),
+            progress: omegon_traits::ToolProgress {
+                elapsed_ms: 12_300,
+                heartbeat: false,
+                phase: None,
+                units: Some(omegon_traits::ProgressUnits {
+                    current: 4,
+                    total: None,
+                    unit: "lines".to_string(),
+                }),
+                tally: None,
+            },
+            details: serde_json::json!(null),
+        };
+        let seg = Segment {
+            meta: SegmentMeta::default(),
+            content: SegmentContent::ToolCard {
+                id: "1".into(),
+                name: "bash".into(),
+                args_summary: None,
+                detail_args: Some("cargo build".into()),
+                result_summary: None,
+                detail_result: None,
+                is_error: false,
+                complete: false,
+                expanded: false,
+                live_partial: Some(partial),
+            },
+        };
+        let (area, mut buf) = make_buf(80, 18);
+        seg.render(area, &mut buf, &Alpharius);
+        let text = buf_text(&buf, area);
+
+        // Status header populated from progress fields
+        assert!(text.contains("running"), "status header should show 'running' fallback phase: {text}");
+        assert!(
+            text.contains("4 lines"),
+            "status header should show units count from partial: {text}"
+        );
+        assert!(
+            text.contains("12.3s"),
+            "status header should show elapsed time from partial: {text}"
+        );
+
+        // Tail content from the partial — the last lines, not the first
+        assert!(
+            text.contains("linking"),
+            "live tail should render most recent line: {text}"
+        );
+        assert!(
+            text.contains("compiling baz"),
+            "live tail should render recent compile lines: {text}"
+        );
+    }
+
+    #[test]
+    fn in_flight_tool_card_with_no_partial_renders_running_placeholder() {
+        // Before any partial arrives, the card should still show a
+        // "▶ running" status line so the operator sees something
+        // instead of an empty body.
+        let seg = Segment {
+            meta: SegmentMeta::default(),
+            content: SegmentContent::ToolCard {
+                id: "1".into(),
+                name: "bash".into(),
+                args_summary: None,
+                detail_args: Some("sleep 30".into()),
+                result_summary: None,
+                detail_result: None,
+                is_error: false,
+                complete: false,
+                expanded: false,
+                live_partial: None,
+            },
+        };
+        let (area, mut buf) = make_buf(80, 8);
+        seg.render(area, &mut buf, &Alpharius);
+        let text = buf_text(&buf, area);
+        assert!(
+            text.contains("running"),
+            "in-flight card with no partial should show 'running' placeholder: {text}"
+        );
+    }
+
+    #[test]
+    fn in_flight_tool_card_renders_idle_marker_for_heartbeat_partials() {
+        // Heartbeat partials carry no tail content, just a "still alive"
+        // signal. The status header should mark the card as idle so
+        // operators know the tool is alive but not actively producing
+        // output (vs. wedged with no signal at all).
+        let partial = omegon_traits::PartialToolResult {
+            tail: String::new(),
+            progress: omegon_traits::ToolProgress {
+                elapsed_ms: 6_000,
+                heartbeat: true,
+                phase: None,
+                units: None,
+                tally: None,
+            },
+            details: serde_json::json!(null),
+        };
+        let seg = Segment {
+            meta: SegmentMeta::default(),
+            content: SegmentContent::ToolCard {
+                id: "1".into(),
+                name: "bash".into(),
+                args_summary: None,
+                detail_args: Some("sleep 30".into()),
+                result_summary: None,
+                detail_result: None,
+                is_error: false,
+                complete: false,
+                expanded: false,
+                live_partial: Some(partial),
+            },
+        };
+        let (area, mut buf) = make_buf(80, 8);
+        seg.render(area, &mut buf, &Alpharius);
+        let text = buf_text(&buf, area);
+        assert!(
+            text.contains("idle"),
+            "heartbeat partial should render 'idle' marker: {text}"
+        );
+        assert!(
+            text.contains("6.0s"),
+            "heartbeat should still surface elapsed_ms: {text}"
+        );
+    }
+
+    #[test]
     fn tool_result_markdown_tables_truncate_wide_preview_cells_in_narrow_cards() {
         let seg = Segment {
             meta: SegmentMeta::default(),
@@ -2116,6 +2386,7 @@ mod tests {
                 is_error: false,
                 complete: true,
                 expanded: false,
+                live_partial: None,
             },
         };
         let (area, mut buf) = make_buf(90, 18);
@@ -2169,6 +2440,7 @@ mod tests {
                 is_error: false,
                 complete: true,
                 expanded: false,
+                live_partial: None,
             },
         };
         let (area, mut buf) = make_buf(60, 10);
@@ -2200,6 +2472,7 @@ mod tests {
                 is_error: false,
                 complete: true,
                 expanded: false,
+                live_partial: None,
             },
         };
         let short = Segment {
@@ -2214,6 +2487,7 @@ mod tests {
                 is_error: false,
                 complete: true,
                 expanded: false,
+                live_partial: None,
             },
         };
 
@@ -2254,6 +2528,7 @@ mod tests {
                 is_error: false,
                 complete: true,
                 expanded: false,
+                live_partial: None,
             },
         };
         let (area, mut buf) = make_buf(28, 8);
@@ -2295,6 +2570,7 @@ mod tests {
                 is_error: false,
                 complete: true,
                 expanded: false,
+                live_partial: None,
             },
         };
         let short = Segment {
@@ -2309,6 +2585,7 @@ mod tests {
                 is_error: false,
                 complete: true,
                 expanded: false,
+                live_partial: None,
             },
         };
 
@@ -2347,6 +2624,7 @@ mod tests {
                 is_error: true,
                 complete: true,
                 expanded: false,
+                live_partial: None,
             },
         };
         let (area, mut buf) = make_buf(60, 8);
@@ -2377,6 +2655,7 @@ mod tests {
                 is_error: false,
                 complete: false,
                 expanded: false,
+                live_partial: None,
             },
         };
         let (area, mut buf) = make_buf(50, 8);
@@ -2434,6 +2713,7 @@ mod tests {
                 is_error: false,
                 complete: true,
                 expanded: false,
+                live_partial: None,
             },
         };
         let h = tool.height(80, &t);
@@ -2456,6 +2736,7 @@ mod tests {
                 is_error: false,
                 complete: true,
                 expanded: false,
+                live_partial: None,
             },
         };
         let h_narrow = tool.height(40, &t);
@@ -2485,6 +2766,7 @@ mod tests {
                 is_error: false,
                 complete: true,
                 expanded: false,
+                live_partial: None,
             },
         };
         let h = tool.height(80, &t);
@@ -2506,6 +2788,7 @@ mod tests {
                 is_error: false,
                 complete: true,
                 expanded: false,
+                live_partial: None,
             },
         };
         let h = tool.height(80, &t);
@@ -2592,6 +2875,7 @@ mod tests {
                 is_error: false,
                 complete: true,
                 expanded: false,
+                live_partial: None,
             },
         };
         let seg_expanded = Segment {
@@ -2606,6 +2890,7 @@ mod tests {
                 is_error: false,
                 complete: true,
                 expanded: true,
+                live_partial: None,
             },
         };
 
@@ -2633,6 +2918,7 @@ mod tests {
                 is_error: false,
                 complete: true,
                 expanded: false,
+                live_partial: None,
             },
         };
         let (area, mut buf) = make_buf(80, 12);
@@ -2665,6 +2951,7 @@ mod tests {
                 is_error: false,
                 complete: true,
                 expanded: false,
+                live_partial: None,
             },
         };
         let (area, mut buf) = make_buf(80, 10);

--- a/core/crates/omegon/src/tui/snapshots/omegon__tui__snapshot_tests__snapshot_tools_panel_with_runtime_and_error.snap
+++ b/core/crates/omegon/src/tui/snapshots/omegon__tui__snapshot_tests__snapshot_tools_panel_with_runtime_and_error.snap
@@ -1,13 +1,13 @@
 ---
 source: crates/omegon/src/tui/snapshot_tests.rs
-assertion_line: 347
+assertion_line: 495
 expression: render_to_string(&terminal)
 ---
 ┌ tools ─────────────────────────────────┐
 │▸ ⌕ cbase        350ms≋≋≋≋≋≋≋≋≋≋≋≋≋≋≋≋≋≋│
-│▸ ▫ recall       220ms≋≋≋≋≋≋≋≋≋≋≋≋≋≋≋≋≋·│
-│✗ ⊕  search      8.1s ≋≋≋≋≋≋≋≋≋≋≋≋≋≋≋≋≋·│
-│  ⌘ sh          41.0s ≋≋≋≋≋≋≋≋≋≋≋≋≋≋≋≋··│
+│▸ ▢ recall       220ms≋≋≋≋≋≋≋≋≋≋≋≋≋≋≋≋≋ │
+│✗ ⌖ search       8.1s ≋≋≋≋≋≋≋≋≋≋≋≋≋≋≋≋≋ │
+│  > sh          41.0s ≋≋≋≋≋≋≋≋≋≋≋≋≋≋≋≋  │
 │                                        │
 │                                        │
 │                                        │

--- a/core/crates/omegon/src/tui/snapshots/omegon__tui__snapshot_tests__snapshot_unified_footer_console.snap
+++ b/core/crates/omegon/src/tui/snapshots/omegon__tui__snapshot_tests__snapshot_unified_footer_console.snap
@@ -4,10 +4,10 @@ assertion_line: 471
 expression: normalized
 ---
   engine                              ┌ inference ───────────────────────────────┐┌ tools ─────────────────────────────┐
-  provider ⤵ Ollama (Local) · ● local │==================++******#%^·············││▸ ▫ recall       220ms≋≋≋≋≋≋≋≋≋≋≋≋≋≋│
-  model   qwen3                       │%%###%%%%%%###%%%%%%###%%%%%%###%%%%%%###%││✗ ⊕  search      8.1s ≋≋≋≋≋≋≋≋≋≋≋≋≋·│
-  version v<current>              │= conv + sys * mem # defs % hist ^ think  ││  ⌘ sh           1.2s ≋≋≋≋≋≋≋≋≋≋≋≋≋·│
-  tier    Victory · High              │↑  800  ↓  120  ⊙  0%   ✦ 0  ◎  0 recalled││                                    │
+  provider ⤵ Ollama (Local) · ● local │==================++******#%^·············││▸ ▢ recall       220ms≋≋≋≋≋≋≋≋≋≋≋≋≋≋│
+  model   qwen3                       │%%###%%%%%%###%%%%%%###%%%%%%###%%%%%%###%││✗ ⌖ search       8.1s ≋≋≋≋≋≋≋≋≋≋≋≋≋ │
+  version v<current>              │= conv + sys * mem # defs % hist ^ think  ││  > sh           1.2s ≋≋≋≋≋≋≋≋≋≋≋≋≋ │
+  tier    Victory · High              │↑ 800  ↓ 120  ⊙ 0%   ✦ 0  ◎ 0 recalled    ││                                    │
   state   Maniple→Squad 68% / ¤262k   ├─ project ⌗2440  ⠊⠉⠉⠑⠒⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠒⠒⠤⢄ ││                                    │
   session T8                          ├─ working ⌗8  ⠊⠉⠉⠑⠒⠒⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤ ││                                    │
                                       └─ episodes ⌗45  ⠊⠉⠉⠑⠒⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤ ││                                    │

--- a/core/crates/omegon/src/tui/tests.rs
+++ b/core/crates/omegon/src/tui/tests.rs
@@ -82,13 +82,20 @@ fn session_reset_clears_instrument_panel_tool_activity() {
         args: serde_json::json!({}),
     });
 
+    // Use a substring stem that survives the instruments-panel column
+    // truncation. The panel renders unknown tools (i.e. ones not in
+    // `tool_short_name`'s match table) with a `· ` fallback prefix and
+    // truncates the result to fit a 14-cell name column, so the literal
+    // "context_clear" is not preserved — it ends up as `· context_cl…`.
+    // The negative assertion below uses the same stem so it remains
+    // strict against the post-reset cleared panel.
     let before = render_app_to_string(&mut app, 140, 36);
-    assert!(before.contains("context_clear") || before.contains("context_clear 0"), "got {before}");
+    assert!(before.contains("context_cl"), "got {before}");
 
     app.handle_agent_event(AgentEvent::SessionReset);
 
     let after = render_app_to_string(&mut app, 140, 36);
-    assert!(!after.contains("context_clear"), "got {after}");
+    assert!(!after.contains("context_cl"), "got {after}");
     assert!(after.contains("New session started. Previous session saved."), "got {after}");
 }
 


### PR DESCRIPTION
## Summary

Four-commit branch consolidating TUI render-quality work. The headline goal: solve the operator-flagged "anemic 17-minute python segment with nothing to look at" failure mode that motivated the L1 instrumentation pass nine PRs back, and clean up the surrounding rendering issues that turned up while in the same code.

| Commit | Headline |
|---|---|
| \`3a8a78d1\` | TUI consumes ToolUpdate, renders live tail in tool cards |
| \`a231d372\` | Wall-clock elapsed timer + instruments panel consolidation |
| \`2d92c637\` | Markdown table alignment, image framing, edit diffs, token annotations |
| \`cb992722\` | Clipboard 24h retention + /clipboard prune |

**1558 tests passing**, 0 failed, 1 ignored. ~2,500 lines added.

## What this branch ships

### Producer-side wiring finally surfacing

The L1 instrumentation pass earlier in the session (#23, #24, #31, #32) wired bash, local_inference, and MCP runners to emit \`ToolUpdate\` events with typed \`PartialToolResult\` payloads. The TUI's \`_ => {}\` catch-all was silently dropping every one of them. This branch makes the TUI consume them.

- **Bash** stdout/stderr line counts + elapsed + idle heartbeats → live tail inside the tool card
- **Local inference** Ollama tokens + phase → live progress with phase label
- **MCP server** progress notifications → status header with units count
- **Idle heartbeats** for runners that go quiet → \`▷ running · idle · 6.0s\` instead of a frozen-looking card

### Render-quality fixes

- **Wall-clock elapsed timer** in tool cards via a new \`started_at: Option<Instant>\` field on \`SegmentContent::ToolCard\`. Captures \`Instant::now()\` at \`ToolStart\`, computes \`started.elapsed()\` at render time. Ticks with every frame draw — no longer freezes between partials. Pinned by a test that constructs a stale partial (elapsed_ms=2000) with a started_at 8s in the past and asserts the rendered output shows ~8s, not 2s.
- **Markdown table cross-row alignment** via a new \`compute_table_widths\` pre-pass that collects table lines into blocks, computes the max-per-column across each block, then constrains the last column to fit. Both call sites (assistant text + tool result rendering) use the helper. Headers and body rows now align across the entire table block instead of computing per-row widths in isolation. The codebase_search column-shred from the screenshot is fixed.
- **Image segment** framing: \`📎\` U+1F4CE PAPERCLIP (in the Unicode emoji set, font-dependent presentation) → \`▦\` U+25A6 (single-cell, not in emoji set, evokes a thumbnail). \`BorderType::Rounded\` with \`border_dim\` → \`BorderType::Double\` with \`accent_muted\` so segment bounds stay unambiguous against image content of any color. Title shows the **full disk path** via \`path.display()\` instead of just the filename — operators see exactly where clipboard pastes live on disk.
- **Edit/change diff renderer**: replaces the boring "Successfully replaced text in {path}" result with a colored line-by-line diff built from the args' \`oldText\`/\`newText\`. Layout: \`Δ N edit(s) · +X / -Y\` summary, then \`- removed\` / \`+ added\` lines, then a truncation marker for collapsed cards. Multi-file \`change\` calls get \`▸ {file}\` headers per hunk. Failed edits still show the diff (intent) plus the error result text below.
- **Token annotations** on every segment in a turn: \`↑1.2k ↓340 · 14:32\` next to the timestamp on the title bar. New \`TokenUsage\` type, new \`actual_tokens: Option<TokenUsage>\` field on \`SegmentMeta\`. Stamped onto every segment in a turn after \`TurnEnd\` arrives via a new \`ConversationView::stamp_turn_tokens\` walkback. Both the bespoke right-rail title in \`render_tool_card\` and the shared \`top_right_timestamp\` helper used by assistant segments combine the tokens with the timestamp into the right-aligned title.

### Instruments panel consolidation

- **Width function consistency**: \`UnicodeWidthChar::width_cjk()\` → \`width()\` in \`render_str_colored\` and \`truncate_display_width\`. The panel renders Western glyphs (\`◇\`, \`▶\`, \`▸\`, \`⚙\`, \`→\`, \`↑\`, \`↓\`, \`⊙\`, \`◎\`) which are East-Asian-Width=Ambiguous — \`width_cjk\` reports them as 2 cells but Western terminals render them in 1 cell. The mismatch produced 1-cell off-by-one errors that pushed names off-axis (the original \`◇  read\` extra-space bug) and accidentally added gaps in the inference panel arrow column (\`↑  800\` → \`↑ 800\`).
- **Silent truncation off-by-one**: the previous code truncated to \`name_w - 1\` cells then conditionally added \`…\` only when \`width > name_w\`. When \`width == name_w\` exactly, the cell got chopped by one character with no visual indicator (the \`context_statu\` bug). Rewritten to only truncate when overflowing, and always ellipsize when truncating.
- **Bar/track collision**: at low recency, the bar character degraded to \`·\` which was also the empty-track character — indistinguishable row of dots. Switched the empty track to literal space so the boundary is always visible.
- **Missing icon for unknown tools**: \`tool_short_name\`'s fallback returned the raw name with no glyph prefix, leaving unknown tools (\`context_status\`) in a different layout column from known tools. Fallback now prepends \`· {name}\` so every tool has an icon column.
- **Glyph emoji-safety + semantic audit**: full table swap. Replaced six emoji-set glyphs (\`⚙ ⚿ ▪ ▫ ▶ ▲\` plus \`⚡\` in the cleave panel) with non-emoji equivalents. Plus semantic improvements per operator request: \`bash: ⌘ → >\` (shell prompt), \`chronos: ⚙ → ◷\` (clock-quadrant), \`change: ⚙ → Δ\` (delta), \`whoami: ⚙ → ⊙\` (self), \`speculate_*: ⊘ → ⎇\` (alternative key = branch), \`web_search: ⊕ → ⌖\` (position indicator). The glyph-safety constraint is now enforced by a test that enumerates every known tool name and asserts the leading glyph is single-cell under \`width()\`.
- **Cleave panel emoji glyphs**: \`▶\` and \`⚡\` → \`▷\` and \`↯\`.
- **Cleave activity arrow space fix**: \`format!(\"→{tool}\")\` → \`format!(\"→ {tool}\")\`. The previous version only \"worked\" because \`width_cjk\` reserved 2 cells for \`→\` and the wide-char overflow blank produced an accidental visual gap. Fixing the width function exposed the missing space; fixed at the source.

### Clipboard paste retention

- **\`Settings.clipboard_retention_hours: u64\`** — default 24, set to 0 to disable. Folds into the existing settings serialization, no new config file format. Operators can override via project profile or user config.
- **Automatic sweep at session start** in \`main.rs\`: walks \`std::env::temp_dir()\` for files matching \`omegon-clipboard-\` prefix, deletes anything older than the configured retention. Logs only when something was actually deleted (silent on the common no-op path).
- **\`/clipboard prune\` slash command** via new \`features::clipboard::ClipboardFeature\` — operator override for on-demand mid-session sweeps. Uses the same \`prune_old_pastes\` helper as the startup sweep.
- **Filename match is intentionally narrow**: only the exact \`omegon-clipboard-\` prefix, case-sensitive, no recursive descent. Belt-and-suspenders against accidentally deleting unrelated temp files. Five near-misses (\`screenshot.png\`, \`clipboard-12-0.png\`, \`omegon-other-12-0.png\`, \`OMEGON-CLIPBOARD-12-0.png\`, \`prefix-omegon-clipboard-1.png\`) verified ignored.

## Test plan

- [x] \`cargo check -p omegon\` — clean (only the 6 pre-existing warnings)
- [x] \`cargo test -p omegon --bin omegon\` — **1558 passed, 0 failed, 1 ignored**
- [x] **35+ new tests** across the branch covering live-tail rendering, wall-clock elapsed timer, table alignment, glyph safety, edit/change diff renderer, token annotation rendering + walkback, clipboard prune behavior, and the slash command feature
- [x] **Two snapshot files** updated (\`snapshot_tools_panel_with_runtime_and_error\`, \`snapshot_unified_footer_console\`) to reflect the new glyph table + spacing fixes. Diffs reviewed manually before accepting; only intentional changes (glyph swaps + width-function tightening).
- [x] **One pre-existing test** (\`session_reset_clears_instrument_panel_tool_activity\`) updated to use a substring assertion compatible with the new fallback prefix; previous assertion was passing for the wrong reason.
- [x] **Four pre-existing markdown-table tests** updated to assert cell content + cross-row column alignment instead of literal padded substrings; previous assertions only matched because each row was computing its own narrow widths (the alignment bug being fixed).

## Honest gaps + reviewer notes

- **The token annotation visual choice** (\`↑1.2k ↓340 · 14:32\`) is subjective. Easy to change before merge if you want different glyphs/format/separator.
- **The clipboard sweep runs at session start only** in \`main.rs\`'s interactive TUI path. The daemon and headless paths don't run the sweep — clipboard pastes are unlikely there but if you want sweep parity across all entry points, it's a 5-line addition per path.
- **The cargo build warnings** (6 unused-variable warnings in \`control_runtime.rs\`) are pre-existing and untouched by this branch.
- **Snapshot acceptance**: I manually verified both snapshot diffs before accepting them. The tools-panel snapshot diff shows exactly the glyph swaps + spacing fix; the inference-panel snapshot diff also picks up the \`↑ 800\` arrow tightening since arrows are also East-Asian-Width=Ambiguous and were getting the same wide-char overflow blank treatment.
- **The diff renderer is naive** (line stack: \`-\` for old, \`+\` for new) rather than a proper Myers diff. For most edits the source has identical context lines around the change, so a Myers diff would show context — but the agent's \`oldText\`/\`newText\` already represent the *contiguous* block being replaced, not full file context, so the naive version is correct for what's available. If we ever want richer diffs we'd need the tool to return more context in its result.
- **Branch protection bypass**: same \`--admin\` situation as the previous PRs in this session. Your call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)