### PR TITLE
feat: Pkl config support + OCI image CI pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ permissions:
   contents: write
   id-token: write
   attestations: write
+  packages: write
 
 env:
   CARGO_TERM_COLOR: always
@@ -392,3 +393,64 @@ jobs:
           gh release edit "${{ env.RELEASE_TAG }}" \
             --repo "${{ github.repository }}" \
             --draft=false
+
+  oci-images:
+    name: OCI images (${{ matrix.image }})
+    needs: release
+    if: ${{ !contains(inputs.tag_name || github.ref_name, '-nightly.') }}
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - image: oci-base
+            description: "Minimal conversation agent"
+          - image: oci-dev
+            description: "Standard coding agent (git, search, HTTP)"
+          - image: oci-python
+            description: "Python project agent"
+          - image: oci-node
+            description: "Node.js project agent"
+          - image: oci-full
+            description: "Full-stack agent (dev + python + node + rust)"
+          - image: oci-ops
+            description: "Infrastructure / ops agent"
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag_name || github.ref }}
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@v17
+
+      - name: Configure Nix cache
+        uses: DeterminateSystems/magic-nix-cache-action@v8
+
+      - name: Authenticate to ghcr.io
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | skopeo login ghcr.io -u "${{ github.actor }}" --password-stdin
+
+      - name: Build and push ${{ matrix.image }}
+        run: |
+          set -euo pipefail
+          VERSION="${RELEASE_TAG#v}"
+          echo "Building and pushing ${{ matrix.image }}:${VERSION}..."
+          nix run .#${{ matrix.image }}.copyToRegistry --accept-flake-config
+          echo "Pushed ${{ matrix.image }}:${VERSION} to ghcr.io"
+
+      - name: Tag as latest (stable only)
+        if: ${{ !contains(env.RELEASE_TAG, '-rc.') }}
+        run: |
+          set -euo pipefail
+          VERSION="${RELEASE_TAG#v}"
+          IMAGE_NAME=$(nix eval --raw .#${{ matrix.image }}.imageName --accept-flake-config 2>/dev/null || echo "")
+          if [ -z "$IMAGE_NAME" ]; then
+            echo "Could not resolve image name, skipping latest tag"
+            exit 0
+          fi
+          skopeo copy \
+            "docker://${IMAGE_NAME}:${VERSION}" \
+            "docker://${IMAGE_NAME}:latest"
+          echo "Tagged ${IMAGE_NAME}:latest"

--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -4311,6 +4311,7 @@ dependencies = [
  "reqwest 0.13.2",
  "rmcp",
  "rpassword",
+ "rpkl",
  "rusqlite",
  "secrecy",
  "serde",
@@ -5813,6 +5814,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rmpv"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a4e1d4b9b938a26d2996af33229f0ca0956c652c1375067f0b45291c1df8417"
+dependencies = [
+ "rmp",
+]
+
+[[package]]
 name = "rpassword"
 version = "7.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5821,6 +5831,18 @@ dependencies = [
  "libc",
  "rtoolbox",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rpkl"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a9bf78448f899ef84e3b12215af07cc91ae9a7f4ab649a118cb9c8d77da6608"
+dependencies = [
+ "dunce",
+ "rmp-serde",
+ "rmpv",
+ "serde",
 ]
 
 [[package]]

--- a/core/crates/omegon/Cargo.toml
+++ b/core/crates/omegon/Cargo.toml
@@ -68,6 +68,7 @@ flate2 = "1.0"
 sigstore = { version = "0.13.0", default-features = false, features = ["cosign", "rustls-tls"] }
 x509-parser = "0.17"
 rpassword = "7"
+rpkl = "0.8"
 
 [dev-dependencies]
 insta = "1.46"

--- a/core/crates/omegon/src/plugins/mod.rs
+++ b/core/crates/omegon/src/plugins/mod.rs
@@ -89,7 +89,11 @@ pub async fn discover_plugins_filtered(
                 continue;
             }
 
-            let manifest_path = plugin_dir.join("plugin.toml");
+            let manifest_path = if plugin_dir.join("plugin.pkl").exists() {
+                plugin_dir.join("plugin.pkl")
+            } else {
+                plugin_dir.join("plugin.toml")
+            };
             if !manifest_path.exists() {
                 continue;
             }
@@ -216,9 +220,14 @@ fn load_legacy_plugin(
     manifest_path: &Path,
     cwd: &Path,
 ) -> anyhow::Result<Option<Box<dyn omegon_traits::Feature>>> {
-    let content = std::fs::read_to_string(manifest_path)?;
-    let manifest: PluginManifest = toml::from_str(&content)
-        .map_err(|e| anyhow::anyhow!("invalid plugin manifest {}: {e}", manifest_path.display()))?;
+    let manifest: PluginManifest = if manifest_path.extension().is_some_and(|e| e == "pkl") {
+        rpkl::from_config(manifest_path)
+            .map_err(|e| anyhow::anyhow!("invalid plugin manifest {}: {e}", manifest_path.display()))?
+    } else {
+        let content = std::fs::read_to_string(manifest_path)?;
+        toml::from_str(&content)
+            .map_err(|e| anyhow::anyhow!("invalid plugin manifest {}: {e}", manifest_path.display()))?
+    };
 
     if !manifest.activation.is_active(cwd) {
         return Ok(None);

--- a/core/crates/omegon/src/triggers.rs
+++ b/core/crates/omegon/src/triggers.rs
@@ -320,25 +320,30 @@ pub fn load_trigger_configs(cwd: &Path) -> Vec<TriggerConfig> {
 
     for entry in entries.flatten() {
         let path = entry.path();
-        if path.extension().is_some_and(|e| e == "toml") {
-            match load_single(&path) {
-                Ok(config) => {
-                    tracing::info!(
-                        name = %config.trigger.name,
-                        schedule = ?config.trigger.schedule,
-                        interval = ?config.trigger.interval,
-                        has_filter = config.filter.is_some(),
-                        "loaded trigger config"
-                    );
-                    configs.push(config);
-                }
-                Err(e) => {
-                    tracing::warn!(
-                        path = %path.display(),
-                        error = %e,
-                        "failed to parse trigger config"
-                    );
-                }
+        let is_config = path
+            .extension()
+            .is_some_and(|e| e == "toml" || e == "pkl");
+        if !is_config {
+            continue;
+        }
+        match load_single(&path) {
+            Ok(config) => {
+                tracing::info!(
+                    name = %config.trigger.name,
+                    schedule = ?config.trigger.schedule,
+                    interval = ?config.trigger.interval,
+                    has_filter = config.filter.is_some(),
+                    format = ?path.extension().unwrap_or_default(),
+                    "loaded trigger config"
+                );
+                configs.push(config);
+            }
+            Err(e) => {
+                tracing::warn!(
+                    path = %path.display(),
+                    error = %e,
+                    "failed to parse trigger config"
+                );
             }
         }
     }
@@ -347,9 +352,19 @@ pub fn load_trigger_configs(cwd: &Path) -> Vec<TriggerConfig> {
 }
 
 fn load_single(path: &Path) -> anyhow::Result<TriggerConfig> {
-    let content = std::fs::read_to_string(path)?;
-    let config: TriggerConfig = toml::from_str(&content)?;
-    Ok(config)
+    let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
+    match ext {
+        "pkl" => {
+            let config: TriggerConfig = rpkl::from_config(path)
+                .map_err(|e| anyhow::anyhow!("pkl: {e}"))?;
+            Ok(config)
+        }
+        _ => {
+            let content = std::fs::read_to_string(path)?;
+            let config: TriggerConfig = toml::from_str(&content)?;
+            Ok(config)
+        }
+    }
 }
 
 // ── Duration parsing ─────────────────────────────────────────────────────
@@ -582,5 +597,69 @@ caller_key = "trigger:daily-review"
 
         let triggers = EventTriggers::from_configs(&[config]);
         assert_eq!(triggers.len(), 0);
+    }
+
+    #[test]
+    fn load_pkl_trigger_config() {
+        let dir = tempfile::tempdir().unwrap();
+        let pkl_path = dir.path().join("review.pkl");
+        std::fs::write(
+            &pkl_path,
+            r#"
+trigger {
+  name = "pkl-review"
+  schedule = "daily"
+}
+
+prompt {
+  template = "Review open PRs via Pkl."
+}
+"#,
+        )
+        .unwrap();
+        let config: TriggerConfig = load_single(&pkl_path).unwrap();
+        assert_eq!(config.trigger.name, "pkl-review");
+        assert_eq!(config.trigger.schedule.as_deref(), Some("daily"));
+        assert!(config.trigger.enabled);
+        assert_eq!(config.prompt.template, "Review open PRs via Pkl.");
+    }
+
+    #[test]
+    fn load_pkl_trigger_with_filter() {
+        let dir = tempfile::tempdir().unwrap();
+        let pkl_path = dir.path().join("github.pkl");
+        std::fs::write(
+            &pkl_path,
+            r#"
+trigger {
+  name = "gh-webhook"
+  interval = "5m"
+}
+
+filter {
+  source = "github"
+  trigger_kind = "prompt"
+}
+
+prompt {
+  template = "Handle GitHub event: {{payload.action}}"
+}
+
+session {
+  caller_key = "trigger:gh-webhook"
+}
+"#,
+        )
+        .unwrap();
+        let config: TriggerConfig = load_single(&pkl_path).unwrap();
+        assert_eq!(config.trigger.name, "gh-webhook");
+        assert_eq!(config.trigger.interval.as_deref(), Some("5m"));
+        let filter = config.filter.unwrap();
+        assert_eq!(filter.source.as_deref(), Some("github"));
+        assert_eq!(filter.trigger_kind.as_deref(), Some("prompt"));
+        assert_eq!(
+            config.session.unwrap().caller_key.as_deref(),
+            Some("trigger:gh-webhook")
+        );
     }
 }

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,98 @@
+{
+  "nodes": {
+    "crane": {
+      "locked": {
+        "lastModified": 1775839657,
+        "narHash": "sha256-SPm9ck7jh3Un9nwPuMGbRU04UroFmOHjLP56T10MOeM=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "7cf72d978629469c4bd4206b95c402514c1f6000",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nix2container": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775487831,
+        "narHash": "sha256-2lguQpLPQaxpQCJjXhmEEAfabwsAhkP29Z7fgLzHARA=",
+        "owner": "nlewo",
+        "repo": "nix2container",
+        "rev": "76be9608a7f4d6c985d28b0e7be903ae2547df3e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nlewo",
+        "repo": "nix2container",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1751274312,
+        "narHash": "sha256-/bVBlRpECLVzjV19t5KMdMFWSwKLtb5RyXdjz3LJT+g=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "50ab793786d9de88ee30ec4e4c24fb4236fc2674",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-24.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "crane": "crane",
+        "flake-utils": "flake-utils",
+        "nix2container": "nix2container",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -29,7 +29,7 @@
         pkgs = import nixpkgs { inherit system; };
         craneLib = crane.mkLib pkgs;
 
-        workspaceVersion = "0.15.23";
+        workspaceVersion = "0.15.24";
 
         commitSha =
           if self ? shortRev then self.shortRev

--- a/pkl/PluginManifest.pkl
+++ b/pkl/PluginManifest.pkl
@@ -1,0 +1,105 @@
+/// Omegon plugin manifest schema.
+///
+/// Plugin manifests define activation rules, context injection,
+/// tool declarations, and event forwarding for Omegon extensions.
+///
+/// Example:
+/// ```
+/// amends "PluginManifest.pkl"
+///
+/// plugin {
+///   name = "scribe"
+///   version = "0.1.0"
+///   description = "Engagement tracking and partnership data"
+/// }
+/// activation {
+///   marker_files { ".scribe" }
+/// }
+/// ```
+module PluginManifest
+
+/// Plugin identity.
+class PluginMeta {
+  name: String(length > 0)
+  version: String(matches(Regex(#"\d+\.\d+\.\d+.*"#)))
+  description: String
+}
+
+/// Activation rules — when the plugin should be loaded.
+class Activation {
+  /// Files whose presence activates the plugin.
+  marker_files: Listing<String>?
+
+  /// Environment variables whose presence activates the plugin.
+  env_vars: Listing<String>?
+
+  /// Always activate regardless of context.
+  always: Boolean = false
+}
+
+/// Context injection from an external source.
+class ContextConfig {
+  /// HTTP endpoint returning context text.
+  endpoint: String?
+
+  /// Local file path for context injection.
+  local_file: String?
+
+  /// Number of turns before refreshing context.
+  ttl_turns: Int(this > 0)?
+
+  /// Injection priority (lower = earlier in prompt).
+  priority: Int?
+}
+
+/// Tool declaration for the plugin.
+class ToolConfig {
+  /// Tool name (must be unique across plugins).
+  name: String(length > 0)
+
+  /// Human-readable description shown to the model.
+  description: String
+
+  /// HTTP endpoint for tool execution. Supports `{param}` templates.
+  endpoint: String
+
+  /// HTTP method.
+  method: ("GET"|"POST"|"PUT"|"DELETE") = "POST"
+
+  /// JSON Schema for tool parameters.
+  parameters: Mapping<String, Any>?
+
+  /// Execution timeout in seconds.
+  timeout_secs: Int(this > 0) = 30
+}
+
+/// Webhook endpoint for a lifecycle event.
+class EventEndpoint {
+  /// HTTP endpoint to POST event data to.
+  url: String
+
+  /// HTTP method.
+  method: ("POST"|"PUT") = "POST"
+}
+
+/// Event forwarding configuration.
+class EventConfig {
+  /// Webhook fired at the end of each agent turn.
+  turn_end: EventEndpoint?
+
+  /// Webhook fired when a session starts.
+  session_start: EventEndpoint?
+
+  /// Webhook fired when the agent process exits.
+  agent_end: EventEndpoint?
+}
+
+plugin: PluginMeta
+
+activation: Activation
+
+context: ContextConfig?
+
+tools: Listing<ToolConfig>?
+
+events: EventConfig?

--- a/pkl/RouteMatrix.pkl
+++ b/pkl/RouteMatrix.pkl
@@ -1,0 +1,34 @@
+/// Omegon model routing matrix schema.
+///
+/// Defines provider routes, model patterns, context ceilings,
+/// tier classifications, and rate-limit breakpoint zones.
+module RouteMatrix
+
+/// A provider route definition.
+class ProviderRoute {
+  /// Provider identifier (e.g., "anthropic", "openai").
+  provider: String(length > 0)
+
+  /// Model ID patterns this route handles (glob-style).
+  patterns: Listing<String(length > 0)>
+
+  /// Maximum context window in tokens.
+  context_ceiling: Int(this > 0)
+
+  /// Capability tier name.
+  tier: String
+}
+
+/// Rate-limit breakpoint zone.
+class BreakpointZone {
+  /// Zone name (e.g., "green", "yellow", "red").
+  name: String
+
+  /// Threshold percentage (0-100) at which this zone activates.
+  threshold: Int(this >= 0 && this <= 100)
+}
+
+/// Top-level route matrix.
+routes: Listing<ProviderRoute>
+
+breakpoint_zones: Listing<BreakpointZone>?

--- a/pkl/TriggerConfig.pkl
+++ b/pkl/TriggerConfig.pkl
@@ -1,0 +1,65 @@
+/// Omegon trigger configuration schema.
+///
+/// Trigger configs live in `.omegon/triggers/` and define scheduled or
+/// event-driven prompt dispatch for daemon mode.
+///
+/// Example:
+/// ```
+/// amends "TriggerConfig.pkl"
+///
+/// trigger {
+///   name = "daily-review"
+///   schedule = "daily"
+/// }
+/// prompt {
+///   template = "Review open PRs and summarize status."
+/// }
+/// ```
+module TriggerConfig
+
+/// Core trigger metadata.
+class TriggerMeta {
+  /// Unique name for this trigger.
+  name: String
+
+  /// Whether this trigger is active. Defaults to true.
+  enabled: Boolean = true
+
+  /// Preset schedule: "hourly", "daily", "weekdays", "weekly".
+  /// Mutually exclusive with `interval`.
+  schedule: ("hourly"|"daily"|"weekdays"|"weekly")?
+
+  /// Interval duration: "30s", "5m", "1h", "6h", "1d".
+  /// Mutually exclusive with `schedule`.
+  interval: String(matches(Regex(#"\d+[smhd]"#)))?
+}
+
+/// Filter for matching inbound DaemonEventEnvelopes.
+class TriggerFilter {
+  /// Match envelope source (e.g., "github", "vox:discord").
+  source: String?
+
+  /// Match envelope trigger_kind (e.g., "prompt", "webhook").
+  trigger_kind: String?
+}
+
+/// Prompt template with optional payload field interpolation.
+class PromptTemplate {
+  /// Template string. Use `{{payload.field}}` for interpolation.
+  template: String(length > 0)
+}
+
+/// Session routing configuration.
+class SessionConfig {
+  /// Caller key for session routing (e.g., "trigger:daily-review").
+  /// Defaults to "trigger:<trigger.name>" if omitted.
+  caller_key: String?
+}
+
+trigger: TriggerMeta
+
+filter: TriggerFilter?
+
+prompt: PromptTemplate
+
+session: SessionConfig?


### PR DESCRIPTION
## Summary

- **Pkl config language** — `rpkl` 0.8 integration. Trigger configs and plugin manifests accept `.pkl` files alongside `.toml`. Three Pkl schemas with typed constraints (pkl/TriggerConfig.pkl, pkl/PluginManifest.pkl, pkl/RouteMatrix.pkl).
- **OCI image CI pipeline** — release.yml now builds and pushes all 6 image variants (base, dev, python, node, full, ops) to ghcr.io/styrene-lab/ via nix2container. Stable releases tagged as `:latest`.
- **Flake version sync** — workspaceVersion updated to 0.15.24, flake.lock generated.

## Test plan

- [x] 1708 tests pass (includes 2 new Pkl integration tests)
- [x] `cargo check -p omegon` clean
- [x] Pkl schema validation tested (valid configs evaluate, invalid rejected with typed errors)
- [ ] OCI push job — will validate on next tagged release