### PR TITLE
fix(auth): prevent stale OAuth env shadowing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [Semantic V
 
 ## [Unreleased]
 
+### Fixed
+
+- Shorten pre-content provider/SSE idle detection from five minutes to 90 seconds, with environment overrides, so stale provider sessions surface as failures instead of apparent hangs.
+- Read Codex CLI JWT `exp` claims and refresh OpenAI OAuth tokens five minutes early so adopted CLI credentials do not wait for stale `last_refresh` timestamps before re-authentication.
+- Stop promoting persisted OAuth credentials into the parent process environment, so one Omegon session no longer shadows shared auth.json refreshes with a stale per-process token.
+- Split well-known secrets into static env credentials and refreshable OAuth session tokens, and only auto-hydrate static credentials into the parent process environment.
+
 ## [0.24.2] - 2026-05-25
 
 ### Added

--- a/core/crates/omegon-secrets/src/lib.rs
+++ b/core/crates/omegon-secrets/src/lib.rs
@@ -25,8 +25,8 @@ pub use guards::{GuardDecision, PathGuard};
 pub use recipes::{Recipe, RecipeStore};
 pub use redact::Redactor;
 pub use resolve::{
-    delete_from_keyring, execute_recipe_async, resolve_secret_async, resolve_vault_secret,
-    store_in_keyring,
+    delete_from_keyring, execute_recipe_async, is_refreshable_oauth_secret_env,
+    resolve_secret_async, resolve_vault_secret, store_in_keyring,
 };
 pub use store::{KeyBackend, SecretStore};
 pub use vault::{AuthConfig, VaultClient, VaultConfig};
@@ -81,6 +81,22 @@ pub struct SecretsManager {
     audit: AuditLog,
     /// Vault client (optional, only if vault.json exists or VAULT_ADDR set)
     vault_client: Arc<Mutex<Option<VaultClient>>>,
+}
+
+fn hydrate_static_process_env(
+    session_cache: &Arc<RwLock<HashMap<String, SecretString>>>,
+    redaction_set: &Arc<RwLock<HashMap<String, SecretString>>>,
+) {
+    let session = session_cache.read().unwrap();
+    let redaction = redaction_set.read().unwrap();
+    for env_name in resolve::STATIC_SECRET_ENVS {
+        if let Some(value) = session.get(*env_name).or_else(|| redaction.get(*env_name)) {
+            // SAFETY: Omegon mutates process env only on the main runtime thread
+            // during setup or in direct response to operator secret changes.
+            // We do not concurrently iterate the environment while doing this.
+            unsafe { std::env::set_var(env_name, value.expose_secret()) };
+        }
+    }
 }
 
 impl SecretsManager {
@@ -587,16 +603,7 @@ impl SecretsManager {
     }
 
     pub fn hydrate_process_env(&self) {
-        let session = self.session_cache.read().unwrap();
-        let redaction = self.redaction_set.read().unwrap();
-        for env_name in resolve::WELL_KNOWN_SECRET_ENVS {
-            if let Some(value) = session.get(*env_name).or_else(|| redaction.get(*env_name)) {
-                // SAFETY: Omegon mutates process env only on the main runtime thread
-                // during setup or in direct response to operator secret changes.
-                // We do not concurrently iterate the environment while doing this.
-                unsafe { std::env::set_var(env_name, value.expose_secret()) };
-            }
-        }
+        hydrate_static_process_env(&self.session_cache, &self.redaction_set);
     }
 
     /// Set a secret recipe (e.g. "env:MY_VAR", "cmd:pass show x", "vault:path").
@@ -660,7 +667,9 @@ impl SecretsManager {
         let _ = delete_from_keyring(name); // best-effort
         self.recipes.write().unwrap().remove(name).map(|_| ())?;
         self.refresh_redaction_set();
-        if resolve::WELL_KNOWN_SECRET_ENVS.contains(&name) {
+        if resolve::STATIC_SECRET_ENVS.contains(&name)
+            || resolve::REFRESHABLE_OAUTH_SECRET_ENVS.contains(&name)
+        {
             // SAFETY: same reasoning as hydrate_process_env().
             unsafe { std::env::remove_var(name) };
         }
@@ -727,6 +736,9 @@ impl SecretsManager {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::{LazyLock, Mutex};
+
+    static ENV_TEST_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
 
     #[test]
     fn runtime_projected_secret_is_redacted_without_recipe() {
@@ -769,6 +781,7 @@ mod tests {
 
     #[test]
     fn hydrate_process_env_populates_well_known_recipe_secret() {
+        let _guard = ENV_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let dir = tempfile::tempdir().unwrap();
         // SAFETY: test process controls these env vars and does not iterate env concurrently.
         unsafe {
@@ -791,7 +804,42 @@ mod tests {
     }
 
     #[test]
+    fn hydrate_process_env_does_not_populate_refreshable_oauth_secret() {
+        let _guard = ENV_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let dir = tempfile::tempdir().unwrap();
+        // SAFETY: test process controls these env vars and does not iterate env concurrently.
+        unsafe {
+            std::env::remove_var("CHATGPT_OAUTH_TOKEN");
+            std::env::set_var("OMEGON_TEST_CHATGPT_TOKEN", "oauth-test-token");
+        }
+        let mgr = SecretsManager::new(dir.path()).unwrap();
+        mgr.set_recipe("CHATGPT_OAUTH_TOKEN", "env:OMEGON_TEST_CHATGPT_TOKEN")
+            .unwrap();
+        mgr.preflight_session_cache(["CHATGPT_OAUTH_TOKEN"]);
+        assert!(
+            std::env::var("CHATGPT_OAUTH_TOKEN").is_err(),
+            "refreshable OAuth tokens must not be auto-hydrated into parent env"
+        );
+        assert!(
+            mgr.session_env()
+                .iter()
+                .any(|(name, value)| name == "CHATGPT_OAUTH_TOKEN" && value == "oauth-test-token"),
+            "refreshable OAuth token should remain available for child/delegate inheritance"
+        );
+        assert_eq!(
+            mgr.redact("Authorization: Bearer oauth-test-token"),
+            "Authorization: Bearer [REDACTED:CHATGPT_OAUTH_TOKEN]"
+        );
+        // SAFETY: cleanup for isolated test env vars.
+        unsafe {
+            std::env::remove_var("OMEGON_TEST_CHATGPT_TOKEN");
+            std::env::remove_var("CHATGPT_OAUTH_TOKEN");
+        }
+    }
+
+    #[test]
     fn delete_recipe_removes_well_known_env_var() {
+        let _guard = ENV_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let dir = tempfile::tempdir().unwrap();
         let mgr = SecretsManager::new(dir.path()).unwrap();
         // SAFETY: test process controls this env var and does not iterate env concurrently.
@@ -802,6 +850,7 @@ mod tests {
 
     #[test]
     fn evict_secrets_removes_cached_value_and_env_var() {
+        let _guard = ENV_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let dir = tempfile::tempdir().unwrap();
         // SAFETY: test process controls these env vars and does not iterate env concurrently.
         unsafe {

--- a/core/crates/omegon-secrets/src/resolve.rs
+++ b/core/crates/omegon-secrets/src/resolve.rs
@@ -18,7 +18,44 @@ use std::sync::{LazyLock, Mutex};
 static TEST_KEYRING: LazyLock<Mutex<HashMap<(String, String), String>>> =
     LazyLock::new(|| Mutex::new(HashMap::new()));
 
-/// Well-known environment variables that commonly contain secrets.
+/// Static API keys and tool credentials that are safe to hydrate into the
+/// process environment. These are bearer/static credentials consumed by legacy
+/// env-based integrations.
+pub const STATIC_SECRET_ENVS: &[&str] = &[
+    "ANTHROPIC_API_KEY",
+    "OPENAI_API_KEY",
+    "OPENROUTER_API_KEY",
+    "BRAVE_API_KEY",
+    "TAVILY_API_KEY",
+    "SERPER_API_KEY",
+    "GITHUB_TOKEN",
+    "GITLAB_TOKEN",
+    "GH_TOKEN",
+    "AWS_ACCESS_KEY_ID",
+    "AWS_SECRET_ACCESS_KEY",
+    "AWS_SESSION_TOKEN",
+    "NPM_TOKEN",
+    "DOCKER_PASSWORD",
+    "IGOR_API_KEY",
+];
+
+/// Refreshable OAuth session tokens. These should be redacted and may be
+/// passed to child processes when explicitly configured, but they must not be
+/// auto-hydrated into the parent process environment: env values have resolver
+/// priority and can shadow shared auth.json refreshes with stale per-process
+/// tokens.
+pub const REFRESHABLE_OAUTH_SECRET_ENVS: &[&str] = &[
+    "ANTHROPIC_OAUTH_TOKEN",
+    "CHATGPT_OAUTH_TOKEN",
+    "ANTIGRAVITY_OAUTH_TOKEN",
+];
+
+pub fn is_refreshable_oauth_secret_env(name: &str) -> bool {
+    REFRESHABLE_OAUTH_SECRET_ENVS.contains(&name)
+}
+
+/// Well-known environment variables that commonly contain secrets and should be
+/// included in redaction/discovery.
 pub const WELL_KNOWN_SECRET_ENVS: &[&str] = &[
     "ANTHROPIC_API_KEY",
     "ANTHROPIC_OAUTH_TOKEN",

--- a/core/crates/omegon/src/auth.rs
+++ b/core/crates/omegon/src/auth.rs
@@ -556,16 +556,13 @@ pub fn read_external_credentials(provider: &str) -> Option<OAuthCredentials> {
                 .get("refresh_token")
                 .and_then(|v| v.as_str())
                 .unwrap_or("");
-            // Codex CLI stores last_refresh as unix seconds; tokens typically last 1 hour
-            let last_refresh = data
-                .get("last_refresh")
-                .and_then(codex_cli_last_refresh_secs)
+            let expires = codex_access_token_expiry_ms(access)
+                .or_else(|| {
+                    data.get("last_refresh")
+                        .and_then(codex_cli_last_refresh_secs)
+                        .map(|last_refresh| (last_refresh + 3600) * 1000)
+                })
                 .unwrap_or(0);
-            let expires = if last_refresh > 0 {
-                (last_refresh + 3600) * 1000 // 1 hour from last refresh, in ms
-            } else {
-                0
-            };
             Some(OAuthCredentials {
                 cred_type: "oauth".into(),
                 access: access.into(),
@@ -646,6 +643,11 @@ pub fn read_external_credentials(provider: &str) -> Option<OAuthCredentials> {
         }
         _ => None,
     }
+}
+
+fn codex_access_token_expiry_ms(access: &str) -> Option<u64> {
+    let exp = extract_jwt_claim(access, "", "exp")?;
+    exp.parse::<u64>().ok().map(|seconds| seconds * 1000)
 }
 
 fn codex_cli_last_refresh_secs(value: &Value) -> Option<u64> {
@@ -1006,7 +1008,7 @@ pub async fn refresh_token(provider: &str, refresh: &str) -> anyhow::Result<OAut
         cred_type: "oauth".into(),
         access: data["access_token"].as_str().unwrap_or("").into(),
         refresh: data["refresh_token"].as_str().unwrap_or(refresh).into(),
-        expires: now_ms + expires_in * 1000 - 5 * 60 * 1000, // 5 min safety margin
+        expires: now_ms + expires_in.saturating_sub(300) * 1000, // 5 min safety margin
     })
 }
 
@@ -1234,7 +1236,7 @@ pub async fn login_anthropic_with_callbacks(
         cred_type: "oauth".into(),
         access: data["access_token"].as_str().unwrap_or("").into(),
         refresh: data["refresh_token"].as_str().unwrap_or("").into(),
-        expires: now_ms + expires_in * 1000 - 5 * 60 * 1000,
+        expires: now_ms + expires_in.saturating_sub(300) * 1000,
     };
 
     // Save to auth.json
@@ -1254,7 +1256,7 @@ pub async fn login_anthropic_with_callbacks(
     // and gets used instead of the freshly-issued one.
     // SAFETY: single-threaded at login time — no other threads reading env.
     unsafe {
-        std::env::set_var("ANTHROPIC_OAUTH_TOKEN", &creds.access);
+        std::env::remove_var("ANTHROPIC_OAUTH_TOKEN");
     }
 
     progress("✓ Authentication successful. Credentials saved.");
@@ -1420,8 +1422,11 @@ pub async fn login_openai_with_callbacks(
         }
     }
     // Update env var so resolve_with_refresh uses the new token immediately.
+    // Clear the session-cached token instead of setting it: env credentials have
+    // resolver priority over auth.json, so keeping an OAuth token in process env
+    // can shadow later shared-file refreshes performed by another Omegon session.
     unsafe {
-        std::env::set_var("CHATGPT_OAUTH_TOKEN", &creds.access);
+        std::env::remove_var("CHATGPT_OAUTH_TOKEN");
     }
 
     progress("✓ OpenAI authentication successful. Credentials saved.");
@@ -1457,7 +1462,7 @@ pub async fn refresh_openai_token(refresh: &str) -> anyhow::Result<OAuthCredenti
         cred_type: "oauth".into(),
         access: data["access_token"].as_str().unwrap_or("").into(),
         refresh: data["refresh_token"].as_str().unwrap_or(refresh).into(),
-        expires: now_ms + expires_in * 1000,
+        expires: now_ms + expires_in.saturating_sub(300) * 1000,
     })
 }
 
@@ -1585,8 +1590,11 @@ pub async fn login_antigravity_with_callbacks(
     };
 
     write_credentials("google-antigravity", &creds)?;
+    // Drop any session-cached Antigravity token so subsequent resolution uses
+    // the shared auth.json entry that was just written and can be refreshed by
+    // any Omegon process on this machine.
     unsafe {
-        std::env::set_var("ANTIGRAVITY_OAUTH_TOKEN", &creds.access);
+        std::env::remove_var("ANTIGRAVITY_OAUTH_TOKEN");
     }
     progress("✓ Google Antigravity authentication successful. Credentials saved.");
 

--- a/core/crates/omegon/src/loop.rs
+++ b/core/crates/omegon/src/loop.rs
@@ -1847,11 +1847,17 @@ async fn consume_llm_stream(
     const REPETITION_ABORT_THRESHOLD: usize = 30; // 30 of last 40 chunks identical → abort
 
     // Two-phase idle timeout:
-    // - Before first content: 300s (OpenAI documents stream_idle_timeout_ms=300000
-    //   as their default — reasoning models can be silent for minutes)
+    // - Before first content: 90s by default. Stale provider sessions can
+    //   otherwise look like silent hangs for too long; override with
+    //   OMEGON_LLM_INITIAL_IDLE_TIMEOUT_SECS for unusually slow reasoning.
     // - After first content: 90s (Claude Code's CLAUDE_STREAM_IDLE_TIMEOUT_MS
     //   default is 90s; nobody in the industry uses less than 60s)
-    let initial_idle_timeout = std::time::Duration::from_secs(300);
+    let initial_idle_timeout = std::env::var("OMEGON_LLM_INITIAL_IDLE_TIMEOUT_SECS")
+        .ok()
+        .and_then(|value| value.parse::<u64>().ok())
+        .filter(|seconds| *seconds >= 30)
+        .map(std::time::Duration::from_secs)
+        .unwrap_or_else(|| std::time::Duration::from_secs(90));
     let content_idle_timeout = std::time::Duration::from_secs(90);
     let received_content = std::sync::atomic::AtomicBool::new(false);
     let idle_timeout = || {

--- a/core/crates/omegon/src/providers.rs
+++ b/core/crates/omegon/src/providers.rs
@@ -832,19 +832,30 @@ impl ToolCallAccum {
 /// Process an SSE byte stream line by line, calling `on_data` for each `data: ` payload.
 /// SSE idle timeout — if no chunk arrives within this window, assume the
 /// connection is stalled and bail so the retry loop can re-attempt.
-/// OpenAI's Codex CLI defaults to 300s (stream_idle_timeout_ms = 300000)
-/// because reasoning models can be silent for minutes before first token.
-const SSE_IDLE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(300);
+///
+/// Keep the default shorter than Codex CLI's 300s. A stale OAuth session can
+/// otherwise look like a silent provider hang for five minutes before the
+/// operator sees any actionable failure. The env override preserves an escape
+/// hatch for unusually slow reasoning streams.
+fn sse_idle_timeout() -> std::time::Duration {
+    std::env::var("OMEGON_SSE_IDLE_TIMEOUT_SECS")
+        .ok()
+        .and_then(|value| value.parse::<u64>().ok())
+        .filter(|seconds| *seconds >= 30)
+        .map(std::time::Duration::from_secs)
+        .unwrap_or_else(|| std::time::Duration::from_secs(90))
+}
 
 async fn process_sse<F>(response: reqwest::Response, mut on_data: F) -> anyhow::Result<()>
 where
     F: FnMut(&str) -> bool, // returns false to stop
 {
+    let idle_timeout = sse_idle_timeout();
     let mut buffer = String::new();
     let mut stream = response.bytes_stream();
 
     loop {
-        match tokio::time::timeout(SSE_IDLE_TIMEOUT, stream.next()).await {
+        match tokio::time::timeout(idle_timeout, stream.next()).await {
             Ok(Some(chunk)) => {
                 let chunk = chunk?;
                 buffer.push_str(&String::from_utf8_lossy(&chunk));
@@ -864,11 +875,11 @@ where
             Err(_) => {
                 tracing::warn!(
                     "SSE stream idle for {}s — treating as stalled",
-                    SSE_IDLE_TIMEOUT.as_secs()
+                    idle_timeout.as_secs()
                 );
                 anyhow::bail!(
                     "SSE stream idle timeout ({}s with no data)",
-                    SSE_IDLE_TIMEOUT.as_secs()
+                    idle_timeout.as_secs()
                 );
             }
         }

--- a/core/crates/omegon/src/setup.rs
+++ b/core/crates/omegon/src/setup.rs
@@ -229,11 +229,22 @@ impl AgentSetup {
         // Replaces the sync preflight_session_cache() which silently skips vault recipes.
         secrets.preflight_session_cache_async(preflight).await;
         let mut session_secret_env = secrets.session_env();
+        let pre_hydrated_env_len = session_secret_env.len();
         hydrate_provider_auth_env_from_auth_json(&mut session_secret_env, &secrets);
-        for (name, value) in &session_secret_env {
+        for (idx, (name, value)) in session_secret_env.iter().enumerate() {
+            if idx >= pre_hydrated_env_len
+                || omegon_secrets::is_refreshable_oauth_secret_env(name.as_str())
+            {
+                // Provider auth copied from auth.json and refreshable OAuth
+                // session tokens are only for child/delegate inheritance. Do
+                // not promote them into this process environment: env
+                // credentials have resolver priority over auth.json and would
+                // freeze a shared disk credential into a per-process stale token.
+                continue;
+            }
             // SAFETY: setup runs before provider detection for this process; exporting
-            // startup-resolved secrets here makes the active provider path see the
-            // same credential surface as child/headless runs.
+            // startup-resolved non-provider secrets here makes the active runtime see
+            // the same credential surface as child/headless runs.
             unsafe { std::env::set_var(name, value) };
         }
 


### PR DESCRIPTION
## Summary
- Split secret env handling into static credentials vs refreshable OAuth session tokens.
- Stop auto-hydrating refreshable OAuth tokens into parent process env so shared auth.json refreshes are not shadowed by stale per-process values.
- Preserve OAuth token redaction and child/delegate inheritance.
- Prefer Codex JWT exp claims and refresh OpenAI OAuth tokens early.
- Reduce provider idle detection from 300s to 90s with env overrides.

## Validation
- cargo test -p omegon-secrets
- cargo test -p omegon providers:: -- --nocapture
- validate standard on changed source files