### PR TITLE
fix: suppress keychain in child agents and smoke tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [Semantic V
 - **Linux Homebrew install honesty** — install and distribution docs now explicitly warn that Homebrew on Linux does not solve host glibc ABI mismatches for Omegon release binaries. Users hitting `GLIBC_2.38` / `GLIBC_2.39` runtime errors are directed toward compatible distro/container baselines.
 - **Release-line correction** — `v0.15.11-rc.2` was published from a mistaken version-line advance after `0.15.10` had not actually closed cleanly. The active candidate line remains the `0.15.10` RC series. See `docs/release-line-correction-0-15-10.md`.
 
-## [0.15.20] - 2026-04-14
+## [0.15.21] - 2026-04-14
 
 ### Fixed
 

--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -4275,7 +4275,7 @@ dependencies = [
 
 [[package]]
 name = "omegon"
-version = "0.15.20"
+version = "0.15.21"
 dependencies = [
  "ansi-to-tui",
  "anyhow",
@@ -4341,7 +4341,7 @@ dependencies = [
 
 [[package]]
 name = "omegon-codescan"
-version = "0.15.20"
+version = "0.15.21"
 dependencies = [
  "anyhow",
  "glob",
@@ -4364,7 +4364,7 @@ dependencies = [
 
 [[package]]
 name = "omegon-extension"
-version = "0.15.20"
+version = "0.15.21"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4380,7 +4380,7 @@ dependencies = [
 
 [[package]]
 name = "omegon-git"
-version = "0.15.20"
+version = "0.15.21"
 dependencies = [
  "anyhow",
  "git2",
@@ -4392,7 +4392,7 @@ dependencies = [
 
 [[package]]
 name = "omegon-memory"
-version = "0.15.20"
+version = "0.15.21"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4410,7 +4410,7 @@ dependencies = [
 
 [[package]]
 name = "omegon-secrets"
-version = "0.15.20"
+version = "0.15.21"
 dependencies = [
  "aes-gcm",
  "aho-corasick",
@@ -4440,7 +4440,7 @@ dependencies = [
 
 [[package]]
 name = "omegon-traits"
-version = "0.15.20"
+version = "0.15.21"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -27,7 +27,7 @@ codegen-units = 4
 strip = false
 
 [workspace.package]
-version = "0.15.20"
+version = "0.15.21"
 edition = "2024"
 license = "BUSL-1.1"
 repository = "https://github.com/styrene-lab/omegon"

--- a/core/crates/omegon-secrets/src/resolve.rs
+++ b/core/crates/omegon-secrets/src/resolve.rs
@@ -41,8 +41,24 @@ pub const WELL_KNOWN_SECRET_ENVS: &[&str] = &[
 /// used for ALL keychain entries so macOS only prompts for authorization once.
 const KEYRING_SERVICE: &str = "sh.styrene.omegon";
 
+/// Returns true when keyring access should be suppressed at runtime.
+/// Set `OMEGON_NO_KEYRING=1` to avoid macOS Keychain prompts in CI,
+/// smoke tests, and headless child agents.
+#[cfg(not(test))]
+fn keyring_suppressed() -> bool {
+    static SUPPRESSED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *SUPPRESSED.get_or_init(|| {
+        std::env::var("OMEGON_NO_KEYRING")
+            .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+            .unwrap_or(false)
+    })
+}
+
 #[cfg(not(test))]
 pub(crate) fn keyring_get(service: &str, name: &str) -> Result<Option<String>, keyring::Error> {
+    if keyring_suppressed() {
+        return Ok(None);
+    }
     let entry = keyring::Entry::new(service, name)?;
     match entry.get_password() {
         Ok(val) if !val.is_empty() => Ok(Some(val)),
@@ -63,6 +79,9 @@ pub(crate) fn keyring_get(service: &str, name: &str) -> Result<Option<String>, k
 
 #[cfg(not(test))]
 pub(crate) fn keyring_set(service: &str, name: &str, value: &str) -> Result<(), keyring::Error> {
+    if keyring_suppressed() {
+        return Ok(());
+    }
     let entry = keyring::Entry::new(service, name)?;
     entry.set_password(value)
 }
@@ -78,6 +97,9 @@ pub(crate) fn keyring_set(service: &str, name: &str, value: &str) -> Result<(), 
 
 #[cfg(not(test))]
 pub(crate) fn keyring_delete(service: &str, name: &str) -> Result<(), keyring::Error> {
+    if keyring_suppressed() {
+        return Ok(());
+    }
     let entry = keyring::Entry::new(service, name)?;
     entry.delete_credential()
 }

--- a/core/crates/omegon/src/child_agent.rs
+++ b/core/crates/omegon/src/child_agent.rs
@@ -75,6 +75,7 @@ pub fn spawn_headless_child_agent(
         .args(&args)
         .current_dir(cwd)
         .env("OMEGON_CHILD", "1")
+        .env("OMEGON_NO_KEYRING", "1")
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .kill_on_drop(true);

--- a/core/crates/omegon/src/cleave_smoke.rs
+++ b/core/crates/omegon/src/cleave_smoke.rs
@@ -425,10 +425,15 @@ fn assert_runtime_profile_report(report: &serde_json::Value) -> anyhow::Result<(
 }
 
 fn scenario_env(scenario: &SmokeScenario) -> Vec<(String, String)> {
-    let mut vars = vec![(
-        "OMEGON_CLEAVE_SMOKE_CHILD_MODE".to_string(),
-        scenario.child_mode.to_string(),
-    )];
+    let mut vars = vec![
+        (
+            "OMEGON_CLEAVE_SMOKE_CHILD_MODE".to_string(),
+            scenario.child_mode.to_string(),
+        ),
+        // Suppress keychain access in smoke children — avoids macOS
+        // password prompts and hangs in headless/CI contexts.
+        ("OMEGON_NO_KEYRING".to_string(), "1".to_string()),
+    ];
     if let Some(path) = scenario.write_file {
         vars.push((
             "OMEGON_CLEAVE_SMOKE_WRITE_FILE".to_string(),


### PR DESCRIPTION
OMEGON_NO_KEYRING=1 for all child agents. No more keychain prompts or hangs.