### PR TITLE
feat(git): jj colocated improvements + worktree hardening

### DIFF
--- a/core/crates/omegon-git/Cargo.toml
+++ b/core/crates/omegon-git/Cargo.toml
@@ -10,10 +10,11 @@ description = "Git operations for Omegon — RepoModel, commit, merge, worktree,
 default = []
 ## Enable jj-lib for library-level queries (adds ~500 deps).
 ## Without this, the jj module uses CLI only.
-jj-lib = ["dep:jj-lib"]
+jj-lib = ["dep:jj-lib", "dep:futures-util"]
 
 [dependencies]
 jj-lib = { version = "0.39", optional = true }
+futures-util = { version = "0.3", optional = true }
 git2 = { version = "0.20", features = ["vendored-libgit2", "vendored-openssl"] }
 anyhow = { workspace = true }
 tracing = { workspace = true }

--- a/core/crates/omegon-git/src/jj.rs
+++ b/core/crates/omegon-git/src/jj.rs
@@ -65,6 +65,41 @@ mod jj_lib_queries {
         Ok((workspace, repo))
     }
 
+    /// Get changed files in the working copy via jj-lib.
+    ///
+    /// Compares the working copy commit's tree against its parent's tree
+    /// to find modified/added/deleted paths — no subprocess needed.
+    pub async fn diff_summary_lib(repo_path: &Path) -> Result<Vec<String>> {
+        if !is_jj_repo(repo_path) {
+            return Ok(vec![]);
+        }
+
+        let (workspace, repo) = load_repo(repo_path).await?;
+        let wc_id = match repo.view().get_wc_commit_id(workspace.workspace_name()) {
+            Some(id) => id.clone(),
+            None => return Ok(vec![]),
+        };
+
+        let wc_commit = repo.store().get_commit(&wc_id)?;
+        let parents = wc_commit.parents().await?;
+        let parent = match parents.first() {
+            Some(p) => p,
+            None => return Ok(vec![]),
+        };
+
+        let parent_tree = parent.tree();
+        let wc_tree = wc_commit.tree();
+        let mut paths = Vec::new();
+
+        // Diff parent tree → working copy tree (async stream)
+        let mut diff = parent_tree.diff_stream(&wc_tree, &jj_lib::matchers::EverythingMatcher);
+        while let Some(entry) = futures_util::StreamExt::next(&mut diff).await {
+            paths.push(entry.path.as_internal_file_string().to_string());
+        }
+
+        Ok(paths)
+    }
+
     /// Get the change ID of the current working copy via jj-lib.
     pub async fn working_copy_change_id(repo_path: &Path) -> Result<Option<String>> {
         if !is_jj_repo(repo_path) {
@@ -117,7 +152,10 @@ pub fn bookmark_set(repo_path: &Path, name: &str, revision: &str) -> Result<()> 
     run_jj(repo_path, &["bookmark", "set", name, "-r", revision])
 }
 
-/// Get changed files in the working copy.
+/// Get changed files in the working copy (sync, CLI-based).
+///
+/// For async callers with jj-lib feature enabled, prefer `diff_summary_lib()`
+/// which queries the tree diff in-process without subprocess overhead.
 pub fn diff_summary(repo_path: &Path) -> Result<Vec<String>> {
     if !is_jj_repo(repo_path) {
         return Ok(vec![]);
@@ -173,6 +211,10 @@ pub fn sync_to_git_main(repo_path: &Path) -> Result<()> {
         })
         .unwrap_or_default();
 
+    // Git CLI operations for jj sync coordination. These intentionally use
+    // the git CLI (not libgit2) because they must match the ref layout that
+    // `jj git export` produces. Coupling to libgit2 here risks diverging
+    // from jj's expectations as the project evolves.
     let main_sha = std::process::Command::new("git")
         .args(["rev-parse", "refs/heads/main"])
         .current_dir(repo_path)
@@ -279,7 +321,12 @@ fn run_jj(repo_path: &Path, args: &[&str]) -> Result<()> {
         .args(args)
         .current_dir(repo_path)
         .output()
-        .with_context(|| format!("jj {} failed to execute", args.join(" ")))?;
+        .with_context(|| {
+            format!(
+                "jj {} failed to execute — is jj installed? (https://martinvonz.github.io/jj/)",
+                args.join(" ")
+            )
+        })?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);

--- a/core/crates/omegon-git/src/worktree.rs
+++ b/core/crates/omegon-git/src/worktree.rs
@@ -133,37 +133,34 @@ pub fn remove_smart(repo_path: &Path, name: &str, workspace_path: &Path) -> Resu
 }
 
 // ── git worktree operations (fallback) ──────────────────────────────────
+//
+// All operations use libgit2 natively — no git CLI subprocess.
 
 /// Create a git worktree with a new branch from HEAD.
 pub fn create(repo_path: &Path, worktree_path: &Path, branch: &str) -> Result<WorktreeInfo> {
-    let _ = std::process::Command::new("git")
-        .args(["branch", "-D", branch])
-        .current_dir(repo_path)
-        .output();
+    let repo = Repository::open(repo_path)?;
 
+    // Delete stale branch if it exists (equivalent to `git branch -D branch`)
+    if let Ok(mut branch_ref) = repo.find_branch(branch, git2::BranchType::Local) {
+        let _ = branch_ref.delete();
+    }
+
+    // Clean up stale worktree directory
     if worktree_path.exists() {
         let _ = std::fs::remove_dir_all(worktree_path);
     }
 
-    let output = std::process::Command::new("git")
-        .args([
-            "worktree",
-            "add",
-            "-b",
-            branch,
-            &worktree_path.to_string_lossy(),
-            "HEAD",
-        ])
-        .current_dir(repo_path)
-        .output()
-        .context("git worktree add failed")?;
+    // Create the worktree with a new branch from HEAD.
+    // git2's worktree() creates both the branch and the worktree atomically.
+    let head = repo.head().context("failed to read HEAD")?;
+    let head_ref = head
+        .resolve()
+        .context("failed to resolve HEAD")?;
+    let mut opts = git2::WorktreeAddOptions::new();
+    opts.reference(Some(&head_ref));
 
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        if !stderr.contains("already exists") {
-            anyhow::bail!("git worktree add failed: {}", stderr.trim());
-        }
-    }
+    repo.worktree(branch, worktree_path, Some(&opts))
+        .with_context(|| format!("failed to create worktree at {}", worktree_path.display()))?;
 
     Ok(WorktreeInfo {
         path: worktree_path.to_path_buf(),
@@ -174,20 +171,26 @@ pub fn create(repo_path: &Path, worktree_path: &Path, branch: &str) -> Result<Wo
 
 /// Remove a git worktree.
 pub fn remove(repo_path: &Path, worktree_path: &Path) -> Result<()> {
-    let output = std::process::Command::new("git")
-        .args([
-            "worktree",
-            "remove",
-            "--force",
-            &worktree_path.to_string_lossy(),
-        ])
-        .current_dir(repo_path)
-        .output()
-        .context("git worktree remove failed")?;
+    let repo = Repository::open(repo_path)?;
 
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        tracing::warn!("worktree remove: {}", stderr.trim());
+    // Find the worktree by matching its path against registered worktrees
+    let worktree_names = repo.worktrees().context("failed to list worktrees")?;
+    for name in worktree_names.iter().flatten() {
+        if let Ok(wt) = repo.find_worktree(name) {
+            if wt.path() == worktree_path || worktree_path.starts_with(wt.path()) {
+                // Prune the worktree reference (with force flags)
+                let mut opts = git2::WorktreePruneOptions::new();
+                opts.valid(true);
+                opts.working_tree(true);
+                let _ = wt.prune(Some(&mut opts));
+                break;
+            }
+        }
+    }
+
+    // Remove the working directory
+    if worktree_path.exists() {
+        let _ = std::fs::remove_dir_all(worktree_path);
     }
     Ok(())
 }
@@ -213,10 +216,19 @@ pub fn delete_branch(repo_path: &Path, branch: &str) -> Result<()> {
 
 /// Prune stale git worktree references.
 pub fn prune(repo_path: &Path) -> Result<()> {
-    let _ = std::process::Command::new("git")
-        .args(["worktree", "prune"])
-        .current_dir(repo_path)
-        .output();
+    let repo = Repository::open(repo_path)?;
+    let Ok(worktree_names) = repo.worktrees() else {
+        return Ok(());
+    };
+    for name in worktree_names.iter().flatten() {
+        if let Ok(wt) = repo.find_worktree(name) {
+            let mut opts = git2::WorktreePruneOptions::new();
+            // Only prune if the worktree is no longer valid (directory gone, etc.)
+            if wt.is_prunable(Some(&mut opts)).unwrap_or(false) {
+                let _ = wt.prune(Some(&mut opts));
+            }
+        }
+    }
     Ok(())
 }
 


### PR DESCRIPTION
## Summary
- Improve jj-git colocated repository handling
- Harden worktree lifecycle management with better error recovery

## Test plan
- [ ] `cargo test -p omegon-git` passes
- [ ] Worktree creation/cleanup works in both git and jj repos

🤖 Generated with [Claude Code](https://claude.com/claude-code)