### PR TITLE
fix: delegate provider inheritance, prefill rejection, fallback ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,14 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [Semantic V
 - **Linux Homebrew install honesty** — install and distribution docs now explicitly warn that Homebrew on Linux does not solve host glibc ABI mismatches for Omegon release binaries. Users hitting `GLIBC_2.38` / `GLIBC_2.39` runtime errors are directed toward compatible distro/container baselines.
 - **Release-line correction** — `v0.15.11-rc.2` was published from a mistaken version-line advance after `0.15.10` had not actually closed cleanly. The active candidate line remains the `0.15.10` RC series. See `docs/release-line-correction-0-15-10.md`.
 
+## [0.15.12] - 2026-04-14
+
+### Fixed
+
+- **Delegate children ignore parent session provider** — delegate workers defaulted to a hardcoded provider candidate list (with `openai-codex:gpt-5.4` first) instead of inheriting the parent session's active model. Children now inherit the parent model via `TurnEnd` event tracking; the candidate list is only used as a last-resort fallback and now respects `OMEGON_MODEL`, `automation_safe_model()`, and puts API-key providers ahead of consumer subscription routes.
+- **Anthropic prefill rejection after compaction/decay** — `build_llm_view()` could produce a conversation ending with an assistant message after decay or repair stripped surrounding messages. Anthropic rejects this with "This model does not support assistant message prefill." A trailing user continuation is now appended when the final message is assistant-role.
+- **Cleave model fallback ignores operator environment** — cleave config fell back to hardcoded `anthropic:claude-sonnet-4-6` when `OMEGON_MODEL` was unset, ignoring configured API-key providers. Now checks `automation_safe_model()` before the hardcoded default.
+
 ## [0.15.11] - 2026-04-14
 
 ### Fixed

--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -4275,7 +4275,7 @@ dependencies = [
 
 [[package]]
 name = "omegon"
-version = "0.15.12-rc.1"
+version = "0.15.12"
 dependencies = [
  "ansi-to-tui",
  "anyhow",
@@ -4341,7 +4341,7 @@ dependencies = [
 
 [[package]]
 name = "omegon-codescan"
-version = "0.15.12-rc.1"
+version = "0.15.12"
 dependencies = [
  "anyhow",
  "glob",
@@ -4364,7 +4364,7 @@ dependencies = [
 
 [[package]]
 name = "omegon-extension"
-version = "0.15.12-rc.1"
+version = "0.15.12"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4380,7 +4380,7 @@ dependencies = [
 
 [[package]]
 name = "omegon-git"
-version = "0.15.12-rc.1"
+version = "0.15.12"
 dependencies = [
  "anyhow",
  "git2",
@@ -4392,7 +4392,7 @@ dependencies = [
 
 [[package]]
 name = "omegon-memory"
-version = "0.15.12-rc.1"
+version = "0.15.12"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4410,7 +4410,7 @@ dependencies = [
 
 [[package]]
 name = "omegon-secrets"
-version = "0.15.12-rc.1"
+version = "0.15.12"
 dependencies = [
  "aes-gcm",
  "aho-corasick",
@@ -4440,7 +4440,7 @@ dependencies = [
 
 [[package]]
 name = "omegon-traits"
-version = "0.15.12-rc.1"
+version = "0.15.12"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -27,7 +27,7 @@ codegen-units = 4
 strip = false
 
 [workspace.package]
-version = "0.15.12-rc.1"
+version = "0.15.12"
 edition = "2024"
 license = "BUSL-1.1"
 repository = "https://github.com/styrene-lab/omegon"

--- a/core/crates/omegon/src/conversation.rs
+++ b/core/crates/omegon/src/conversation.rs
@@ -665,6 +665,18 @@ impl ConversationState {
             });
         }
 
+        // Anthropic rejects conversations ending with an assistant message
+        // ("This model does not support assistant message prefill"). After
+        // compaction/decay/repair, the final message can be assistant-role.
+        // Append a minimal user continuation so the provider always gets
+        // a legal conversation shape.
+        if matches!(messages.last(), Some(LlmMessage::Assistant { .. })) {
+            messages.push(LlmMessage::User {
+                content: "Continue.".into(),
+                images: vec![],
+            });
+        }
+
         messages
     }
 
@@ -1296,12 +1308,16 @@ mod tests {
         conv.intent.stats.turns = 1; // Advance turn so the message is old
 
         let view = conv.build_llm_view();
-        assert_eq!(view.len(), 1);
+        // The decayed assistant message plus a trailing user continuation
+        // (build_llm_view appends one when the final message is assistant-role
+        // to satisfy provider requirements).
+        assert_eq!(view.len(), 2);
         if let LlmMessage::Assistant { thinking, .. } = &view[0] {
             assert!(thinking.is_empty(), "Thinking should be stripped on decay");
         } else {
             panic!("Expected Assistant message");
         }
+        assert!(matches!(&view[1], LlmMessage::User { .. }));
     }
 
     #[test]

--- a/core/crates/omegon/src/features/cleave.rs
+++ b/core/crates/omegon/src/features/cleave.rs
@@ -872,8 +872,9 @@ impl CleaveFeature {
             agent_binary,
             bridge_path: PathBuf::new(), // Not used in native mode
             node: String::new(),
-            model: std::env::var("OMEGON_MODEL")
-                .unwrap_or_else(|_| "anthropic:claude-sonnet-4-6".into()),
+            model: std::env::var("OMEGON_MODEL").ok().filter(|s| !s.is_empty())
+                .or_else(crate::providers::automation_safe_model)
+                .unwrap_or_else(|| "anthropic:claude-sonnet-4-6".into()),
             max_parallel,
             timeout_secs: 900,
             idle_timeout_secs: 180,

--- a/core/crates/omegon/src/features/delegate.rs
+++ b/core/crates/omegon/src/features/delegate.rs
@@ -475,12 +475,20 @@ If blocked, say the blocker plainly.\n",
         prompt: &str,
         runtime: &DelegateRuntimeRequest,
         mind: Option<&str>,
+        session_model: Option<String>,
     ) -> anyhow::Result<String> {
         let prompt_path = write_child_prompt_file(&self.cwd, ".delegate-prompt.md", prompt)?;
 
         let model = match runtime.model.clone() {
             Some(model) => model,
-            None => crate::providers::delegate_default_model().await,
+            None => {
+                // Inherit the parent session's model so children use the same
+                // provider the operator is actually running on.
+                match session_model {
+                    Some(m) => m,
+                    None => crate::providers::delegate_default_model().await,
+                }
+            }
         };
         let child_config = ChildAgentSpawnConfig {
             agent_binary: std::env::current_exe()
@@ -530,6 +538,7 @@ If blocked, say the blocker plainly.\n",
         worker_profile: DelegateWorkerProfile,
         facts: Option<Vec<String>>,
         mind: Option<String>,
+        session_model: Option<String>,
     ) -> anyhow::Result<()> {
         // Assemble field kit: load persona mind if specified
         let mut field_kit_context = String::new();
@@ -594,10 +603,11 @@ If blocked, say the blocker plainly.\n",
 
         let store = self.result_store.clone();
         let cwd = self.cwd.clone();
+        let parent_model = session_model;
         crate::task_spawn::spawn_best_effort_result("delegate-real-task", async move {
             let runner = DelegateRunner::new(cwd, store.clone());
             match runner
-                .run_delegate_child(&prompt, &runtime, mind.as_deref())
+                .run_delegate_child(&prompt, &runtime, mind.as_deref(), parent_model)
                 .await
             {
                 Ok(result) => {
@@ -662,6 +672,10 @@ pub struct DelegateFeature {
     runner: Arc<DelegateRunner>,
     progress_handle: Arc<Mutex<DelegateProgress>>,
     event_slot: DelegateEventSlot,
+    /// Parent session model, updated on each TurnEnd. Used as the default
+    /// for child delegates so they inherit the operator's active provider
+    /// instead of falling back to a hardcoded candidate list.
+    session_model: Arc<Mutex<Option<String>>>,
 }
 
 impl DelegateFeature {
@@ -677,6 +691,7 @@ impl DelegateFeature {
             runner,
             progress_handle,
             event_slot,
+            session_model: Arc::new(Mutex::new(None)),
         }
     }
 }
@@ -861,6 +876,7 @@ impl Feature for DelegateFeature {
                 let task_id = self.result_store.generate_task_id();
 
                 // Spawn the delegate
+                let parent_model = self.session_model.lock().ok().and_then(|s| s.clone());
                 self.runner
                     .spawn_delegate(
                         task_id.clone(),
@@ -872,6 +888,7 @@ impl Feature for DelegateFeature {
                         worker_profile,
                         facts,
                         mind,
+                        parent_model,
                     )
                     .await?;
                 if let Ok(mut handle) = self.progress_handle.lock() {
@@ -1045,7 +1062,14 @@ impl Feature for DelegateFeature {
 
     fn on_event(&mut self, event: &BusEvent) -> Vec<BusRequest> {
         match event {
-            BusEvent::TurnEnd { .. } => {
+            BusEvent::TurnEnd { model, .. } => {
+                // Capture the parent session's model so delegate children
+                // inherit it instead of falling back to hardcoded defaults.
+                if let Some(m) = model {
+                    if let Ok(mut slot) = self.session_model.lock() {
+                        *slot = Some(m.clone());
+                    }
+                }
                 if let Ok(mut handle) = self.progress_handle.lock() {
                     *handle = self.result_store.progress_snapshot();
                 }

--- a/core/crates/omegon/src/providers.rs
+++ b/core/crates/omegon/src/providers.rs
@@ -373,14 +373,29 @@ pub async fn resolve_execution_model_spec(model_spec: &str) -> Option<String> {
 }
 
 pub async fn delegate_default_model() -> String {
-    // Delegate workers are headless child agents. Prefer providers that are
-    // actually executable in the current environment across the full upstream
-    // matrix, not a brittle hardcoded local-only default.
+    // Delegate workers are headless child agents. Respect the operator's
+    // explicit configuration before probing available providers.
+
+    // 1. Explicit operator override via env var.
+    if let Ok(env_model) = std::env::var("OMEGON_MODEL") {
+        if !env_model.is_empty() {
+            return env_model;
+        }
+    }
+
+    // 2. Automation-safe providers (API-key-based, not consumer subscriptions).
+    if let Some(model) = automation_safe_model() {
+        return model;
+    }
+
+    // 3. Probe available providers. Prefer API-key providers over consumer
+    //    subscription routes (openai-codex OAuth) to avoid credential
+    //    mismatches when the parent session uses a different provider.
     const CANDIDATES: &[(&str, &str)] = &[
-        ("openai-codex", "gpt-5.4"),
-        ("openai", "gpt-4o"),
         ("anthropic", "claude-sonnet-4-6"),
+        ("openai", "gpt-4o"),
         ("openrouter", "openai/gpt-4o"),
+        ("openai-codex", "gpt-5.4"),
         ("ollama-cloud", "gpt-oss:120b-cloud"),
         ("groq", "llama-3.3-70b-versatile"),
         ("xai", "grok-3-mini-fast"),
@@ -394,10 +409,6 @@ pub async fn delegate_default_model() -> String {
         if resolve_provider(provider).await.is_some() {
             return format!("{provider}:{model}");
         }
-    }
-
-    if let Some(model) = automation_safe_model() {
-        return model;
     }
 
     // Absolute last resort when nothing upstream is configured.


### PR DESCRIPTION
## Summary
- Delegate children inherit parent session model instead of defaulting to hardcoded `openai-codex:gpt-5.4`
- `build_llm_view` appends trailing user message when conversation ends with assistant role (prevents Anthropic prefill rejection)
- `delegate_default_model` respects `OMEGON_MODEL` env var and `automation_safe_model()` before provider probe list; `openai-codex` demoted below API-key providers
- Cleave config uses `automation_safe_model()` fallback before hardcoded default

Tagged as `v0.15.12`.

## Test plan
- [x] All 1656 tests pass
- [x] `assistant_decay_strips_thinking` test updated for trailing user message
- [x] Snapshot updated for version string