### PR TITLE
chore(release): 0.15.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [Semantic V
 - **Linux Homebrew install honesty** — install and distribution docs now explicitly warn that Homebrew on Linux does not solve host glibc ABI mismatches for Omegon release binaries. Users hitting `GLIBC_2.38` / `GLIBC_2.39` runtime errors are directed toward compatible distro/container baselines.
 - **Release-line correction** — `v0.15.11-rc.2` was published from a mistaken version-line advance after `0.15.10` had not actually closed cleanly. The active candidate line remains the `0.15.10` RC series. See `docs/release-line-correction-0-15-10.md`.
 
-## [0.15.12] - 2026-04-14
+## [0.15.13] - 2026-04-14
 
 ### Fixed
 

--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -4275,7 +4275,7 @@ dependencies = [
 
 [[package]]
 name = "omegon"
-version = "0.15.12"
+version = "0.15.13"
 dependencies = [
  "ansi-to-tui",
  "anyhow",
@@ -4341,7 +4341,7 @@ dependencies = [
 
 [[package]]
 name = "omegon-codescan"
-version = "0.15.12"
+version = "0.15.13"
 dependencies = [
  "anyhow",
  "glob",
@@ -4364,7 +4364,7 @@ dependencies = [
 
 [[package]]
 name = "omegon-extension"
-version = "0.15.12"
+version = "0.15.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4380,7 +4380,7 @@ dependencies = [
 
 [[package]]
 name = "omegon-git"
-version = "0.15.12"
+version = "0.15.13"
 dependencies = [
  "anyhow",
  "git2",
@@ -4392,7 +4392,7 @@ dependencies = [
 
 [[package]]
 name = "omegon-memory"
-version = "0.15.12"
+version = "0.15.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4410,7 +4410,7 @@ dependencies = [
 
 [[package]]
 name = "omegon-secrets"
-version = "0.15.12"
+version = "0.15.13"
 dependencies = [
  "aes-gcm",
  "aho-corasick",
@@ -4440,7 +4440,7 @@ dependencies = [
 
 [[package]]
 name = "omegon-traits"
-version = "0.15.12"
+version = "0.15.13"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -27,7 +27,7 @@ codegen-units = 4
 strip = false
 
 [workspace.package]
-version = "0.15.12"
+version = "0.15.13"
 edition = "2024"
 license = "BUSL-1.1"
 repository = "https://github.com/styrene-lab/omegon"


### PR DESCRIPTION
Version bump from 0.15.12 due to GitHub immutable release constraints. Same fixes.