### PR TITLE
docs(site): update install examples to 0.15.11

### DIFF
--- a/site/src/pages/docs/install.astro
+++ b/site/src/pages/docs/install.astro
@@ -39,8 +39,8 @@ CHANNEL=rc curl -fsSL {previewSiteUrl}/install.sh | sh
 CHANNEL=nightly curl -fsSL {previewSiteUrl}/install.sh | sh
 
 # Install a specific stable, RC, or nightly-pinned version
-VERSION=0.15.10 curl -fsSL {previewSiteUrl}/install.sh | sh
-# Replace 0.15.10 with the release you actually want
+VERSION=0.15.11 curl -fsSL {previewSiteUrl}/install.sh | sh
+# Replace 0.15.11 with the release you actually want
 
 # Non-interactive (CI)
 curl -fsSL {previewSiteUrl}/install.sh | sh -s -- --no-confirm</code></pre>
@@ -49,8 +49,8 @@ curl -fsSL {previewSiteUrl}/install.sh | sh -s -- --no-confirm</code></pre>
 INSTALL_DIR=~/.local/bin curl -fsSL {canonicalSiteUrl}/install.sh | sh
 
 # Install a specific stable version
-VERSION=0.15.10 curl -fsSL {canonicalSiteUrl}/install.sh | sh
-# Replace 0.15.10 with the stable release you actually want
+VERSION=0.15.11 curl -fsSL {canonicalSiteUrl}/install.sh | sh
+# Replace 0.15.11 with the stable release you actually want
 
 # Non-interactive (CI)
 curl -fsSL {canonicalSiteUrl}/install.sh | sh -s -- --no-confirm</code></pre>
@@ -100,11 +100,10 @@ brew install omegon</code></pre>
 
   <h3>Verify a Download</h3>
   <pre><code># Verify cosign signature (keyless)
-# Replace 0.15.10 with the release you downloaded
-# Replace 0.15.10 with the release you downloaded
-cosign verify-blob omegon-0.15.10-aarch64-apple-darwin.tar.gz \
-  --signature omegon-0.15.10-aarch64-apple-darwin.tar.gz.sig \
-  --certificate omegon-0.15.10-aarch64-apple-darwin.tar.gz.pem \
+# Replace 0.15.11 with the release you downloaded
+cosign verify-blob omegon-0.15.11-aarch64-apple-darwin.tar.gz \
+  --signature omegon-0.15.11-aarch64-apple-darwin.tar.gz.sig \
+  --certificate omegon-0.15.11-aarch64-apple-darwin.tar.gz.pem \
   --certificate-identity-regexp '.*' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com</code></pre>
   <p>


### PR DESCRIPTION
## Summary
- Bump all version references in `site/src/pages/docs/install.astro` from 0.15.10 to 0.15.11
- Remove duplicate comment line in cosign verification section

Follows the 0.15.11 hotfix release which fixes broken tool surfaces (delegate, persona, auth, memory) in full harness mode after `/unshackle`.

## Test plan
- [ ] Verify site build succeeds
- [ ] Confirm install page shows 0.15.11 in all examples