### PR TITLE
feat(extensions): add UI contribution schema

### DIFF
--- a/core/crates/omegon-extension/src/capabilities.rs
+++ b/core/crates/omegon-extension/src/capabilities.rs
@@ -55,6 +55,10 @@ pub struct Capabilities {
     #[serde(default)]
     pub voice: bool,
 
+    /// Extension can declare host-owned operator surface contributions.
+    #[serde(default)]
+    pub ui_contributions: bool,
+
     /// Extension can return declarative host action requests in tool results.
     #[serde(default)]
     pub host_actions: bool,
@@ -81,6 +85,7 @@ impl Default for Capabilities {
             elicitation: false,
             streaming: false,
             voice: false,
+            ui_contributions: false,
             host_actions: false,
             host_action_execution: false,
         }
@@ -101,6 +106,7 @@ impl Capabilities {
             elicitation: true,
             streaming: true,
             voice: true,
+            ui_contributions: true,
             host_actions: true,
             host_action_execution: true,
         }
@@ -120,6 +126,7 @@ impl Capabilities {
             elicitation: self.elicitation && other.elicitation,
             streaming: self.streaming && other.streaming,
             voice: self.voice && other.voice,
+            ui_contributions: self.ui_contributions && other.ui_contributions,
             host_actions: self.host_actions && other.host_actions,
             host_action_execution: self.host_action_execution && other.host_action_execution,
         }
@@ -172,6 +179,7 @@ mod tests {
         assert!(!caps.widgets);
         assert!(!caps.sampling);
         assert!(!caps.voice);
+        assert!(!caps.ui_contributions);
         assert!(!caps.host_actions);
         assert!(!caps.host_action_execution);
     }
@@ -184,6 +192,7 @@ mod tests {
         assert!(caps.sampling);
         assert!(caps.elicitation);
         assert!(caps.voice);
+        assert!(caps.ui_contributions);
         assert!(caps.host_actions);
         assert!(caps.host_action_execution);
     }
@@ -203,6 +212,7 @@ mod tests {
         assert!(!active.mind);
         assert!(!active.sampling);
         assert!(!active.voice);
+        assert!(!active.ui_contributions);
         assert!(!active.host_actions);
         assert!(!active.host_action_execution);
     }
@@ -218,6 +228,7 @@ mod tests {
         assert!(caps.tools);
         assert!(caps.streaming);
         assert!(!caps.voice);
+        assert!(!caps.ui_contributions);
         assert!(!caps.host_actions);
         assert!(!caps.host_action_execution);
     }

--- a/core/crates/omegon-extension/src/lib.rs
+++ b/core/crates/omegon-extension/src/lib.rs
@@ -114,6 +114,7 @@ mod resources;
 mod rpc;
 mod sampling;
 mod streaming;
+mod ui_contributions;
 
 pub use capabilities::{
     Capabilities, ExtensionInfo, HostInfo, InitializeParams, InitializeResult, PROTOCOL_VERSION,
@@ -148,6 +149,11 @@ pub use sampling::{
     SamplingMessage, SamplingRoute, TokenUsage,
 };
 pub use streaming::{CancelledParams, ProgressContent, ProgressReporter, ToolProgressParams};
+pub use ui_contributions::{
+    CommandContribution, ListItemTemplate, ListPrimitiveView, PrimitiveAction, PrimitiveView,
+    StatusItemContribution, SurfaceContribution, SurfacePlacement, SurfaceRendering,
+    UiContribution, UiContributionSet, UiNamespace,
+};
 
 /// Convenience type for RPC method results.
 pub type RpcResult = Result<serde_json::Value>;

--- a/core/crates/omegon-extension/src/manifest.rs
+++ b/core/crates/omegon-extension/src/manifest.rs
@@ -28,7 +28,85 @@ impl ManifestError {
     }
 }
 
-/// Extension metadata from manifest.toml.
+/// Declarative operator-surface contribution envelope.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct UiConfig {
+    #[serde(default)]
+    pub namespace: String,
+    #[serde(default)]
+    pub description: String,
+    #[serde(default)]
+    pub commands: Vec<UiCommand>,
+    #[serde(default)]
+    pub status_items: Vec<UiStatusItem>,
+    #[serde(default)]
+    pub surfaces: Vec<UiSurface>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UiCommand {
+    pub id: String,
+    pub title: String,
+    pub slash: String,
+    pub tool: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UiStatusItem {
+    pub id: String,
+    pub title: String,
+    pub refresh_tool: String,
+    pub interval_ms: u64,
+    pub template: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UiSurface {
+    pub id: String,
+    pub title: String,
+    pub surface_type: String,
+    pub rendering: String,
+    #[serde(default)]
+    pub preferred_placements: Vec<String>,
+    #[serde(default)]
+    pub open_tool: Option<String>,
+    #[serde(default)]
+    pub status_tool: Option<String>,
+    #[serde(default)]
+    pub view: Option<UiPrimitiveView>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UiPrimitiveView {
+    pub primitive: String,
+    pub data_tool: String,
+    #[serde(default)]
+    pub item: Option<UiListItemTemplate>,
+    #[serde(default)]
+    pub actions: Vec<UiPrimitiveAction>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UiListItemTemplate {
+    #[serde(default)]
+    pub title: Option<String>,
+    #[serde(default)]
+    pub subtitle: Option<String>,
+    #[serde(default)]
+    pub badge: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UiPrimitiveAction {
+    pub id: String,
+    pub title: String,
+    pub tool: String,
+    #[serde(default)]
+    pub args: serde_json::Value,
+    #[serde(default)]
+    pub confirm: bool,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ExtensionManifest {
     pub extension: ExtensionMetadata,
@@ -43,6 +121,8 @@ pub struct ExtensionManifest {
     pub config: HashMap<String, ConfigField>,
     #[serde(default)]
     pub capabilities: Capabilities,
+    #[serde(default)]
+    pub ui: UiConfig,
     #[serde(default)]
     pub permissions: ManifestPermissions,
 }
@@ -405,6 +485,7 @@ mod tests {
             mind: MindConfig::default(),
             config: HashMap::new(),
             capabilities: Capabilities::default(),
+            ui: UiConfig::default(),
             permissions: ManifestPermissions::default(),
         };
 
@@ -428,6 +509,7 @@ mod tests {
             mind: MindConfig::default(),
             config: HashMap::new(),
             capabilities: Capabilities::default(),
+            ui: UiConfig::default(),
             permissions: ManifestPermissions::default(),
         };
 
@@ -451,6 +533,7 @@ mod tests {
             mind: MindConfig::default(),
             config: HashMap::new(),
             capabilities: Capabilities::default(),
+            ui: UiConfig::default(),
             permissions: ManifestPermissions::default(),
         };
 
@@ -646,6 +729,7 @@ default = "gmail"
                 },
             )]),
             capabilities: Capabilities::default(),
+            ui: UiConfig::default(),
             permissions: ManifestPermissions::default(),
         };
 

--- a/core/crates/omegon-extension/src/manifest.rs
+++ b/core/crates/omegon-extension/src/manifest.rs
@@ -650,6 +650,60 @@ allow_env = ["BOOKOKRAT_THEME"]
     }
 
     #[test]
+    fn test_ui_contributions_parse_from_toml() {
+        let toml_str = r#"
+[extension]
+name = "reader"
+version = "0.1.0"
+
+[runtime]
+type = "native"
+binary = "target/release/reader"
+
+[capabilities]
+ui_contributions = true
+
+[ui]
+namespace = "reader"
+description = "Document reader surfaces"
+
+[[ui.commands]]
+id = "open"
+title = "Open Reader"
+slash = "/reader open"
+tool = "reader_open"
+
+[[ui.status_items]]
+id = "status"
+title = "Reader"
+refresh_tool = "reader_status"
+interval_ms = 30000
+template = "{state}"
+
+[[ui.surfaces]]
+id = "reader"
+title = "Reader"
+surface_type = "document_reader"
+rendering = "delegated"
+preferred_placements = ["side_pane", "new_tab", "external"]
+open_tool = "reader_open"
+status_tool = "reader_status"
+"#;
+
+        let manifest: ExtensionManifest = toml::from_str(toml_str).unwrap();
+        assert!(manifest.capabilities.ui_contributions);
+        assert_eq!(manifest.ui.namespace, "reader");
+        assert_eq!(manifest.ui.commands[0].slash, "/reader open");
+        assert_eq!(manifest.ui.status_items[0].refresh_tool, "reader_status");
+        assert_eq!(manifest.ui.surfaces[0].rendering, "delegated");
+        assert_eq!(manifest.ui.surfaces[0].preferred_placements[0], "side_pane");
+        assert_eq!(
+            manifest.ui.surfaces[0].open_tool.as_deref(),
+            Some("reader_open")
+        );
+    }
+
+    #[test]
     fn test_config_fields_parse_from_toml() {
         let toml_str = r#"
 [extension]

--- a/core/crates/omegon-extension/src/ui_contributions.rs
+++ b/core/crates/omegon-extension/src/ui_contributions.rs
@@ -1,0 +1,192 @@
+//! Declarative operator-surface contribution protocol types.
+//!
+//! Extensions declare commands, passive status items, and host-managed surfaces.
+//! The host validates these declarations against the extension manifest and owns
+//! rendering, routing, placement, focus, and policy.
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct UiContributionSet {
+    pub version: u16,
+    pub namespace: UiNamespace,
+    #[serde(default)]
+    pub contributions: Vec<UiContribution>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct UiNamespace {
+    pub requested: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fallback: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum UiContribution {
+    Command(CommandContribution),
+    StatusItem(StatusItemContribution),
+    Surface(SurfaceContribution),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CommandContribution {
+    pub id: String,
+    pub title: String,
+    pub slash: String,
+    pub tool: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub args_schema: Option<Value>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct StatusItemContribution {
+    pub id: String,
+    pub title: String,
+    pub refresh_tool: String,
+    pub refresh_interval_ms: u64,
+    pub template: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SurfaceRendering {
+    Host,
+    Delegated,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SurfacePlacement {
+    SidePane,
+    BottomPane,
+    Modal,
+    NewTab,
+    External,
+    BackgroundSession,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SurfaceContribution {
+    pub id: String,
+    pub title: String,
+    pub surface_type: String,
+    pub rendering: SurfaceRendering,
+    #[serde(default)]
+    pub preferred_placements: Vec<SurfacePlacement>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub open_tool: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub status_tool: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub view: Option<PrimitiveView>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "primitive", rename_all = "snake_case")]
+pub enum PrimitiveView {
+    List(ListPrimitiveView),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ListPrimitiveView {
+    pub data_tool: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub item: Option<ListItemTemplate>,
+    #[serde(default)]
+    pub actions: Vec<PrimitiveAction>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ListItemTemplate {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub subtitle: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub badge: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PrimitiveAction {
+    pub id: String,
+    pub title: String,
+    pub tool: String,
+    #[serde(default)]
+    pub args: Value,
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub confirm: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn reader_delegated_surface_round_trips() {
+        let value = json!({
+            "version": 1,
+            "namespace": {"requested": "reader", "fallback": "omegon-reader"},
+            "contributions": [{
+                "kind": "surface",
+                "id": "reader",
+                "title": "Reader",
+                "surface_type": "document_reader",
+                "rendering": "delegated",
+                "preferred_placements": ["side_pane", "new_tab", "external", "background_session"],
+                "open_tool": "reader_open",
+                "status_tool": "reader_status"
+            }]
+        });
+        let parsed: UiContributionSet = serde_json::from_value(value.clone()).unwrap();
+        assert_eq!(parsed.namespace.requested, "reader");
+        match &parsed.contributions[0] {
+            UiContribution::Surface(surface) => {
+                assert_eq!(surface.rendering, SurfaceRendering::Delegated);
+                assert_eq!(surface.surface_type, "document_reader");
+                assert_eq!(surface.preferred_placements[0], SurfacePlacement::SidePane);
+                assert!(surface.view.is_none());
+            }
+            other => panic!("expected surface, got {other:?}"),
+        }
+        assert_eq!(serde_json::to_value(parsed).unwrap(), value);
+    }
+
+    #[test]
+    fn scratchpad_host_list_surface_round_trips() {
+        let value = json!({
+            "version": 1,
+            "namespace": {"requested": "scratchpad"},
+            "contributions": [{
+                "kind": "surface",
+                "id": "scratchpad",
+                "title": "Scratchpad",
+                "surface_type": "primitive_view",
+                "rendering": "host",
+                "preferred_placements": ["side_pane", "modal"],
+                "view": {
+                    "primitive": "list",
+                    "data_tool": "scratchpad_list",
+                    "item": {"title": "{title}", "subtitle": "{body_preview}", "badge": "{tag_count}"},
+                    "actions": [{"id": "open", "title": "Open", "tool": "scratchpad_get", "args": {"id": "{id}"}}]
+                }
+            }]
+        });
+        let parsed: UiContributionSet = serde_json::from_value(value.clone()).unwrap();
+        match &parsed.contributions[0] {
+            UiContribution::Surface(surface) => {
+                assert_eq!(surface.rendering, SurfaceRendering::Host);
+                match surface.view.as_ref().unwrap() {
+                    PrimitiveView::List(list) => {
+                        assert_eq!(list.data_tool, "scratchpad_list");
+                        assert_eq!(list.actions[0].tool, "scratchpad_get");
+                    }
+                }
+            }
+            other => panic!("expected surface, got {other:?}"),
+        }
+        assert_eq!(serde_json::to_value(parsed).unwrap(), value);
+    }
+}

--- a/core/crates/omegon/src/extensions/manifest.rs
+++ b/core/crates/omegon/src/extensions/manifest.rs
@@ -34,7 +34,85 @@ use serde::{Deserialize, Serialize};
 use std::path::Path;
 
 /// Top-level manifest structure.
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct UiConfig {
+    #[serde(default)]
+    pub namespace: String,
+    #[serde(default)]
+    pub description: String,
+    #[serde(default)]
+    pub commands: Vec<UiCommand>,
+    #[serde(default)]
+    pub status_items: Vec<UiStatusItem>,
+    #[serde(default)]
+    pub surfaces: Vec<UiSurface>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UiCommand {
+    pub id: String,
+    pub title: String,
+    pub slash: String,
+    pub tool: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UiStatusItem {
+    pub id: String,
+    pub title: String,
+    pub refresh_tool: String,
+    pub interval_ms: u64,
+    pub template: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UiSurface {
+    pub id: String,
+    pub title: String,
+    pub surface_type: String,
+    pub rendering: String,
+    #[serde(default)]
+    pub preferred_placements: Vec<String>,
+    #[serde(default)]
+    pub open_tool: Option<String>,
+    #[serde(default)]
+    pub status_tool: Option<String>,
+    #[serde(default)]
+    pub view: Option<UiPrimitiveView>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UiPrimitiveView {
+    pub primitive: String,
+    pub data_tool: String,
+    #[serde(default)]
+    pub item: Option<UiListItemTemplate>,
+    #[serde(default)]
+    pub actions: Vec<UiPrimitiveAction>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UiListItemTemplate {
+    #[serde(default)]
+    pub title: Option<String>,
+    #[serde(default)]
+    pub subtitle: Option<String>,
+    #[serde(default)]
+    pub badge: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UiPrimitiveAction {
+    pub id: String,
+    pub title: String,
+    pub tool: String,
+    #[serde(default)]
+    pub args: serde_json::Value,
+    #[serde(default)]
+    pub confirm: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ExtensionManifest {
     pub extension: ExtensionMetadata,
     pub runtime: RuntimeConfig,
@@ -54,6 +132,8 @@ pub struct ExtensionManifest {
     pub config: std::collections::HashMap<String, omegon_extension::ConfigField>,
     #[serde(default)]
     pub capabilities: omegon_extension::Capabilities,
+    #[serde(default)]
+    pub ui: UiConfig,
     #[serde(default)]
     pub permissions: omegon_extension::ManifestPermissions,
 }

--- a/core/crates/omegon/src/extensions/manifest.rs
+++ b/core/crates/omegon/src/extensions/manifest.rs
@@ -415,6 +415,60 @@ description = "Timeline of engagement activity"
     }
 
     #[test]
+    fn parse_ui_contributions_manifest() {
+        let toml = r#"
+[extension]
+name = "reader"
+version = "0.1.0"
+
+[runtime]
+type = "native"
+binary = "target/release/reader"
+
+[capabilities]
+ui_contributions = true
+
+[ui]
+namespace = "reader"
+description = "Document reader surfaces"
+
+[[ui.commands]]
+id = "open"
+title = "Open Reader"
+slash = "/reader open"
+tool = "reader_open"
+
+[[ui.status_items]]
+id = "status"
+title = "Reader"
+refresh_tool = "reader_status"
+interval_ms = 30000
+template = "{state}"
+
+[[ui.surfaces]]
+id = "reader"
+title = "Reader"
+surface_type = "document_reader"
+rendering = "delegated"
+preferred_placements = ["side_pane", "new_tab", "external"]
+open_tool = "reader_open"
+status_tool = "reader_status"
+"#;
+        let manifest: ExtensionManifest = toml::from_str(toml).unwrap();
+        assert!(manifest.capabilities.ui_contributions);
+        assert_eq!(manifest.ui.namespace, "reader");
+        assert_eq!(manifest.ui.description, "Document reader surfaces");
+        assert_eq!(manifest.ui.commands[0].tool, "reader_open");
+        assert_eq!(manifest.ui.status_items[0].interval_ms, 30000);
+        assert_eq!(manifest.ui.surfaces[0].surface_type, "document_reader");
+        assert_eq!(manifest.ui.surfaces[0].rendering, "delegated");
+        assert_eq!(
+            manifest.ui.surfaces[0].status_tool.as_deref(),
+            Some("reader_status")
+        );
+    }
+
+    #[test]
     fn parse_manifest_with_secrets() {
         let toml = r#"
 [extension]

--- a/core/crates/omegon/src/extensions/mod.rs
+++ b/core/crates/omegon/src/extensions/mod.rs
@@ -1741,6 +1741,7 @@ binary = "voice-extension.sh"
             mcp: None,
             config,
             capabilities: omegon_extension::Capabilities::default(),
+            ui: manifest::UiConfig::default(),
             permissions: omegon_extension::ManifestPermissions::default(),
         }
     }

--- a/docs/design/0.25-roadmap-extension-surfaces.md
+++ b/docs/design/0.25-roadmap-extension-surfaces.md
@@ -1,0 +1,79 @@
+---
+title: 0.25 Roadmap — Extension Surfaces, Resource Opens, and SDK Contracts
+status: exploring
+tags: [roadmap, 0.25, extensions, ui, host-actions, sdk]
+---
+
+# 0.25 Roadmap — Extension Surfaces, Resource Opens, and SDK Contracts
+
+## Overview
+
+0.25 should turn the 0.24 HostAction substrate into operator-visible extension surfaces. The release theme is:
+
+> Extensions describe operator intent and surfaces declaratively; Omegon validates policy, chooses host-owned rendering/execution paths, and keeps fallback behavior visible and actionable.
+
+This roadmap groups the currently open issues into ordered feature lanes.
+
+## Issue mapping
+
+### Core 0.25.0 lane
+
+- [[extension-ui-contributions-101]] — declarative TUI contributions and slash commands.
+- [[terminal-background-session-visibility-104]] — make `terminal.create@1` fallback sessions inspectable in standalone Omegon TUI.
+- [[resource-open-host-action-83]] — semantic `resource.open@1` for host-routed viewer/editor opens.
+
+### Optional / stretch 0.25.0 lane
+
+- [[acp-terminal-delegation-87]] — ACP/Flynt host terminal delegation for `terminal.create@1` and built-in terminal use cases.
+
+### 0.25.x voice UX lane
+
+- [[voice-control-metadata-98]] — consume voice control metadata and define TTS lifecycle events.
+- [[tts-agent-mode-100]] — make short spoken status cues a deterministic agent/host behavior contract.
+
+### Post-schema SDK stabilization lane
+
+- [[sdk-lockstep-contract-102]] — publish a canonical SDK contract artifact for Rust/Python/TypeScript SDK ports.
+- [[sdk-repo-extraction-103]] — extract `omegon-extension` into a standalone Rust SDK repo after contract stabilization.
+
+## Ordering constraints
+
+1. #101 comes first because it defines how extensions describe commands/status/surfaces without hardcoding Reader/Flynt behavior into the host.
+2. #104 can proceed in parallel with #101 because it improves the existing `terminal.create@1` fallback path without requiring new semantic resource routing.
+3. #83 should consume the vocabulary from #101 and the fallback visibility guarantees from #104.
+4. #87 should build on #104; standalone fallback visibility remains required even when ACP host delegation exists.
+5. #98 precedes #100 because TTS agent mode needs a lifecycle/control metadata contract first.
+6. #102 follows #101/#83 schema stabilization.
+7. #103 follows #102 and should not happen as a big-bang move.
+
+## Non-goals for initial 0.25.0
+
+- Do not make Reader know about Flynt, Zed, or host-specific routing.
+- Do not make Flynt mandatory for `terminal.create@1` acceptance.
+- Do not extract the Rust SDK repo before the contract artifact exists.
+- Do not make TTS speak long agent answers, logs, code, secrets, URLs, or tables.
+
+## Design readiness
+
+Readiness is intentionally staged:
+
+| Lane | Readiness | Reason |
+|---|---:|---|
+| #101 extension UI contributions | medium | Initial schema substrate exists locally; host validation/rendering plan still needed. |
+| #104 terminal background visibility | high | Narrow dogfood bug with concrete acceptance path. |
+| #83 resource.open@1 | medium | Shape is clear, but routing policy depends on surface vocabulary. |
+| #87 ACP terminal delegation | medium-low | Flynt pieces exist, but host capability negotiation/terminal delegation contract needs tightening. |
+| #98 voice metadata | medium | Event shape exists in `omegon-voice`; host consumption policy is unsettled. |
+| #100 TTS agent mode | low | Depends on #98 and agent behavior policy. |
+| #102 SDK lockstep | medium | Need contract artifact format decision. |
+| #103 SDK extraction | low | Explicitly blocked on #102. |
+
+## Implementation strategy
+
+Use one PR per lane/slice:
+
+1. `feature/extension-ui-contributions-101` — schema/protocol only, then host validation.
+2. `feature/terminal-background-visibility-104` — result card/session transcript affordance.
+3. `feature/resource-open-hostaction-83` — SDK + policy + initial file routing.
+4. `feature/acp-terminal-delegation-87` — ACP terminal host delegation once #104 is merged.
+5. Voice and SDK stabilization branches after the initial surface/resource work lands.

--- a/docs/design/acp-terminal-delegation-87.md
+++ b/docs/design/acp-terminal-delegation-87.md
@@ -1,0 +1,58 @@
+---
+title: ACP Terminal Delegation (#87)
+status: exploring
+tags: [0.25, acp, terminal, host-actions, flynt]
+---
+
+# ACP Terminal Delegation (#87)
+
+## Problem
+
+Flynt has an integrated terminal surface, but Omegon still often creates its own internal/background PTY for terminal use cases.
+
+This splits behavior:
+
+- Extension HostActions can request `terminal.create@1`.
+- Built-in `terminal` tool creates Omegon-owned background sessions.
+- ACP permission flow can review actions, but host terminal execution is not the canonical path.
+
+## Goal
+
+When an ACP host advertises terminal capability, Omegon can delegate terminal creation to the host and receive structured outcomes.
+
+## Use cases
+
+1. Extension/MCP emits `terminal.create@1` and ACP host renders approval card, then executes locally.
+2. Built-in `terminal start` can delegate to ACP host terminal backend when available.
+3. Tool-result metadata preserves raw candidates and outcomes for host UI cards.
+
+## Decisions
+
+### Decision: #104 is still required
+
+ACP delegation is not a replacement for standalone visibility. If no ACP terminal backend exists, fallback background sessions must still be inspectable.
+
+### Decision: terminal delegation is host-owned, not extension-owned
+
+Extensions declare intent; Flynt/Omegon decide placement and execution.
+
+## Open questions
+
+- [assumption] ACP permission request metadata can carry terminal.create candidates with sufficient fidelity for Flynt.
+- How does ACP host advertise terminal backend capability?
+- Does host execute and return `TerminalCreateResult`, or does Omegon execute after approval?
+- How should built-in `terminal` tool expose delegation vs internal background backend?
+
+## Acceptance
+
+- ACP contract documents terminal delegation.
+- Flynt can distinguish terminal HostAction candidates from ordinary transcript text.
+- Host can approve and execute a terminal create request locally.
+- Built-in terminal tool has a host-delegation path when capability exists.
+- Fallback to Omegon background PTY remains intact.
+
+## Links
+
+- [[0.25-roadmap-extension-surfaces]]
+- [[terminal-background-session-visibility-104]]
+- [[resource-open-host-action-83]]

--- a/docs/design/extension-operator-surface-contributions.md
+++ b/docs/design/extension-operator-surface-contributions.md
@@ -237,3 +237,194 @@ For the MVP, surface contributions describe the operator affordance and preferre
 - Host validates runtime contributions against manifest envelope.
 - Host rejects raw drawing claims.
 - At least a reader status diagnostic can show accepted contributions before full visual rendering lands.
+
+## Surface rendering modes
+
+Surface contributions have two independent axes:
+
+```text
+rendering: host | delegated
+placement: side_pane | bottom_pane | modal | new_tab | external | background_session
+```
+
+`placement` says where the operator should see the contribution. `rendering`
+says who owns the visual/runtime implementation.
+
+### Delegated rendering
+
+Delegated surfaces are for extensions that own a domain-specific UI or runtime.
+Reader is the canonical MVP example.
+
+```json
+{
+  "kind": "surface",
+  "id": "reader",
+  "title": "Reader",
+  "surface_type": "document_reader",
+  "rendering": "delegated",
+  "preferred_placements": ["side_pane", "new_tab", "external", "background_session"],
+  "open_tool": "reader_open",
+  "status_tool": "reader_status"
+}
+```
+
+Meaning:
+
+- Reader owns document navigation/rendering through its backend.
+- Omegon/Cockpit owns placement, lifecycle, focus, diagnostics, and policy.
+- Placement can degrade honestly, e.g. side pane to external app to background
+  terminal session.
+- Delegated rendering still cannot draw into host frames unless the selected
+  backend is host-approved.
+
+### Host-rendered primitive surfaces
+
+Host-rendered surfaces are for simple extensions that want to use Omegon/Cockpit
+primitives rather than ship their own UI.
+
+The extension declares data tools, action tools, and a primitive view schema. The
+host renders the view using blessed primitives.
+
+```json
+{
+  "kind": "surface",
+  "id": "scratchpad",
+  "title": "Scratchpad",
+  "surface_type": "primitive_view",
+  "rendering": "host",
+  "preferred_placements": ["side_pane", "modal"],
+  "view": {
+    "primitive": "list",
+    "data_tool": "scratchpad_list",
+    "item": {
+      "title": "{title}",
+      "subtitle": "{body_preview}",
+      "badge": "{tag_count}"
+    },
+    "actions": [
+      {
+        "id": "open",
+        "title": "Open",
+        "tool": "scratchpad_get",
+        "args": { "id": "{id}" }
+      }
+    ]
+  }
+}
+```
+
+Meaning:
+
+- Extension does not render.
+- Extension provides data through declared tools.
+- Host owns layout, styling, focus, scrolling, selection, and confirmation UI.
+- Host-owned actions route only to declared extension tools.
+- If no requested placement is available, host-rendered primitive views can
+  degrade to ordinary command/tool result output.
+
+## Initial primitive vocabulary
+
+The first MVP should implement only one host-rendered primitive:
+
+```text
+list
+```
+
+Reserve but do not implement the broader vocabulary:
+
+```text
+table
+key_value
+markdown
+form
+card_grid
+tree
+log
+progress
+empty_state
+```
+
+The `list` primitive should be enough for a scratchpad or simple search-results
+extension and prevents the protocol from overfitting to Reader's delegated
+surface model.
+
+## Host-rendered primitive safety rules
+
+Allowed for `rendering = host`:
+
+- data from declared tools
+- limited field interpolation such as `{title}` or `{id}`
+- host-owned list/card/table styling
+- host-owned actions routed to declared tools
+- host-owned confirmation dialogs
+- host-enforced refresh intervals
+
+Denied:
+
+- raw ANSI
+- terminal escape sequences
+- arbitrary layout code
+- arbitrary HTML/JS
+- keyboard capture
+- background refresh below host minimum
+- actions targeting tools not owned by the extension
+- filesystem or process side effects except through existing tool/HostAction
+  policy paths
+
+## Updated Reader/Scratchpad MVP pairing
+
+Use two dogfood extensions to keep the model honest:
+
+| Dogfood target | Surface mode | Proves |
+|---|---|---|
+| Reader | delegated document_reader | placement/backend degradation and domain UI ownership |
+| Scratchpad | host primitive_view/list | simple extensions can use host primitives without owning UI |
+
+Reader remains the primary MVP because it exercises surface placement,
+HostAction approval, backend degradation, and status. Scratchpad should be the
+minimal primitive-view smoke test.
+
+## Updated slice plan
+
+### Slice 1: protocol/schema
+
+- Add `ui_contributions` capability.
+- Add surface `rendering = host | delegated`.
+- Add surface `surface_type`.
+- Add `preferred_placements`.
+- Add host-rendered `view.primitive = list` schema.
+- Add SDK JSON round-trip tests for:
+  - Reader delegated document_reader surface.
+  - Scratchpad host-rendered list surface.
+- Add manifest TOML parsing tests for both examples.
+- No rendering yet.
+
+### Slice 2: validation/registry
+
+- Runtime `ui/list_contributions` discovery gated by capability.
+- Runtime contribution validation against manifest envelope.
+- Host rejects raw drawing claims.
+- Host records accepted delegated and host-rendered surfaces in a registry.
+- Diagnostics expose accepted/rejected contribution reasons.
+
+### Slice 3: command contribution MVP
+
+- Reader command contribution routes a namespaced slash command to `reader_open`
+  or `reader_status`.
+- Scratchpad command contribution routes to a simple scratchpad tool.
+- Namespace conflict behavior is deterministic and visible.
+
+### Slice 4: primitive list MVP
+
+- Host renders a scratchpad-style list primitive from a data tool result.
+- Supports title/subtitle/badge field templates.
+- Supports one host-owned action routed to an extension tool.
+- No arbitrary rendering or custom styling.
+
+### Slice 5: Reader surface placement MVP
+
+- Host registers Reader's delegated document_reader surface.
+- Host chooses an available placement/backend.
+- If side pane is unavailable, result reports actual placement and warning.
+- Existing terminal.create@1/Bookokrat fallback remains a backend, not the
+  surface protocol itself.

--- a/docs/design/extension-operator-surface-contributions.md
+++ b/docs/design/extension-operator-surface-contributions.md
@@ -1,0 +1,239 @@
+# Extension Operator Surface Contributions
+
+Status: exploring
+Issue: #101
+Primary dogfood target: omegon-reader
+
+## Problem
+
+Extensions need operator-facing affordances beyond raw tools: slash commands, command-palette entries, passive status items, and host-managed reading/panel surfaces. The existing extension boundary exposes tools and declarative HostActions, but it does not let an extension install a discoverable operator UX such as reader open/status commands, a reader footer item, or a host-selected reader surface.
+
+Reader is the right MVP because it exercises the hard parts of the boundary: command contribution, passive status contribution, surface intent with preferred placements, HostAction approval/backend degradation, and strict prohibition on extension-owned terminal drawing.
+
+## Core decision
+
+Extensions declare operator-surface contributions. They do not draw UI, mutate host registries, or claim terminal layout directly.
+
+```text
+Extension manifest/runtime declaration
+  -> Omegon validates namespace + permission envelope
+  -> host registry stores accepted contributions
+  -> Cockpit/TUI/Flynt render commands, status items, and surfaces
+  -> HostActions execute only through existing approval/policy paths
+```
+
+Panels are host placements, not extension-owned drawing contexts.
+
+```text
+contribution kind: surface
+placement choice: side_pane | bottom_pane | new_tab | external | background_session
+```
+
+A Reader extension can declare a document_reader surface and prefer side_pane, then new_tab, then external. The host chooses the actual placement based on active capabilities.
+
+## Non-goals for the MVP
+
+- No raw extension drawing in the terminal.
+- No arbitrary ANSI rendering from extensions.
+- No direct keybinding install without explicit future approval policy.
+- No imperative mutation of slash command registries by extensions.
+- No requirement that TUI implement a visual reader pane in the first slice.
+- No automatic HostAction execution outside existing approval/policy seams.
+
+## Contribution kinds
+
+Initial protocol vocabulary:
+
+| Kind | Meaning | MVP status |
+|---|---|---|
+| command | Slash command / command palette entry routed to an extension tool | MVP |
+| status_item | Passive host-rendered status/footer item refreshed by a tool | MVP |
+| surface | Semantic host-managed surface intent, e.g. document_reader | MVP declaration only |
+| completion_provider | Argument completion source | later |
+| notification | Rate-limited operator notification | later |
+| keybinding | Explicit operator-approved keybinding | later |
+
+## Reader MVP shape
+
+### Manifest envelope
+
+The manifest declares the install-time permission envelope. Runtime contributions must be a subset of this envelope.
+
+```toml
+[capabilities]
+tools = true
+host_actions = true
+ui_contributions = true
+
+[ui]
+namespace = "reader"
+description = "Open books and document-like files in a host-managed reader surface."
+
+[[ui.commands]]
+id = "open"
+title = "Open Reader"
+slash = "open"
+tool = "reader_open"
+
+[[ui.commands]]
+id = "status"
+title = "Reader Status"
+slash = "status"
+tool = "reader_status"
+
+[[ui.status_items]]
+id = "reader"
+title = "Reader"
+refresh_tool = "reader_status"
+interval_ms = 30000
+template = "reader:{state}"
+
+[[ui.surfaces]]
+id = "reader"
+title = "Reader"
+surface_type = "document_reader"
+open_tool = "reader_open"
+status_tool = "reader_status"
+preferred_placements = ["side_pane", "new_tab", "external", "background_session"]
+```
+
+### Runtime contribution response
+
+Proposed method:
+
+```text
+ui/list_contributions
+```
+
+Example:
+
+```json
+{
+  "version": 1,
+  "namespace": {
+    "requested": "reader",
+    "fallback": "omegon-reader"
+  },
+  "contributions": [
+    {
+      "kind": "command",
+      "id": "open",
+      "title": "Open Reader",
+      "slash": "open",
+      "tool": "reader_open"
+    },
+    {
+      "kind": "command",
+      "id": "status",
+      "title": "Reader Status",
+      "slash": "status",
+      "tool": "reader_status"
+    },
+    {
+      "kind": "status_item",
+      "id": "reader",
+      "title": "Reader",
+      "refresh_tool": "reader_status",
+      "refresh_interval_ms": 30000,
+      "template": "reader:{state}"
+    },
+    {
+      "kind": "surface",
+      "id": "reader",
+      "title": "Reader",
+      "surface_type": "document_reader",
+      "preferred_placements": ["side_pane", "new_tab", "external", "background_session"],
+      "open_tool": "reader_open",
+      "status_tool": "reader_status"
+    }
+  ]
+}
+```
+
+Resolved operator UI examples:
+
+```text
+reader open command
+reader status command
+reader status footer item
+```
+
+## Namespace rules
+
+- Namespace is required for any operator-visible contribution.
+- Namespace must be lowercase kebab/snake/alphanumeric with separators only.
+- Runtime requested namespace must match or be within manifest envelope.
+- If namespace conflicts with an existing host command or extension namespace, host chooses deterministic fallback, e.g. omegon-reader.
+- Conflict must be visible in diagnostics/status.
+- Contribution ids are local to namespace.
+
+## Validation rules
+
+The host rejects or drops runtime contributions that exceed the manifest envelope:
+
+- command id not declared in manifest
+- slash alias not declared in manifest
+- tool not owned by that extension
+- status item refresh interval below host minimum
+- status template references unsupported keys
+- surface type not declared in manifest
+- preferred placement not supported by host policy vocabulary
+- raw drawing/ANSI/panel-content claims
+
+## Relationship to HostActions
+
+Reader surface opening can start with current HostAction primitives using terminal.create@1, but the protocol should evolve toward semantic surface actions such as surface.open@1.
+
+For the MVP, surface contributions describe the operator affordance and preferred placement. Actual opening may still route through reader_open and terminal.create@1 until a surface.open@1 HostAction exists.
+
+## MVP implementation slices
+
+### Slice 1: protocol/schema only
+
+- Add ui_contributions capability.
+- Add SDK types for contribution sets, namespaces, command/status/surface contributions.
+- Add manifest parser support for ui commands, status items, and surfaces.
+- Add JSON/TOML round-trip tests using Reader examples.
+- No TUI rendering yet.
+
+### Slice 2: host validation/registry
+
+- During extension spawn, call ui/list_contributions only when capability is enabled.
+- Validate runtime contributions against manifest envelope.
+- Store accepted contributions in a host registry.
+- Expose diagnostics through a status/debug path.
+
+### Slice 3: Reader command routing
+
+- Register accepted command contributions into slash parser/command palette.
+- Route reader open/status commands to declared tools.
+- Preserve namespace conflict diagnostics.
+
+### Slice 4: Reader status item
+
+- Poll declared refresh tool with rate limits.
+- Render reader state in footer/status.
+- Degrade silently if extension unavailable; surface diagnostics in details.
+
+### Slice 5: semantic surfaces
+
+- Register surface contributions.
+- Map Reader document_reader intent into available host surface backends.
+- Keep terminal/bookokrat fallback as backend, not protocol.
+
+## Open questions
+
+- [assumption] Cockpit/TUI command palette has a stable registry entry point.
+- [assumption] Slash command routing can call extension tools without reopening the entire prompt submission path.
+- Should status item refresh use tool calls, extension notifications, or both?
+- Should surface.open@1 be introduced in this change or deferred until after Reader command/status MVP?
+- What is the exact namespace conflict display in Slim mode?
+
+## Acceptance for first MVP
+
+- Reader manifest can declare command/status/surface contribution envelope.
+- Reader runtime can return matching ui/list_contributions payload.
+- Omegon SDK/protocol tests validate the payload shape.
+- Host validates runtime contributions against manifest envelope.
+- Host rejects raw drawing claims.
+- At least a reader status diagnostic can show accepted contributions before full visual rendering lands.

--- a/docs/design/extension-ui-contributions-101.md
+++ b/docs/design/extension-ui-contributions-101.md
@@ -1,0 +1,87 @@
+---
+title: Extension UI Contributions (#101)
+status: exploring
+tags: [0.25, extensions, ui, tui, sdk]
+---
+
+# Extension UI Contributions (#101)
+
+## Problem
+
+Extensions need a declarative way to contribute operator-facing commands, passive status items, and host/delegated surfaces without hardcoding extension-specific behavior into Omegon or Flynt.
+
+Reader is the dogfood case, but the design must remain generic.
+
+## Goal
+
+Define a stable extension UI contribution schema for 0.25:
+
+- slash-command contributions
+- status item contributions
+- delegated surfaces such as a Reader/document pane
+- host-rendered primitive surfaces such as list views
+- capability-gated legacy-safe manifest parsing
+
+## Current local status
+
+Initial substrate exists on branch:
+
+```text
+feature/extension-ui-contributions-101
+```
+
+Commit:
+
+```text
+ca05ecae feat(extensions): add UI contribution schema
+```
+
+It includes:
+
+- `Capabilities::ui_contributions`
+- `omegon-extension::ui_contributions` SDK types
+- `[ui]` manifest structs in SDK and host parsers
+- Pkl schema support
+- SDK round-trip tests for Reader delegated surface and Scratchpad host list surface
+
+## Decisions
+
+### Decision: Schema/protocol first
+
+Ship #101 in slices. The first slice only defines capability, manifest/schema, SDK structs, and parser tests. Rendering/routing comes after schema stability.
+
+Cost: user-visible UI contributions are not complete in the first PR.
+Benefit: downstream SDKs and first-party extensions can start declaring intent without host UI coupling.
+
+### Decision: Reader is a consumer, not a special case
+
+Reader should declare a delegated `document_reader` surface through `[ui]`. Omegon should not special-case `omegon-reader` by name.
+
+### Decision: Keep manifest structs separate from SDK payload structs for now
+
+Manifest parser structs can remain manifest-specific while SDK structs represent protocol payloads. Add conversion tests before runtime registration.
+
+Cost: duplicate type definitions can drift.
+Mitigation: conversion/round-trip tests and eventual schema contract artifact (#102).
+
+## Open questions
+
+- [assumption] A first-slice manifest parser can accept `[ui]` declarations without immediately registering commands in the TUI.
+- [assumption] `namespace` should be unique per extension and host-normalized on collision.
+- How should slash commands resolve conflicts: extension namespace prefix only, explicit operator aliases, or first-install wins?
+- Should delegated surfaces require a paired HostAction such as `terminal.create@1` or `resource.open@1`, or can `open_tool` remain an arbitrary extension tool?
+
+## Acceptance for first slice
+
+- Legacy manifests parse with `ui_contributions = false` by default.
+- `[capabilities] ui_contributions = true` parses in SDK and host manifest loaders.
+- `[ui]` commands/status/surfaces parse from TOML.
+- SDK exports typed contribution structs.
+- Pkl schema validates the envelope.
+- Tests cover Reader delegated surface and host-rendered list primitive shape.
+
+## Links
+
+- [[0.25-roadmap-extension-surfaces]]
+- [[terminal-background-session-visibility-104]]
+- [[resource-open-host-action-83]]

--- a/docs/design/resource-open-host-action-83.md
+++ b/docs/design/resource-open-host-action-83.md
@@ -1,0 +1,94 @@
+---
+title: resource.open@1 HostAction (#83)
+status: exploring
+tags: [0.25, host-actions, resources, routing, viewer]
+---
+
+# resource.open@1 HostAction (#83)
+
+## Problem
+
+Extensions and agents need to request “open this resource for the operator” without embedding app-specific routing logic.
+
+Reader should not decide:
+
+```text
+markdown -> Flynt
+code -> Zed
+ebook -> Bookokrat
+```
+
+That belongs to the host because it depends on installed apps, active surfaces, workspace trust, operator policy, and runtime mode.
+
+## Goal
+
+Define `resource.open@1` as a semantic HostAction:
+
+```json
+{
+  "id": "open-resource",
+  "type": "resource.open@1",
+  "params": {
+    "uri": "file:///workspace/docs/architecture.md",
+    "intent": "view",
+    "kind": "markdown",
+    "placement": "main_tab",
+    "reuse_key": "docs/architecture.md",
+    "title": "Architecture"
+  }
+}
+```
+
+## Proposed params
+
+- `uri`: initially `file://`; future `omegon://` and `https://` optional.
+- `intent`: `view | edit | read | inspect`.
+- `kind`: `markdown | code | text | diagram | image | ebook | pdf | directory | unknown`.
+- `placement`: `main_tab | side_pane | editor | external | default`.
+- `reuse_key`: optional stable host reuse key.
+- `title`: optional display title.
+
+## Proposed result
+
+- `resource_id`
+- `backend`: `flynt | zed | terminal.create@1/bookokrat | system | built_in`
+- `actual_placement`
+- `handle`
+- `warnings`
+
+## Decisions
+
+### Decision: Route through HostAction policy/executor framework
+
+`resource.open@1` should use the same parse/validate/manifest/runtime/approval pipeline as `terminal.create@1`.
+
+### Decision: Do not make Reader a router
+
+Reader may emit `resource.open@1` or declare a delegated reader surface, but host chooses the backend.
+
+## Dependencies
+
+- [[extension-ui-contributions-101]] for surface vocabulary and delegated surfaces.
+- [[terminal-background-session-visibility-104]] for honest terminal fallback visibility.
+- [[acp-terminal-delegation-87]] for Flynt/native host placement if ACP client is available.
+
+## Open questions
+
+- [assumption] `file://` is enough for the first slice.
+- Should edit intent require stricter approval than view/read intent?
+- Should markdown default to Flynt only when Flynt is connected, or can standalone Omegon provide a built-in markdown view?
+- How should path traversal/trust boundaries be enforced for file URIs?
+
+## Acceptance
+
+- SDK exposes typed `resource.open@1` params/result.
+- Manifest policy can allow/deny resource open actions.
+- Host validates file URI trust boundary before opening.
+- At least markdown/text/code kinds produce deterministic routed or fallback outcomes.
+- Reader can request a resource open without knowing Flynt/Zed routing rules.
+
+## Links
+
+- [[0.25-roadmap-extension-surfaces]]
+- [[terminal-background-session-visibility-104]]
+- [[extension-ui-contributions-101]]

--- a/docs/design/sdk-lockstep-contract-102.md
+++ b/docs/design/sdk-lockstep-contract-102.md
@@ -1,0 +1,70 @@
+---
+title: SDK Lockstep Contract (#102)
+status: exploring
+tags: [sdk, contract, 0.25, extensions, python, typescript]
+---
+
+# SDK Lockstep Contract (#102)
+
+## Problem
+
+Rust, Python, and TypeScript extension SDKs can drift silently. Recent examples include stale TypeScript declarations and Python defaults lagging the host contract.
+
+## Goal
+
+Publish a canonical SDK contract artifact owned by the Rust SDK and consumed/validated by downstream SDK ports.
+
+## Candidate artifact
+
+```text
+core/crates/omegon-extension/schema/sdk-contract.json
+```
+
+or:
+
+```text
+core/crates/omegon-extension/schema/sdk-contract.pkl
+```
+
+## Contract contents
+
+- SDK contract version
+- protocol versions
+- RPC methods
+- tool definition schema
+- tool result schema
+- error codes
+- capability flags
+- manifest schema fragments
+- HostAction schemas
+- UI contribution schemas
+- resource/open schemas after #83
+
+## Decisions
+
+### Decision: Rust SDK remains canonical until extraction
+
+Downstream Python/TypeScript SDKs validate against Rust-owned contract data.
+
+### Decision: Do not extract repo before contract exists
+
+This issue blocks [[sdk-repo-extraction-103]].
+
+## Open questions
+
+- [assumption] JSON Schema is better for Python/TypeScript validation; Pkl remains useful for host config validation.
+- Should SDK ports generate types or validate handwritten types?
+- What version granularity: `0.25`, `0.25.0`, or independent `contract_version = 1`?
+
+## Acceptance
+
+- Rust SDK exports a versioned contract artifact.
+- Rust tests assert artifact matches current SDK constants/types where practical.
+- Python/TypeScript SDK repos can validate their exposed constants/types against it.
+- Release checklist requires contract update/check for SDK changes.
+
+## Links
+
+- [[0.25-roadmap-extension-surfaces]]
+- [[extension-ui-contributions-101]]
+- [[sdk-repo-extraction-103]]

--- a/docs/design/sdk-repo-extraction-103.md
+++ b/docs/design/sdk-repo-extraction-103.md
@@ -1,0 +1,59 @@
+---
+title: Standalone Rust Extension SDK Repo (#103)
+status: seed
+tags: [sdk, repo, extraction, extensions]
+---
+
+# Standalone Rust Extension SDK Repo (#103)
+
+## Problem
+
+`omegon-extension` is becoming the public SDK contract for extension authors and downstream SDK ports, but it still lives inside the Omegon monorepo.
+
+## Goal
+
+Eventually extract it to:
+
+```text
+styrene-lab/omegon-extension
+```
+
+without breaking first-party extensions or downstream SDKs.
+
+## Dependency chain
+
+This is blocked on [[sdk-lockstep-contract-102]].
+
+Recommended sequence:
+
+1. Stabilize 0.25 UI/resource schemas inside the monorepo.
+2. Publish SDK contract artifact.
+3. Make Python/TypeScript ports validate against contract.
+4. Use example extensions as conformance fixtures.
+5. Extract Rust SDK repo.
+6. Update Omegon and first-party extensions to depend on the standalone crate/tag.
+
+## Decisions
+
+### Decision: No big-bang extraction
+
+Do not move the SDK before contract validation exists. Repo extraction without lockstep would amplify drift.
+
+## Open questions
+
+- [assumption] Crate version remains aligned with Omegon through 0.x.
+- Should the standalone SDK publish independently or tag lockstep with host releases?
+- How do bundled examples consume local path dependencies during host development?
+- Which CI owns cross-repo conformance after extraction?
+
+## Acceptance
+
+- Standalone repo exists with history or clean import.
+- Omegon depends on the standalone crate without losing local development ergonomics.
+- First-party extensions build against the standalone crate.
+- Downstream SDK ports validate against the same contract artifact.
+
+## Links
+
+- [[0.25-roadmap-extension-surfaces]]
+- [[sdk-lockstep-contract-102]]

--- a/docs/design/terminal-background-session-visibility-104.md
+++ b/docs/design/terminal-background-session-visibility-104.md
@@ -1,0 +1,76 @@
+---
+title: Terminal Background Session Visibility (#104)
+status: exploring
+tags: [0.25, terminal, host-actions, tui, reader]
+---
+
+# Terminal Background Session Visibility (#104)
+
+## Problem
+
+`terminal.create@1` can create an Omegon-owned `portable_pty` background session, but standalone Omegon TUI currently gives the operator no practical way to inspect, tail, attach to, or stop that session.
+
+For `omegon-reader`, this means the HostAction succeeds but the operator cannot read the spawned reader output.
+
+## Goal
+
+Make `terminal.create@1` fallback sessions visible and actionable in standalone Omegon TUI.
+
+## Desired first slice
+
+When a HostAction returns:
+
+```json
+{
+  "type": "terminal.create@1",
+  "actual_placement": "background_session",
+  "terminal_id": "..."
+}
+```
+
+Omegon should expose at least one usable affordance:
+
+- visible `terminal_id`
+- transcript path or transcript tail
+- exact command to inspect/tail/stop the session from the TUI
+- explicit degraded placement warning (`side_pane -> background_session`)
+
+## Better slice
+
+Add a TUI terminal sessions panel/list, including:
+
+- active sessions
+- terminal IDs/titles
+- latest transcript tail
+- stop action
+- attach/read affordance
+
+## Decisions
+
+### Decision: Standalone fallback remains required even with ACP/Flynt
+
+ACP/Flynt terminal delegation (#87) is not a replacement for standalone visibility. If Omegon creates a background session, Omegon must make it inspectable.
+
+### Decision: Be honest about placement degradation
+
+A degraded `side_pane` request must not pretend a visual side pane opened. The result card/panel must show the actual placement.
+
+## Open questions
+
+- [assumption] Existing terminal session registry already has enough transcript/tail state to expose in the TUI.
+- Is the first visible surface an expanded HostAction result card, a terminal panel, or both?
+- Should `terminal_id` be clickable/selectable in Slim mode?
+- How do we avoid flooding the conversation with live terminal output?
+
+## Acceptance
+
+- Running `omegon-reader reader_open execute=true` in standalone Omegon TUI yields a visible reader/terminal affordance.
+- The operator can inspect output without leaving Omegon.
+- The result clearly states actual placement and degradation warning.
+- No Flynt dependency is required.
+
+## Links
+
+- [[0.25-roadmap-extension-surfaces]]
+- [[acp-terminal-delegation-87]]
+- [[extension-ui-contributions-101]]

--- a/docs/design/tts-agent-mode-100.md
+++ b/docs/design/tts-agent-mode-100.md
@@ -1,0 +1,55 @@
+---
+title: TTS Agent Mode (#100)
+status: exploring
+tags: [0.25, voice, tts, agent-ux]
+---
+
+# TTS Agent Mode (#100)
+
+## Problem
+
+`omegon-voice` can speak using Piper/TTS tools, but agent-mode spoken UX is not deterministic. Operators can enable spoken cues, yet subsequent agent turns may answer only in text or report audio status out of sync with playback.
+
+## Goal
+
+Define a deterministic host/agent behavior contract for short spoken status cues.
+
+## Desired behavior
+
+When spoken status cues are enabled:
+
+- Short operational status may be spoken.
+- Long answers remain text-first in TUI.
+- Agent speaks short handoff cues for long answers, not full content.
+- Failures can produce short failure cues.
+- Text and audio timing language must be honest.
+
+## Decisions
+
+### Decision: TTS agent mode depends on #98
+
+Do not define agent cue behavior until voice/TTS lifecycle metadata is settled.
+
+### Decision: Never speak sensitive or high-density content by default
+
+Do not speak code, logs, tables, URLs, hashes, secrets, or long answers.
+
+## Open questions
+
+- [assumption] A session-level state can tell the agent spoken cues are active.
+- Where should the active TTS mode live: host status, memory/session metadata, skill state, or extension status?
+- Should cue selection be prompt-instruction based, tool-policy based, or explicit host automation?
+- How do we prevent repeated/annoying spoken cues during rapid tool loops?
+
+## Acceptance
+
+- Session state exposes `spoken_status_cues`, voice profile, and backend.
+- Agent consistently uses `voice_speak_async` or equivalent for short cues when active.
+- Long answers are not spoken in full.
+- Playback timing language distinguishes queued vs completed audio.
+- TTS mode is visible/auditable in the TUI or session details.
+
+## Links
+
+- [[0.25-roadmap-extension-surfaces]]
+- [[voice-control-metadata-98]]

--- a/docs/design/voice-control-metadata-98.md
+++ b/docs/design/voice-control-metadata-98.md
@@ -1,0 +1,68 @@
+---
+title: Voice Control Metadata and TTS Lifecycle (#98)
+status: exploring
+tags: [0.25, voice, tts, tui, metadata]
+---
+
+# Voice Control Metadata and TTS Lifecycle (#98)
+
+## Problem
+
+`omegon-voice` emits richer `voice/transcription` metadata such as radio cues and session-close requests, but Omegon currently treats the event mostly as prompt text.
+
+The host needs deliberate semantics for:
+
+- `radio_cue`
+- `end_of_turn`
+- `close_session_requested`
+- TTS playback lifecycle
+
+## Goal
+
+Consume voice control metadata without submitting cue words as literal prompt text, and define host-visible TTS lifecycle events.
+
+## Event fields
+
+Example:
+
+```json
+{
+  "text": "Assess this current directory",
+  "duration_s": 3.2,
+  "radio_cue": "over",
+  "end_of_turn": true,
+  "close_session_requested": false
+}
+```
+
+`over_and_out` should submit the normalized prompt, then close the voice session through an explicit host/extension control path.
+
+## Decisions
+
+### Decision: Cue words are metadata, not prompt text
+
+If the extension recognized `over` or `over and out`, host must not re-add those cue words to the submitted prompt.
+
+### Decision: Voice state remains extension-reported
+
+Host does not infer microphone or playback truth from OS indicators. Extension emits lifecycle state; host displays/acts on it.
+
+## Open questions
+
+- [assumption] `omegon-voice` strips cue words from `text` before emission.
+- Should `close_session_requested` trigger `voice_session_stop` directly, queue a tool call, or surface a deterministic operator-visible stop action?
+- Should `duration_s` and radio cue metadata be stored in conversation details, audit log, or only trace logs?
+- Which TTS lifecycle states are required: `queued`, `speaking`, `interrupted`, `completed`, `failed`?
+
+## Acceptance
+
+- Host preserves voice metadata alongside visible prompt submission.
+- `over` submits normally and keeps session open.
+- `over_and_out` requests/executes voice session closure after prompt acceptance.
+- Cue words are never appended to submitted text.
+- TTS lifecycle has a documented state model.
+
+## Links
+
+- [[0.25-roadmap-extension-surfaces]]
+- [[tts-agent-mode-100]]

--- a/openspec/changes/0.25-extension-surfaces/design.md
+++ b/openspec/changes/0.25-extension-surfaces/design.md
@@ -1,0 +1,24 @@
+# 0.25 Extension Surfaces Design
+
+## Overview
+
+This change captures the 0.25 planning map. It does not implement runtime behavior directly; implementation proceeds in issue-specific branches/changes.
+
+## Design nodes
+
+- `docs/design/0.25-roadmap-extension-surfaces.md`
+- `docs/design/extension-ui-contributions-101.md`
+- `docs/design/terminal-background-session-visibility-104.md`
+- `docs/design/resource-open-host-action-83.md`
+- `docs/design/acp-terminal-delegation-87.md`
+- `docs/design/voice-control-metadata-98.md`
+- `docs/design/tts-agent-mode-100.md`
+- `docs/design/sdk-lockstep-contract-102.md`
+- `docs/design/sdk-repo-extraction-103.md`
+
+## Decisions
+
+- Treat #101, #104, and #83 as core 0.25.0 candidates.
+- Treat #87 as stretch/adjacent unless Flynt terminal delegation becomes required for 0.25.0.
+- Treat #98/#100 as 0.25.x voice UX unless release scope expands.
+- Treat #102/#103 as SDK stabilization after schema settles, with #103 blocked on #102.

--- a/openspec/changes/0.25-extension-surfaces/proposal.md
+++ b/openspec/changes/0.25-extension-surfaces/proposal.md
@@ -1,0 +1,28 @@
+# 0.25 Extension Surfaces Roadmap
+
+## Intent
+
+Coordinate the 0.25 feature line around extension-declared operator surfaces, visible HostAction fallbacks, semantic resource opening, and SDK contract stabilization.
+
+## Scope
+
+Core 0.25.0 candidates:
+
+- #101 declarative extension UI contributions
+- #104 visible standalone `terminal.create@1` background sessions
+- #83 semantic `resource.open@1` HostAction
+
+Stretch/adjacent:
+
+- #87 ACP terminal delegation
+- #98 voice control metadata and TTS lifecycle
+- #100 TTS agent mode
+- #102 SDK lockstep contract
+- #103 standalone SDK extraction
+
+## Success criteria
+
+- Design nodes exist for each open feature issue.
+- Dependencies and ordering are explicit.
+- Initial #101 schema work is isolated from patch-release lines.
+- Each implementation slice can become a PR with focused validation.

--- a/openspec/changes/0.25-extension-surfaces/specs/extensions/roadmap.md
+++ b/openspec/changes/0.25-extension-surfaces/specs/extensions/roadmap.md
@@ -1,0 +1,19 @@
+# 0.25 Extension Surfaces — Delta Spec
+
+## ADDED Requirements
+
+### Requirement: Roadmap identifies ordered feature lanes
+
+The 0.25 planning artifacts SHALL identify ordered implementation lanes for extension UI contributions, visible terminal fallback sessions, semantic resource opens, ACP terminal delegation, voice UX, and SDK contract stabilization.
+
+#### Scenario: Core 0.25 features are discoverable
+Given the roadmap exists
+When an operator reviews 0.25 planning
+Then #101, #104, and #83 are listed as core 0.25.0 candidates
+And dependencies between them are explicit
+
+#### Scenario: Deferred SDK extraction is marked blocked
+Given SDK extraction is listed
+When an operator reviews its design node
+Then it identifies the SDK lockstep contract as a prerequisite
+And it does not recommend big-bang extraction

--- a/openspec/changes/0.25-extension-surfaces/tasks.md
+++ b/openspec/changes/0.25-extension-surfaces/tasks.md
@@ -10,6 +10,6 @@
 ## 2. Milestone follow-up
 <!-- specs: extensions/roadmap -->
 
-- [ ] 2.1 Assign #104, #83, and optionally #87 to milestone 0.25.0.
-- [ ] 2.2 Decide whether #98/#100 belong to 0.25.0 or 0.25.x.
-- [ ] 2.3 Decide whether #102 starts in 0.25.0 or after #101/#83 schema stabilization.
+- [x] 2.1 Assign #104, #83, and optionally #87 to milestone 0.25.0.
+- [x] 2.2 Decide whether #98/#100 belong to 0.25.0 or 0.25.x.
+- [x] 2.3 Decide whether #102 starts in 0.25.0 or after #101/#83 schema stabilization.

--- a/openspec/changes/0.25-extension-surfaces/tasks.md
+++ b/openspec/changes/0.25-extension-surfaces/tasks.md
@@ -1,0 +1,15 @@
+# 0.25 Extension Surfaces Tasks
+
+## 1. Planning artifacts
+<!-- specs: extensions/roadmap -->
+
+- [x] 1.1 Create roadmap design node for the 0.25 feature line.
+- [x] 1.2 Create design nodes for #101, #104, #83, #87, #98, #100, #102, and #103.
+- [x] 1.3 Create OpenSpec planning change linking the roadmap and design nodes.
+
+## 2. Milestone follow-up
+<!-- specs: extensions/roadmap -->
+
+- [ ] 2.1 Assign #104, #83, and optionally #87 to milestone 0.25.0.
+- [ ] 2.2 Decide whether #98/#100 belong to 0.25.0 or 0.25.x.
+- [ ] 2.3 Decide whether #102 starts in 0.25.0 or after #101/#83 schema stabilization.

--- a/openspec/changes/extension-operator-surface-contributions/design.md
+++ b/openspec/changes/extension-operator-surface-contributions/design.md
@@ -1,0 +1,52 @@
+# Design: Extension Operator Surface Contributions
+
+Canonical design node: `docs/design/extension-operator-surface-contributions.md`.
+
+## Architecture
+
+```text
+Extension manifest envelope
+  -> runtime ui/list_contributions
+  -> host validation and namespace resolution
+  -> accepted contribution registry
+  -> host/Cockpit/TUI/Flynt render or route contributions
+```
+
+## Contribution vocabulary
+
+MVP contribution kinds:
+
+- `command`
+- `status_item`
+- `surface`
+
+Surface contributions include:
+
+- `rendering = delegated | host`
+- `surface_type`
+- `preferred_placements`
+
+Reader uses delegated rendering with `surface_type = document_reader`.
+Scratchpad uses host rendering with `surface_type = primitive_view` and
+`view.primitive = list`.
+
+## Host validation
+
+Runtime contributions must not exceed the manifest envelope. The host validates:
+
+- namespace
+- contribution kind
+- command ids/slash aliases/tools
+- status refresh tool and minimum interval
+- surface ids/types/rendering/preferred placements
+- primitive view schema for host-rendered surfaces
+- tool ownership
+
+Invalid contributions are rejected with diagnostics; valid contributions are
+stored in a registry.
+
+## Safety
+
+Extensions never draw directly into the terminal. Host-rendered primitive views
+use blessed schemas; delegated surfaces go through host-selected placement and
+HostAction policy.

--- a/openspec/changes/extension-operator-surface-contributions/proposal.md
+++ b/openspec/changes/extension-operator-surface-contributions/proposal.md
@@ -1,0 +1,31 @@
+# Proposal: Extension Operator Surface Contributions
+
+## Intent
+
+Add a declarative extension contribution surface for operator-facing UX:
+commands, passive status items, and host-managed surfaces. Reader is the primary
+MVP dogfood target and Scratchpad is the primitive host-rendered smoke target.
+
+## Why
+
+Extensions currently expose tools and HostActions, but not discoverable operator
+UX. Reader needs host-owned command/status/surface affordances without directly
+drawing into the terminal or mutating host UI registries.
+
+## Scope
+
+First implementation track:
+
+- Add SDK/protocol types for UI contribution declarations.
+- Add manifest envelope parsing for Reader-style command/status/surface entries.
+- Add runtime `ui/list_contributions` response shape.
+- Add host validation/registry design for accepted contributions.
+- Keep rendering and command routing as later slices unless explicitly pulled in.
+
+## Non-goals
+
+- No raw extension terminal drawing.
+- No arbitrary ANSI/HTML/JS rendering.
+- No direct keybinding install.
+- No guaranteed side pane.
+- No automatic HostAction execution outside existing policy/approval paths.

--- a/openspec/changes/extension-operator-surface-contributions/specs/extensions/operator-surface-contributions.md
+++ b/openspec/changes/extension-operator-surface-contributions/specs/extensions/operator-surface-contributions.md
@@ -1,0 +1,63 @@
+# extensions/operator-surface-contributions — Delta Spec
+
+## ADDED Requirements
+
+### Requirement: UI contribution capability defaults off
+
+Extensions SHALL only participate in operator-surface contribution discovery when
+they explicitly declare `ui_contributions = true`.
+
+#### Scenario: Legacy extension has no UI contributions
+Given an extension capability payload omits `ui_contributions`
+When the host decodes capabilities
+Then `ui_contributions` is false
+And the host does not call `ui/list_contributions`
+
+### Requirement: Runtime contributions stay within manifest envelope
+
+The host SHALL reject runtime UI contributions that exceed the extension's
+manifest-declared envelope.
+
+#### Scenario: Runtime command not in manifest is rejected
+Given a manifest declares only a `reader` command contribution with id `status`
+When `ui/list_contributions` returns a command id `open`
+Then the host rejects the `open` contribution
+And records a diagnostic explaining that the command exceeds the manifest envelope
+
+### Requirement: Reader can declare delegated document surface
+
+Reader SHALL be able to declare a delegated `document_reader` surface with host
+selected placement.
+
+#### Scenario: Reader declares delegated document reader surface
+Given Reader declares `ui_contributions = true`
+And the manifest includes a surface with `surface_type = document_reader`
+And `rendering = delegated`
+When the host validates matching runtime contributions
+Then the Reader surface is accepted
+And preferred placements are preserved in order
+
+### Requirement: Simple extensions can declare host-rendered primitive list surface
+
+Simple extensions SHALL be able to declare a host-rendered `primitive_view` list
+surface without owning UI rendering.
+
+#### Scenario: Scratchpad declares host-rendered list surface
+Given Scratchpad declares `ui_contributions = true`
+And the manifest includes `surface_type = primitive_view`
+And `rendering = host`
+And `view.primitive = list`
+When runtime contributions match the manifest envelope
+Then the host accepts the surface
+And marks rendering ownership as host
+
+### Requirement: Raw drawing remains unsupported
+
+Extensions SHALL NOT contribute raw terminal drawing, arbitrary ANSI, arbitrary
+HTML/JS, or direct keybindings in the MVP.
+
+#### Scenario: Raw drawing contribution is rejected
+Given an extension returns a contribution with kind `raw_terminal`
+When the host validates runtime contributions
+Then the contribution is rejected
+And no host UI registry entry is created

--- a/openspec/changes/extension-operator-surface-contributions/tasks.md
+++ b/openspec/changes/extension-operator-surface-contributions/tasks.md
@@ -1,0 +1,52 @@
+# Tasks: Extension Operator Surface Contributions
+
+## 1. SDK/protocol schema
+<!-- specs: extensions/operator-surface-contributions -->
+
+- [ ] 1.1 Add `ui_contributions` capability defaulting false.
+- [ ] 1.2 Add SDK structs for `UiContributionSet`, namespace, commands, status items, and surfaces.
+- [ ] 1.3 Add delegated Reader JSON round-trip test.
+- [ ] 1.4 Add host-rendered Scratchpad list JSON round-trip test.
+
+## 2. Manifest envelope parsing
+<!-- specs: extensions/operator-surface-contributions -->
+
+- [ ] 2.1 Parse `[ui]` namespace/description.
+- [ ] 2.2 Parse `[[ui.commands]]` entries.
+- [ ] 2.3 Parse `[[ui.status_items]]` entries.
+- [ ] 2.4 Parse `[[ui.surfaces]]` entries with rendering and placements.
+- [ ] 2.5 Add TOML tests for Reader manifest envelope.
+- [ ] 2.6 Add TOML tests for Scratchpad host-rendered list envelope.
+
+## 3. Runtime discovery and validation
+<!-- specs: extensions/operator-surface-contributions -->
+
+- [ ] 3.1 Call `ui/list_contributions` only when capability is enabled.
+- [ ] 3.2 Validate runtime contributions against manifest envelope.
+- [ ] 3.3 Validate tool ownership.
+- [ ] 3.4 Reject raw drawing/unsupported contribution kinds.
+- [ ] 3.5 Store accepted contributions in a host registry.
+- [ ] 3.6 Expose accepted/rejected diagnostics.
+
+## 4. Reader command/status MVP
+<!-- specs: extensions/operator-surface-contributions -->
+
+- [ ] 4.1 Register accepted Reader command contributions into namespaced slash routing.
+- [ ] 4.2 Route Reader status command to `reader_status`.
+- [ ] 4.3 Route Reader open command to `reader_open` with placement args.
+- [ ] 4.4 Preserve deterministic namespace conflict fallback.
+
+## 5. Host-rendered primitive list MVP
+<!-- specs: extensions/operator-surface-contributions -->
+
+- [ ] 5.1 Define minimal `list` primitive schema.
+- [ ] 5.2 Render host-owned list from extension data tool response.
+- [ ] 5.3 Support title/subtitle/badge field interpolation.
+- [ ] 5.4 Support one host-owned action routed to an extension tool.
+
+## 6. Validation
+<!-- specs: extensions/operator-surface-contributions -->
+
+- [ ] 6.1 Run `cargo test -p omegon-extension ui_contribution -- --nocapture`.
+- [ ] 6.2 Run `cargo test -p omegon operator_surface -- --nocapture`.
+- [ ] 6.3 Run `just lint`.

--- a/pkl/ExtensionManifest.pkl
+++ b/pkl/ExtensionManifest.pkl
@@ -87,7 +87,81 @@ class McpConfig {
   serve_subcommand: String = "serve"
 }
 
-/// Widget declaration — UI surface exposed by the extension.
+
+/// Capability declarations for extension features.
+class CapabilitiesConfig {
+  tools: Boolean = true
+  widgets: Boolean = false
+  mind: Boolean = false
+  vox: Boolean = false
+  resources: Boolean = false
+  prompts: Boolean = false
+  sampling: Boolean = false
+  elicitation: Boolean = false
+  streaming: Boolean = false
+  voice: Boolean = false
+  ui_contributions: Boolean = false
+  host_actions: Boolean = false
+  host_action_execution: Boolean = false
+}
+
+/// Declarative operator-surface contribution envelope.
+class UiConfig {
+  namespace: String(matches(Regex(#"^[a-z0-9][a-z0-9_-]*$"#)))
+  description: String = ""
+  commands: Listing<UiCommand>?
+  status_items: Listing<UiStatusItem>?
+  surfaces: Listing<UiSurface>?
+}
+
+class UiCommand {
+  id: String(length > 0)
+  title: String(length > 0)
+  slash: String(length > 0)
+  tool: String(length > 0)
+}
+
+class UiStatusItem {
+  id: String(length > 0)
+  title: String(length > 0)
+  refresh_tool: String(length > 0)
+  interval_ms: Int(this >= 5000) = 30000
+  template: String(length > 0)
+}
+
+class UiSurface {
+  id: String(length > 0)
+  title: String(length > 0)
+  surface_type: String(length > 0)
+  rendering: "host"|"delegated"
+  preferred_placements: Listing<"side_pane"|"bottom_pane"|"modal"|"new_tab"|"external"|"background_session">?
+  open_tool: String?
+  status_tool: String?
+  view: UiPrimitiveView?
+}
+
+class UiPrimitiveView {
+  primitive: "list"
+  data_tool: String(length > 0)
+  item: UiListItemTemplate?
+  actions: Listing<UiPrimitiveAction>?
+}
+
+class UiListItemTemplate {
+  title: String?
+  subtitle: String?
+  badge: String?
+}
+
+class UiPrimitiveAction {
+  id: String(length > 0)
+  title: String(length > 0)
+  tool: String(length > 0)
+  args: Dynamic?
+  confirm: Boolean = false
+}
+
+/// Widget declaration — legacy UI surface exposed by the extension.
 class WidgetConfig {
   /// Human-readable label for the tab or modal.
   label: String(length > 0)
@@ -130,6 +204,12 @@ secrets: SecretsConfig?
 /// MCP capability declaration (optional).
 /// If present, this extension supports remote access via MCP.
 mcp: McpConfig?
+
+/// Capability declarations for extension features.
+capabilities: CapabilitiesConfig?
+
+/// Declarative operator-surface contribution envelope.
+ui: UiConfig?
 
 /// Configuration field declarations, keyed by field name.
 /// The host resolves values from per-extension config and delivers


### PR DESCRIPTION
## Summary

Starts the 0.25 extension-surface line for #101 by adding the schema/protocol substrate for declarative extension UI contributions.

## What changed

- Adds `capabilities.ui_contributions` with legacy default `false`.
- Exports typed UI contribution structs from `omegon-extension`.
- Adds `[ui]` manifest parsing for commands, status items, delegated surfaces, and host-rendered primitive list surfaces.
- Adds Pkl schema support for UI contribution declarations.
- Adds 0.25 roadmap/design nodes for related upstream issues (#101, #104, #83, #87, #98, #100, #102, #103).
- Assigns the related upstream issues to milestone `0.25.0`.

## Validation

- `cargo test -p omegon-extension ui_contribution -- --nocapture`
- `cargo test -p omegon parse_ui_contributions_manifest -- --nocapture`
- `just lint`

## Notes

This PR intentionally does not render/register contributed UI yet. It establishes the schema and parser contract first; runtime registration and TUI rendering should follow in later focused PRs.
