### PR TITLE
fix(brew): remove global deprecation, guard against recurrence

### DIFF
--- a/homebrew/Formula/omegon.rb
+++ b/homebrew/Formula/omegon.rb
@@ -5,9 +5,7 @@ class Omegon < Formula
   desc "Terminal-native AI agent harness — single binary, ten providers, zero dependencies"
   homepage "https://omegon.styrene.dev"
   license "BUSL-1.1"
-  version "0.15.4"
-
-  deprecate! date: "2026-04-12", because: "is outdated — run: brew install styrene-lab/tap/omegon-rc"
+  version "0.15.11"
 
   LINUX_MIN_GLIBC = Version.new("2.39")
 

--- a/scripts/release_manifest.py
+++ b/scripts/release_manifest.py
@@ -140,6 +140,10 @@ def update_homebrew_formula(*, manifest_path: Path, formula_path: Path) -> None:
     content = formula_path.read_text()
     content = re.sub(r'version ".*"', f'version "{version}"', content, count=1)
 
+    # Strip any deprecate! directive — version-specific deprecations must not
+    # survive into the next stable formula update.
+    content = re.sub(r'\n  deprecate!.*\n', '\n', content)
+
     replacement_shas = [sha_by_target[target] for target in FORMULA_TARGET_ORDER]
     sha_iter = iter(replacement_shas)
 


### PR DESCRIPTION
## Summary
- Remove `deprecate!` from the stable Homebrew formula — it was 0.15.4-specific but reads as a blanket package deprecation
- Add `deprecate!` strip to `release_manifest.py` so version-specific deprecations don't survive into the next stable update
- Remote tap already fixed via direct API commit (`120665d5eda8`)

## Test plan
- [ ] `brew update && brew info omegon` no longer shows deprecation warning
- [ ] Next `release_manifest.py update-homebrew` run strips any stale deprecation