### PR TITLE
fix(tui): nuclear clear entire panel area before rendering instruments

### DIFF
--- a/core/crates/omegon/src/tui/instruments.rs
+++ b/core/crates/omegon/src/tui/instruments.rs
@@ -970,6 +970,17 @@ impl InstrumentPanel {
         label: Color,
         t: &dyn Theme,
     ) {
+        // Clear the ENTIRE allocated area (including the border cells)
+        // before drawing. Block::render writes border symbols and applies
+        // the block's style to interior cells, but it does NOT reset the
+        // SYMBOL of interior cells if a previous rendering pass left
+        // content there. The operator's screenshot showed conversation-
+        // segment text ("omegon", "Bash;3;7;14m") leaking through the
+        // inference panel because the previous frame's cell symbols
+        // survived under the new background color. This nuclear clear
+        // guarantees every cell starts as a space regardless of what
+        // any other rendering pass left behind.
+        clear_area(area, frame.buffer_mut(), panel_bg(t));
         let block = Block::default()
             .borders(Borders::ALL)
             .border_style(Style::default().fg(border).bg(t.footer_bg()))
@@ -1324,6 +1335,8 @@ impl InstrumentPanel {
         } else {
             Color::Rgb(42, 180, 200) // teal — complete
         };
+        // Same nuclear clear as render_inference/render_tools.
+        clear_area(area, frame.buffer_mut(), panel_bg(t));
         let block = Block::default()
             .borders(Borders::ALL)
             .border_style(Style::default().fg(border).bg(t.footer_bg()))
@@ -1506,6 +1519,10 @@ impl InstrumentPanel {
         label: Color,
         t: &dyn Theme,
     ) {
+        // Same nuclear clear as render_inference — see the comment
+        // there. Ensures no cross-panel or cross-frame content
+        // survives into the tools panel area.
+        clear_area(area, frame.buffer_mut(), panel_bg(t));
         let block = Block::default()
             .borders(Borders::ALL)
             .border_style(Style::default().fg(border).bg(t.footer_bg()))


### PR DESCRIPTION
## Summary

Operator screenshot (rc.76, post-#35 rebuild) still showed conversation content leaking through the instruments panels. Nuclear fix: \`clear_area(area, ...)\` BEFORE \`Block::render\` in all three instrument panel renderers.

## Root cause

\`Block::render\` applies its style (including bg) to every cell in the allocated area, but it does **not** reset the **symbol** of interior cells. If a previous rendering pass wrote text into cells that fall inside the panel's area (e.g. the conversation widget rendering before the footer), the Block overwrites the bg color but the symbol survives. The subsequent \`clear_area(inner, ...)\` only touches the area between borders — leaked text at the border positions survives.

## Fix

Add \`clear_area(area, frame.buffer_mut(), panel_bg(t))\` before \`Block::default()...render()\` in:
- \`render_inference\`
- \`render_tools\`
- \`render_cleave_panel\`

This sets every cell in the entire allocated area — including border positions — to space+bg **before** anything else draws. Combined with the existing inner clear, there are two layers: area-level (before borders), then inner-level (after borders, before content).

The engine panel (\`render_left_panel\` in \`footer.rs\`) already does the equivalent via ratatui's \`Clear\` widget. No change needed.

## Test plan

- [x] \`cargo test -p omegon --bin omegon\` — **1561 passed, 0 failed, 1 ignored**
- [ ] Operator visual verification after rebuild — the previous symptoms (\`omegon ⊙ Bash;3;7;14m\` on the inference panel's activity row) should be gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)