### PR TITLE
fix(voice): pump idle TUI transcriptions

### DIFF
--- a/core/crates/omegon/src/extensions/mod.rs
+++ b/core/crates/omegon/src/extensions/mod.rs
@@ -270,6 +270,15 @@ impl ExtensionFeature {
 
     /// Send a JSON-RPC request and receive the response.
     async fn rpc_call(&self, method: &str, params: Value) -> Result<Value> {
+        self.rpc_call_with_idle_timeout(method, params, None).await
+    }
+
+    async fn rpc_call_with_idle_timeout(
+        &self,
+        method: &str,
+        params: Value,
+        idle_timeout: Option<std::time::Duration>,
+    ) -> Result<Value> {
         let mut guard = self.handles.lock().await;
         let handles = guard
             .as_mut()
@@ -291,7 +300,15 @@ impl ExtensionFeature {
         let mut line = String::new();
         loop {
             line.clear();
-            let n = handles.reader.read_line(&mut line).await?;
+            let read = handles.reader.read_line(&mut line);
+            let n = if let Some(timeout) = idle_timeout {
+                match tokio::time::timeout(timeout, read).await {
+                    Ok(result) => result?,
+                    Err(_) => return Ok(json!({"timeout": true})),
+                }
+            } else {
+                read.await?
+            };
             if n == 0 {
                 return Err(anyhow!("extension closed connection"));
             }
@@ -445,6 +462,7 @@ impl ExtensionFeature {
             handles: self.handles.clone(),
             request_id: self.request_id.clone(),
             name: self.runtime.name.clone(),
+            notification_sink: self.runtime.notification_sink.clone(),
         }
     }
 }
@@ -457,9 +475,40 @@ pub struct ExtensionPollingHandle {
     handles: Arc<Mutex<Option<ProcessHandles>>>,
     request_id: Arc<AtomicU64>,
     name: String,
+    notification_sink: Option<ExtensionNotificationSink>,
 }
 
 impl ExtensionPollingHandle {
+    pub async fn pump_notifications_for(&self, idle_timeout: std::time::Duration) -> Result<()> {
+        let mut guard = self.handles.lock().await;
+        let handles = guard
+            .as_mut()
+            .ok_or_else(|| anyhow!("extension process not running"))?;
+        let read = async {
+            let mut line = String::new();
+            let n = handles.reader.read_line(&mut line).await?;
+            anyhow::Ok::<(usize, String)>((n, line))
+        };
+        match tokio::time::timeout(idle_timeout, read).await {
+            Ok(Ok((0, _))) => Err(anyhow!("extension closed connection")),
+            Ok(Ok((_n, line))) => {
+                let trimmed = line.trim();
+                if trimmed.is_empty() {
+                    return Ok(());
+                }
+                if let Ok(omegon_extension::RpcIncoming::Notification(notification)) =
+                    omegon_extension::RpcIncoming::parse(trimmed)
+                    && let Some(sink) = &self.notification_sink
+                {
+                    sink.send(notification);
+                }
+                Ok(())
+            }
+            Ok(Err(err)) => Err(err),
+            Err(_) => Ok(()),
+        }
+    }
+
     /// Name of the extension this handle is connected to.
     pub fn extension_name(&self) -> &str {
         &self.name
@@ -672,6 +721,8 @@ pub struct SpawnedExtension {
     pub widget_rx: broadcast::Receiver<WidgetEvent>,
     /// Polling handle for extensions that provide `vox_route` (event bridge).
     pub vox_polling_handle: Option<ExtensionPollingHandle>,
+    /// Idle notification pump for voice-capable extensions.
+    pub voice_polling_handle: Option<ExtensionPollingHandle>,
     /// Push notification receiver for voice-capable extensions.
     pub voice_notification_rx: Option<mpsc::UnboundedReceiver<ExtensionNotification>>,
 }
@@ -1063,11 +1114,18 @@ async fn spawn_native(
         tab_widgets.push(tab_widget);
     }
 
+    let voice_polling_handle = if manifest.capabilities.voice {
+        Some(feature.polling_handle())
+    } else {
+        None
+    };
+
     Ok(SpawnedExtension {
         feature: Box::new(feature),
         widgets: tab_widgets,
         widget_rx,
         vox_polling_handle,
+        voice_polling_handle,
         voice_notification_rx: notification_pair.1,
     })
 }
@@ -1147,11 +1205,18 @@ async fn spawn_container(
         tab_widgets.push(tab_widget);
     }
 
+    let voice_polling_handle = if manifest.capabilities.voice {
+        Some(feature.polling_handle())
+    } else {
+        None
+    };
+
     Ok(SpawnedExtension {
         feature: Box::new(feature),
         widgets: tab_widgets,
         widget_rx,
         vox_polling_handle,
+        voice_polling_handle,
         voice_notification_rx: notification_pair.1,
     })
 }

--- a/core/crates/omegon/src/main.rs
+++ b/core/crates/omegon/src/main.rs
@@ -3827,6 +3827,7 @@ async fn run_interactive_command(cli: &Cli) -> anyhow::Result<()> {
     let extension_widgets = std::mem::take(&mut agent.extension_widgets);
     let widget_receivers = std::mem::take(&mut agent.widget_receivers);
     let voice_notification_receivers = std::mem::take(&mut agent.voice_notification_receivers);
+    let voice_polling_handles = std::mem::take(&mut agent.voice_polling_handles);
     // Show splash only on first launch; skip on subsequent runs unless
     // the operator explicitly replays via /splash.
     let is_first_run = first_run::should_run(&cli.cwd);
@@ -3844,6 +3845,7 @@ async fn run_interactive_command(cli: &Cli) -> anyhow::Result<()> {
         extension_widgets,
         widget_receivers,
         voice_notification_receivers,
+        voice_polling_handles,
     };
     let tui_cancel = shared_cancel.clone();
     let tui_settings = shared_settings.clone();
@@ -7857,6 +7859,7 @@ mod tests {
             delegate_event_slot: std::sync::Arc::new(std::sync::Mutex::new(None)),
             vox_polling_handles: vec![],
             voice_notification_receivers: vec![],
+            voice_polling_handles: vec![],
         }
     }
 

--- a/core/crates/omegon/src/setup.rs
+++ b/core/crates/omegon/src/setup.rs
@@ -89,6 +89,8 @@ pub struct AgentSetup {
     /// Notification receivers for voice-capable extensions.
     pub voice_notification_receivers:
         Vec<tokio::sync::mpsc::UnboundedReceiver<crate::extensions::ExtensionNotification>>,
+    /// Idle notification pumps for voice-capable extensions.
+    pub voice_polling_handles: Vec<crate::extensions::ExtensionPollingHandle>,
 }
 
 /// Pre-computed state gathered during setup for TUI initial display.
@@ -745,15 +747,16 @@ impl AgentSetup {
             widget_receivers,
             vox_polling_handles,
             voice_notification_receivers,
+            voice_polling_handles,
         ) = match discover_and_register_extensions(&cwd, &mut bus, std::sync::Arc::clone(&secrets))
             .await
         {
-            Ok((widgets, receivers, handles, voice_receivers)) => {
-                (widgets, receivers, handles, voice_receivers)
+            Ok((widgets, receivers, handles, voice_receivers, voice_handles)) => {
+                (widgets, receivers, handles, voice_receivers, voice_handles)
             }
             Err(e) => {
                 tracing::warn!("extension discovery failed: {}", e);
-                (vec![], vec![], vec![], vec![])
+                (vec![], vec![], vec![], vec![], vec![])
             }
         };
 
@@ -1164,6 +1167,7 @@ impl AgentSetup {
             delegate_event_slot,
             vox_polling_handles,
             voice_notification_receivers,
+            voice_polling_handles,
             skill_phases,
         })
     }
@@ -1485,12 +1489,13 @@ async fn discover_and_register_extensions(
     Vec<tokio::sync::broadcast::Receiver<crate::extensions::WidgetEvent>>,
     Vec<crate::extensions::ExtensionPollingHandle>,
     Vec<tokio::sync::mpsc::UnboundedReceiver<crate::extensions::ExtensionNotification>>,
+    Vec<crate::extensions::ExtensionPollingHandle>,
 )> {
     let ext_dir = crate::paths::omegon_home()?.join("extensions");
 
     if !ext_dir.exists() {
         tracing::debug!("extension directory not found: {}", ext_dir.display());
-        return Ok((vec![], vec![], vec![], vec![]));
+        return Ok((vec![], vec![], vec![], vec![], vec![]));
     }
 
     let profile = crate::settings::Profile::load(cwd);
@@ -1501,6 +1506,7 @@ async fn discover_and_register_extensions(
     let mut widget_receivers = vec![];
     let mut vox_polling_handles = vec![];
     let mut voice_notification_receivers = vec![];
+    let mut voice_polling_handles = vec![];
     for entry in std::fs::read_dir(&ext_dir)? {
         let entry = entry?;
         let path = entry.path();
@@ -1567,6 +1573,9 @@ async fn discover_and_register_extensions(
                 if let Some(handle) = spawned.vox_polling_handle {
                     vox_polling_handles.push(handle);
                 }
+                if let Some(handle) = spawned.voice_polling_handle {
+                    voice_polling_handles.push(handle);
+                }
                 if let Some(rx) = spawned.voice_notification_rx {
                     voice_notification_receivers.push(rx);
                 }
@@ -1600,6 +1609,7 @@ async fn discover_and_register_extensions(
         widget_receivers,
         vox_polling_handles,
         voice_notification_receivers,
+        voice_polling_handles,
     ))
 }
 

--- a/core/crates/omegon/src/tui/mod.rs
+++ b/core/crates/omegon/src/tui/mod.rs
@@ -8024,6 +8024,8 @@ pub struct TuiConfig {
     /// Voice notification receivers — one per voice-capable extension.
     pub voice_notification_receivers:
         Vec<tokio::sync::mpsc::UnboundedReceiver<crate::extensions::ExtensionNotification>>,
+    /// Voice idle notification pumps — one per voice-capable extension.
+    pub voice_polling_handles: Vec<crate::extensions::ExtensionPollingHandle>,
 }
 
 /// Initial state snapshot gathered during setup, before the TUI event loop starts.
@@ -8757,6 +8759,19 @@ pub async fn run_tui(
     }
     app.widget_receivers = config.widget_receivers;
     app.voice_notification_receivers = config.voice_notification_receivers;
+    for handle in config.voice_polling_handles {
+        tokio::spawn(async move {
+            loop {
+                if handle
+                    .pump_notifications_for(std::time::Duration::from_millis(250))
+                    .await
+                    .is_err()
+                {
+                    break;
+                }
+            }
+        });
+    }
     for mut rx in std::mem::take(&mut app.voice_notification_receivers) {
         let tx = command_tx.clone();
         tokio::spawn(async move {


### PR DESCRIPTION
## Summary

Addresses the reopened #93 idle-TUI failure. #95 only forwarded voice notifications while extension RPC reads were active. When the agent turn ended, no one was reading extension stdout, so `voice/transcription` notifications stayed unread and never reached the TUI command channel.

## What changed

- Adds a voice-capable extension polling handle that can perform short idle reads from the extension stdout stream.
- Plumbs voice polling handles from setup into the interactive TUI.
- Starts TUI-owned idle pump tasks that keep reading process-local voice notifications after the agent turn ends.
- Keeps the existing `voice/transcription` -> `VoicePrompt` -> `SubmitPrompt` path from #95.
- Preserves the daemon/headless bridge behavior.

## Validation

- `cargo test -p omegon voice_prompt -- --nocapture`
- `cargo test -p omegon extensions::tests::voice_capable -- --nocapture`
- `cargo test -p omegon status::tests::footer -- --nocapture`
- `just lint`
