### PR TITLE
fix: tokio nested runtime panic in cleave smoke

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [Semantic V
 - **Linux Homebrew install honesty** — install and distribution docs now explicitly warn that Homebrew on Linux does not solve host glibc ABI mismatches for Omegon release binaries. Users hitting `GLIBC_2.38` / `GLIBC_2.39` runtime errors are directed toward compatible distro/container baselines.
 - **Release-line correction** — `v0.15.11-rc.2` was published from a mistaken version-line advance after `0.15.10` had not actually closed cleanly. The active candidate line remains the `0.15.10` RC series. See `docs/release-line-correction-0-15-10.md`.
 
-## [0.15.19] - 2026-04-14
+## [0.15.20] - 2026-04-14
 
 ### Fixed
 

--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -4275,7 +4275,7 @@ dependencies = [
 
 [[package]]
 name = "omegon"
-version = "0.15.19"
+version = "0.15.20"
 dependencies = [
  "ansi-to-tui",
  "anyhow",
@@ -4341,7 +4341,7 @@ dependencies = [
 
 [[package]]
 name = "omegon-codescan"
-version = "0.15.19"
+version = "0.15.20"
 dependencies = [
  "anyhow",
  "glob",
@@ -4364,7 +4364,7 @@ dependencies = [
 
 [[package]]
 name = "omegon-extension"
-version = "0.15.19"
+version = "0.15.20"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4380,7 +4380,7 @@ dependencies = [
 
 [[package]]
 name = "omegon-git"
-version = "0.15.19"
+version = "0.15.20"
 dependencies = [
  "anyhow",
  "git2",
@@ -4392,7 +4392,7 @@ dependencies = [
 
 [[package]]
 name = "omegon-memory"
-version = "0.15.19"
+version = "0.15.20"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4410,7 +4410,7 @@ dependencies = [
 
 [[package]]
 name = "omegon-secrets"
-version = "0.15.19"
+version = "0.15.20"
 dependencies = [
  "aes-gcm",
  "aho-corasick",
@@ -4440,7 +4440,7 @@ dependencies = [
 
 [[package]]
 name = "omegon-traits"
-version = "0.15.19"
+version = "0.15.20"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -27,7 +27,7 @@ codegen-units = 4
 strip = false
 
 [workspace.package]
-version = "0.15.19"
+version = "0.15.20"
 edition = "2024"
 license = "BUSL-1.1"
 repository = "https://github.com/styrene-lab/omegon"

--- a/core/crates/omegon/src/main.rs
+++ b/core/crates/omegon/src/main.rs
@@ -3440,7 +3440,7 @@ async fn run_agent_command(cli: &Cli, usage_json: Option<PathBuf>) -> anyhow::Re
     let requested_model = cli.model.clone();
     let requested_provider = providers::infer_provider_id(&requested_model);
 
-    if maybe_run_injected_cleave_smoke_child(&cli.cwd)? {
+    if maybe_run_injected_cleave_smoke_child(&cli.cwd).await? {
         return Ok(());
     }
 
@@ -3773,7 +3773,7 @@ async fn run_agent_command(cli: &Cli, usage_json: Option<PathBuf>) -> anyhow::Re
     result
 }
 
-fn maybe_run_injected_cleave_smoke_child(cwd: &Path) -> anyhow::Result<bool> {
+async fn maybe_run_injected_cleave_smoke_child(cwd: &Path) -> anyhow::Result<bool> {
     let Some(mode) = std::env::var("OMEGON_CLEAVE_SMOKE_CHILD_MODE").ok() else {
         return Ok(false);
     };
@@ -3797,9 +3797,8 @@ fn maybe_run_injected_cleave_smoke_child(cwd: &Path) -> anyhow::Result<bool> {
         }
         "report-runtime" => {
             let shared_settings = settings::shared("anthropic:claude-sonnet-4-6");
-            let agent = tokio::runtime::Handle::current().block_on(async {
-                setup::AgentSetup::new(cwd, None, Some(shared_settings.clone())).await
-            })?;
+            let agent =
+                setup::AgentSetup::new(cwd, None, Some(shared_settings.clone())).await?;
             let status = agent.initial_harness_status.clone();
             let tool_names: Vec<String> = agent
                 .bus


### PR DESCRIPTION
Async the cleave smoke child function to eliminate block_on inside runtime.