### PR TITLE
fix(voice): preserve control metadata and lifecycle state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,16 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [Semantic V
 
 ## [Unreleased]
 
+## [0.24.7] - 2026-05-27
+
 ### Changed
 
 - Preserve voice transcription control metadata (`radio_cue`, `end_of_turn`, `close_session_requested`, and utterance duration) through host prompt routing so radio cues can drive lifecycle behavior without leaking into prompt text.
 - Represent spoken-output lifecycle via status-only `voice/tts_state` notifications, independent from microphone capture state, and deterministically handle `over_and_out` close intent after prompt acceptance; close-session control requires both `radio_cue=over_and_out` and `close_session_requested=true`.
+
+### Fixed
+
+- Stop lifecycle read-model snapshots from rewriting `ai/lifecycle/state.json`, including idempotent OpenSpec progress sync timestamp churn, so dashboard/status reads do not dirty downstream agents' worktrees.
 
 ## [0.24.6] - 2026-05-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [Semantic V
 ### Changed
 
 - Preserve voice transcription control metadata (`radio_cue`, `end_of_turn`, `close_session_requested`, and utterance duration) through host prompt routing so radio cues can drive lifecycle behavior without leaking into prompt text.
-- Represent spoken-output lifecycle via status-only `voice/tts_state` notifications, independent from microphone capture state, and deterministically handle `over_and_out` close intent after prompt acceptance.
+- Represent spoken-output lifecycle via status-only `voice/tts_state` notifications, independent from microphone capture state, and deterministically handle `over_and_out` close intent after prompt acceptance; close-session control requires both `radio_cue=over_and_out` and `close_session_requested=true`.
 
 ## [0.24.6] - 2026-05-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,11 +16,9 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [Semantic V
 
 ## [Unreleased]
 
-## [0.24.7] - 2026-05-26
+### Changed
 
-### Fixed
-
-- Preserve voice prompt origin metadata when queued voice transcriptions are drained after an active turn so follow-up turns remain attributed to voice instead of local TUI input.
+- Preserve voice transcription control metadata (`radio_cue`, `end_of_turn`, `close_session_requested`, and utterance duration) through host prompt routing so radio cues can drive lifecycle behavior without leaking into prompt text.
 
 ## [0.24.6] - 2026-05-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [Semantic V
 ### Changed
 
 - Preserve voice transcription control metadata (`radio_cue`, `end_of_turn`, `close_session_requested`, and utterance duration) through host prompt routing so radio cues can drive lifecycle behavior without leaking into prompt text.
+- Represent spoken-output lifecycle via status-only `voice/tts_state` notifications, independent from microphone capture state, and deterministically handle `over_and_out` close intent after prompt acceptance.
 
 ## [0.24.6] - 2026-05-26
 

--- a/core/crates/omegon-opsx/src/fsm.rs
+++ b/core/crates/omegon-opsx/src/fsm.rs
@@ -677,6 +677,9 @@ impl<S: StateStore> Lifecycle<S> {
             .iter_mut()
             .find(|c| c.name == name)
             .ok_or_else(|| OpsxError::NotFound(format!("change '{name}'")))?;
+        if change.tasks_total == total && change.tasks_done == done {
+            return Ok(());
+        }
         change.tasks_total = total;
         change.tasks_done = done;
         change.updated_at = iso_now();
@@ -1402,6 +1405,33 @@ mod tests {
             .unwrap();
         assert_eq!(change.tasks_total, 10);
         assert_eq!(change.tasks_done, 7);
+    }
+
+    #[test]
+    fn update_change_progress_is_idempotent_when_counts_do_not_change() {
+        let (_tmp, mut lc) = test_lifecycle();
+        lc.create_change("prog", "Progress", None).unwrap();
+        lc.update_change_progress("prog", 10, 7).unwrap();
+        let first_updated_at = lc
+            .state()
+            .changes
+            .iter()
+            .find(|c| c.name == "prog")
+            .unwrap()
+            .updated_at
+            .clone();
+
+        lc.update_change_progress("prog", 10, 7).unwrap();
+        let second_updated_at = lc
+            .state()
+            .changes
+            .iter()
+            .find(|c| c.name == "prog")
+            .unwrap()
+            .updated_at
+            .clone();
+
+        assert_eq!(first_updated_at, second_updated_at);
     }
 
     #[test]

--- a/core/crates/omegon/src/bus.rs
+++ b/core/crates/omegon/src/bus.rs
@@ -328,6 +328,11 @@ impl EventBus {
         self.tool_definitions_mode(false)
     }
 
+    pub fn has_tool(&self, tool_name: &str) -> bool {
+        self.tool_defs.iter().any(|(_, def)| def.name == tool_name)
+            || self.internal_tool_owners.contains_key(tool_name)
+    }
+
     /// Tool definitions with optional schema compaction for token efficiency.
     pub fn tool_definitions_mode(&self, compact: bool) -> Vec<ToolDefinition> {
         let disabled = self.disabled_tools.as_ref().and_then(|d| d.lock().ok());

--- a/core/crates/omegon/src/extensions/host_actions.rs
+++ b/core/crates/omegon/src/extensions/host_actions.rs
@@ -1653,6 +1653,14 @@ allowed = [{allowed}]
     #[test]
     fn terminal_create_side_pane_degradation_includes_inspection_hint() {
         let manifest = terminal_manifest(&["printf"], &["${workspace}"], &[]);
+        let terminal_name = format!(
+            "side-visible-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("clock after epoch")
+                .as_nanos()
+        );
         let outcome = process_host_action_candidate_with_approval_decision(
             json!({
                 "id": "open-side",
@@ -1662,7 +1670,8 @@ allowed = [{allowed}]
                     "command": "printf",
                     "args": ["side-visible"],
                     "cwd": ".",
-                    "placement": "side_pane"
+                    "placement": "side_pane",
+                    "name": terminal_name
                 }
             }),
             &manifest,

--- a/core/crates/omegon/src/extensions/voice_bridge.rs
+++ b/core/crates/omegon/src/extensions/voice_bridge.rs
@@ -142,6 +142,11 @@ fn transcription_params_to_event(
         return None;
     }
     let duration_s = params.get("duration_s").and_then(Value::as_f64);
+    let radio_cue = params.get("radio_cue").and_then(Value::as_str);
+    let end_of_turn = params.get("end_of_turn").and_then(Value::as_bool);
+    let close_session_requested = params
+        .get("close_session_requested")
+        .and_then(Value::as_bool);
     let utterance_id = params
         .get("utterance_id")
         .and_then(Value::as_str)
@@ -158,6 +163,10 @@ fn transcription_params_to_event(
             "utterance_id": utterance_id,
             "trust_level": "operator",
             "extension": extension_name,
+            "source_channel": "voice",
+            "radio_cue": radio_cue,
+            "end_of_turn": end_of_turn,
+            "close_session_requested": close_session_requested,
         }),
         caller_role: Some("edit".to_string()),
         source_user: None,
@@ -194,10 +203,34 @@ mod tests {
         assert_eq!(event.payload["utterance_id"], "u1");
         assert_eq!(event.payload["trust_level"], "operator");
         assert_eq!(event.payload["extension"], "omegon-voice");
+        assert_eq!(event.payload["source_channel"], "voice");
         assert_eq!(event.caller_role.as_deref(), Some("edit"));
         assert_eq!(event.source_user, None);
         assert_eq!(event.source_channel.as_deref(), Some("voice"));
         assert_eq!(event.source_thread, None);
+    }
+
+    #[test]
+    fn transcription_control_metadata_is_preserved() {
+        let event = voice_notification_to_event(&notification(
+            "voice/transcription",
+            json!({
+                "text": "assess this directory",
+                "duration_s": 2.1,
+                "utterance_id": "u2",
+                "radio_cue": "over",
+                "end_of_turn": true,
+                "close_session_requested": false
+            }),
+        ))
+        .expect("voice event");
+
+        assert_eq!(event.payload["text"], "assess this directory");
+        assert_eq!(event.payload["duration_s"], 2.1);
+        assert_eq!(event.payload["radio_cue"], "over");
+        assert_eq!(event.payload["end_of_turn"], true);
+        assert_eq!(event.payload["close_session_requested"], false);
+        assert_eq!(event.payload["source_channel"], "voice");
     }
 
     #[test]

--- a/core/crates/omegon/src/extensions/voice_bridge.rs
+++ b/core/crates/omegon/src/extensions/voice_bridge.rs
@@ -17,6 +17,15 @@ pub struct VoiceStateUpdate {
     pub mic_open: bool,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VoiceTtsUpdate {
+    pub extension: String,
+    pub state: String,
+    pub audio_output: bool,
+    pub backend: Option<String>,
+    pub voice: Option<String>,
+}
+
 /// Start a push-driven bridge for one voice-capable extension.
 pub fn start_voice_bridge(
     rx: mpsc::UnboundedReceiver<ExtensionNotification>,
@@ -47,6 +56,12 @@ pub fn start_voice_bridge_with_status(
                     if let Some(update) = voice_notification_to_state(&notification) {
                         if let Some(sink) = &status_sink {
                             sink.publish(update);
+                        }
+                        continue;
+                    }
+                    if let Some(update) = voice_notification_to_tts_state(&notification) {
+                        if let Some(sink) = &status_sink {
+                            sink.publish_tts(update);
                         }
                         continue;
                     }
@@ -104,6 +119,28 @@ impl VoiceStatusSink {
             .events_tx
             .send(AgentEvent::HarnessStatusChanged { status_json });
     }
+
+    pub fn publish_tts(&self, update: VoiceTtsUpdate) {
+        let status_json = match self.harness_status.lock() {
+            Ok(mut status) => {
+                status.voice_tts_state = Some(crate::status::VoiceTtsStatus {
+                    extension: update.extension,
+                    state: update.state,
+                    audio_output: update.audio_output,
+                    backend: update.backend,
+                    voice: update.voice,
+                });
+                serde_json::to_value(&*status).unwrap_or_default()
+            }
+            Err(err) => {
+                tracing::error!(error = %err, "failed to update voice TTS status");
+                return;
+            }
+        };
+        let _ = self
+            .events_tx
+            .send(AgentEvent::HarnessStatusChanged { status_json });
+    }
 }
 
 pub(crate) fn voice_notification_to_state(
@@ -121,6 +158,36 @@ pub(crate) fn voice_notification_to_state(
         extension: notification.extension_name.clone(),
         state: state.to_string(),
         mic_open,
+    })
+}
+
+pub(crate) fn voice_notification_to_tts_state(
+    notification: &ExtensionNotification,
+) -> Option<VoiceTtsUpdate> {
+    if notification.method != "voice/tts_state" {
+        return None;
+    }
+    let state = notification.params.get("state")?.as_str()?.trim();
+    if state.is_empty() {
+        return None;
+    }
+    let audio_output = notification.params.get("audio_output")?.as_bool()?;
+    Some(VoiceTtsUpdate {
+        extension: notification.extension_name.clone(),
+        state: state.to_string(),
+        audio_output,
+        backend: notification
+            .params
+            .get("backend")
+            .and_then(Value::as_str)
+            .filter(|value| !value.trim().is_empty())
+            .map(ToString::to_string),
+        voice: notification
+            .params
+            .get("voice")
+            .and_then(Value::as_str)
+            .filter(|value| !value.trim().is_empty())
+            .map(ToString::to_string),
     })
 }
 
@@ -267,6 +334,34 @@ mod tests {
     }
 
     #[test]
+    fn voice_tts_state_notification_becomes_status_update_without_prompt_event() {
+        let update = voice_notification_to_tts_state(&notification(
+            "voice/tts_state",
+            json!({
+                "state": "speaking",
+                "audio_output": true,
+                "backend": "macos",
+                "voice": "Reed (English (US))"
+            }),
+        ))
+        .expect("voice tts state");
+
+        assert_eq!(update.extension, "omegon-voice");
+        assert_eq!(update.state, "speaking");
+        assert!(update.audio_output);
+        assert_eq!(update.backend.as_deref(), Some("macos"));
+        assert_eq!(update.voice.as_deref(), Some("Reed (English (US))"));
+        assert!(
+            voice_notification_to_event(&notification(
+                "voice/tts_state",
+                json!({"state": "speaking", "audio_output": true}),
+            ))
+            .is_none(),
+            "voice tts state must not become a daemon prompt event"
+        );
+    }
+
+    #[test]
     fn voice_state_notification_becomes_status_update_without_prompt_event() {
         let update = voice_notification_to_state(&notification(
             "voice/state",
@@ -333,6 +428,26 @@ mod tests {
             AgentEvent::HarnessStatusChanged { status_json } => {
                 assert_eq!(status_json["voice_state"]["state"], "processing");
                 assert_eq!(status_json["voice_state"]["mic_open"], true);
+            }
+            other => panic!("unexpected event: {other:?}"),
+        }
+
+        sink.publish_tts(VoiceTtsUpdate {
+            extension: "omegon-voice".to_string(),
+            state: "speaking".to_string(),
+            audio_output: true,
+            backend: Some("macos".to_string()),
+            voice: Some("Reed".to_string()),
+        });
+
+        let stored = status.lock().unwrap().voice_tts_state.clone().unwrap();
+        assert_eq!(stored.extension, "omegon-voice");
+        assert_eq!(stored.state, "speaking");
+        assert!(stored.audio_output);
+        match events_rx.try_recv().expect("tts status event") {
+            AgentEvent::HarnessStatusChanged { status_json } => {
+                assert_eq!(status_json["voice_tts_state"]["state"], "speaking");
+                assert_eq!(status_json["voice_tts_state"]["audio_output"], true);
             }
             other => panic!("unexpected event: {other:?}"),
         }

--- a/core/crates/omegon/src/ipc/connection.rs
+++ b/core/crates/omegon/src/ipc/connection.rs
@@ -266,6 +266,7 @@ impl IpcConnection {
                             submitted_by: "ipc-controller".to_string(),
                             via: "ipc",
                             queue_mode: crate::tui::PromptQueueMode::InterruptAfterTurn,
+                            metadata: crate::tui::PromptMetadata::default(),
                         }))
                         .await
                         .is_ok();

--- a/core/crates/omegon/src/lifecycle/read_model.rs
+++ b/core/crates/omegon/src/lifecycle/read_model.rs
@@ -126,13 +126,6 @@ impl LifecycleReadHandle {
             changes.extend(spec::list_archived_changes(&self.repo_path));
         }
 
-        {
-            let mut opsx = self.opsx.lock().unwrap();
-            for change in &active_changes {
-                sync_opsx_change_from_info(&mut opsx, change)?;
-            }
-        }
-
         let opsx_states = self.opsx_states();
         let mut projected = Vec::new();
         for change in &changes {
@@ -312,8 +305,45 @@ mod tests {
             .unwrap();
         assert_eq!(snapshot.changes.len(), 1);
         assert_eq!(snapshot.changes[0].name, "snapshot-change");
-        assert_eq!(snapshot.changes[0].lifecycle_state, "specced");
+        assert_eq!(snapshot.changes[0].lifecycle_state, "specified");
         assert_eq!(snapshot.changes[0].file_stage, "specified");
+        assert!(
+            handle.opsx.lock().unwrap().state().changes.is_empty(),
+            "read-model snapshots must not write opsx state"
+        );
+    }
+
+    #[test]
+    fn openspec_snapshot_is_read_only_when_opsx_state_is_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = dir.path();
+        let change_dir = repo.join("openspec/changes/read-only");
+        fs::create_dir_all(change_dir.join("specs")).unwrap();
+        fs::write(
+            change_dir.join("proposal.md"),
+            "# Read Only
+",
+        )
+        .unwrap();
+        fs::write(
+            change_dir.join("tasks.md"),
+            "- [ ] pending
+",
+        )
+        .unwrap();
+
+        let provider = Arc::new(Mutex::new(LifecycleContextProvider::new(repo)));
+        let opsx = Arc::new(Mutex::new(
+            OpsxLifecycle::load(JsonFileStore::new(repo)).unwrap(),
+        ));
+        let handle = LifecycleReadHandle::new(provider, opsx, repo.to_path_buf());
+
+        let snapshot = handle
+            .openspec_snapshot(SnapshotOptions::default())
+            .unwrap();
+        assert_eq!(snapshot.changes.len(), 1);
+        assert_eq!(snapshot.changes[0].lifecycle_state, "proposed");
+        assert!(handle.opsx.lock().unwrap().state().changes.is_empty());
     }
 
     #[test]

--- a/core/crates/omegon/src/main.rs
+++ b/core/crates/omegon/src/main.rs
@@ -3914,12 +3914,13 @@ async fn run_interactive_command(cli: &Cli) -> anyhow::Result<()> {
         };
 
         let cmd = match cmd {
-            tui::TuiCommand::VoicePrompt { text, .. } => tui::TuiCommand::SubmitPrompt(tui::PromptSubmission {
+            tui::TuiCommand::VoicePrompt { text, metadata } => tui::TuiCommand::SubmitPrompt(tui::PromptSubmission {
                 text: format!("🎙 {}", text.trim()),
                 image_paths: Vec::new(),
                 submitted_by: "voice".to_string(),
                 via: "voice",
                 queue_mode: tui::PromptQueueMode::UntilReady,
+                metadata: tui::PromptMetadata { voice: Some(metadata) },
             }),
             other => other,
         };
@@ -4537,6 +4538,7 @@ async fn run_interactive_command(cli: &Cli) -> anyhow::Result<()> {
                                             submitted_by: "web-dashboard".to_string(),
                                             via: "websocket",
                                             queue_mode: crate::tui::PromptQueueMode::InterruptAfterTurn,
+                                            metadata: crate::tui::PromptMetadata::default(),
                                         })
                                     }
                                     web::WebCommand::SlashCommand {
@@ -4949,7 +4951,7 @@ async fn run_interactive_command(cli: &Cli) -> anyhow::Result<()> {
                 };
                 let via = control_surface_from_via(prompt.via);
 
-                runtime.enqueue_prompt(prompt.text, prompt.image_paths, actor, via, Some(match prompt.queue_mode {
+                runtime.enqueue_prompt(prompt.text, prompt.image_paths, actor, via, prompt.metadata, Some(match prompt.queue_mode {
                         crate::tui::PromptQueueMode::InterruptAfterTurn => QueueMode::InterruptAfterTurn,
                         crate::tui::PromptQueueMode::UntilReady => QueueMode::UntilReady,
                         crate::tui::PromptQueueMode::Immediate => QueueMode::Immediate,
@@ -5005,12 +5007,13 @@ async fn run_interactive_command(cli: &Cli) -> anyhow::Result<()> {
                                 };
 
                                 let cmd = match cmd {
-                                    tui::TuiCommand::VoicePrompt { text, .. } => tui::TuiCommand::SubmitPrompt(tui::PromptSubmission {
+                                    tui::TuiCommand::VoicePrompt { text, metadata } => tui::TuiCommand::SubmitPrompt(tui::PromptSubmission {
                                         text: format!("🎙 {}", text.trim()),
                                         image_paths: Vec::new(),
                                         submitted_by: "voice".to_string(),
                                         via: "voice",
                                         queue_mode: tui::PromptQueueMode::UntilReady,
+                                        metadata: tui::PromptMetadata { voice: Some(metadata) },
                                     }),
                                     other => other,
                                 };
@@ -5022,7 +5025,7 @@ async fn run_interactive_command(cli: &Cli) -> anyhow::Result<()> {
                                             label: prompt.submitted_by.clone(),
                                         };
                                         let via = control_surface_from_via(prompt.via);
-                                        runtime.enqueue_prompt(prompt.text, prompt.image_paths, actor, via, Some(match prompt.queue_mode {
+                                        runtime.enqueue_prompt(prompt.text, prompt.image_paths, actor, via, prompt.metadata, Some(match prompt.queue_mode {
                                             crate::tui::PromptQueueMode::InterruptAfterTurn => QueueMode::InterruptAfterTurn,
                                             crate::tui::PromptQueueMode::UntilReady => QueueMode::UntilReady,
                                             crate::tui::PromptQueueMode::Immediate => QueueMode::Immediate,
@@ -5330,13 +5333,14 @@ enum QueueMode {
     Immediate,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 struct PromptEnvelope {
     id: u64,
     text: String,
     image_paths: Vec<PathBuf>,
     submitted_by: RuntimeActor,
     via: ControlSurface,
+    metadata: tui::PromptMetadata,
     queue_mode: QueueMode,
 }
 
@@ -5349,7 +5353,7 @@ enum ActiveTurnPhase {
     },
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 struct ActiveTurnMeta {
     runtime_turn_id: u64,
     prompt: PromptEnvelope,
@@ -5632,6 +5636,7 @@ impl InteractiveRuntimeSupervisor {
         image_paths: Vec<PathBuf>,
         actor: RuntimeActor,
         via: ControlSurface,
+        metadata: tui::PromptMetadata,
         queue_mode: Option<QueueMode>,
     ) -> u64 {
         self.next_prompt_id += 1;
@@ -5642,6 +5647,7 @@ impl InteractiveRuntimeSupervisor {
             image_paths,
             submitted_by: actor,
             via,
+            metadata,
             queue_mode: queue_mode.unwrap_or(self.default_queue_mode),
         });
         prompt_id
@@ -8022,6 +8028,32 @@ mod tests {
         assert!(interactive_resume_mode(&cli).is_none());
     }
 
+    #[test]
+    fn interactive_runtime_supervisor_preserves_prompt_metadata() {
+        let mut supervisor = InteractiveRuntimeSupervisor::default();
+        let metadata = tui::PromptMetadata {
+            voice: Some(tui::VoicePromptMetadata {
+                event_id: "u-close".to_string(),
+                duration_s: Some(2.1),
+                radio_cue: Some("over_and_out".to_string()),
+                end_of_turn: Some(true),
+                close_session_requested: Some(true),
+            }),
+        };
+        supervisor.enqueue_prompt(
+            "🎙 stop listening".to_string(),
+            Vec::new(),
+            RuntimeActor::tui(),
+            ControlSurface::Tui,
+            metadata.clone(),
+            None,
+        );
+
+        let active = supervisor.maybe_start_next_turn().expect("active turn");
+        assert_eq!(active.prompt.metadata, metadata);
+    }
+
+    #[test]
     fn interactive_runtime_supervisor_starts_first_prompt_fifo() {
         let mut supervisor = InteractiveRuntimeSupervisor::default();
         supervisor.enqueue_prompt(
@@ -8029,6 +8061,7 @@ mod tests {
             Vec::new(),
             RuntimeActor::tui(),
             ControlSurface::Tui,
+            tui::PromptMetadata::default(),
             None,
         );
         supervisor.enqueue_prompt(
@@ -8036,6 +8069,7 @@ mod tests {
             Vec::new(),
             RuntimeActor::auspex(),
             ControlSurface::Ipc,
+            tui::PromptMetadata::default(),
             None,
         );
 
@@ -8058,6 +8092,7 @@ mod tests {
             Vec::new(),
             RuntimeActor::tui(),
             ControlSurface::Tui,
+            tui::PromptMetadata::default(),
             None,
         );
         supervisor.maybe_start_next_turn().expect("active turn");
@@ -8085,6 +8120,7 @@ mod tests {
             Vec::new(),
             RuntimeActor::tui(),
             ControlSurface::Tui,
+            tui::PromptMetadata::default(),
             None,
         );
         supervisor.maybe_start_next_turn().expect("active turn");
@@ -8105,6 +8141,7 @@ mod tests {
             Vec::new(),
             RuntimeActor::tui(),
             ControlSurface::Tui,
+            tui::PromptMetadata::default(),
             None,
         );
         supervisor.enqueue_prompt(
@@ -8112,6 +8149,7 @@ mod tests {
             vec![PathBuf::from("/tmp/paste.png")],
             RuntimeActor::auspex(),
             ControlSurface::Ipc,
+            tui::PromptMetadata::default(),
             None,
         );
 
@@ -8141,6 +8179,7 @@ mod tests {
             Vec::new(),
             RuntimeActor::tui(),
             ControlSurface::Tui,
+            tui::PromptMetadata::default(),
             None,
         );
         supervisor.enqueue_prompt(
@@ -8148,6 +8187,7 @@ mod tests {
             Vec::new(),
             RuntimeActor::auspex(),
             ControlSurface::Ipc,
+            tui::PromptMetadata::default(),
             None,
         );
 
@@ -8173,6 +8213,7 @@ mod tests {
             Vec::new(),
             RuntimeActor::tui(),
             ControlSurface::Tui,
+            tui::PromptMetadata::default(),
             None,
         );
         supervisor.enqueue_prompt(
@@ -8180,6 +8221,7 @@ mod tests {
             Vec::new(),
             RuntimeActor::auspex(),
             ControlSurface::Ipc,
+            tui::PromptMetadata::default(),
             None,
         );
         supervisor

--- a/core/crates/omegon/src/main.rs
+++ b/core/crates/omegon/src/main.rs
@@ -5355,11 +5355,10 @@ struct PromptEnvelope {
 
 impl PromptEnvelope {
     fn requests_voice_close(&self) -> bool {
-        self.metadata
-            .voice
-            .as_ref()
-            .and_then(|voice| voice.close_session_requested)
-            .unwrap_or(false)
+        self.metadata.voice.as_ref().is_some_and(|voice| {
+            voice.close_session_requested == Some(true)
+                && voice.radio_cue.as_deref() == Some("over_and_out")
+        })
     }
 }
 
@@ -8086,7 +8085,7 @@ mod tests {
     }
 
     #[test]
-    fn prompt_envelope_detects_voice_close_request() {
+    fn prompt_envelope_requires_over_and_out_for_voice_close_request() {
         let prompt = PromptEnvelope {
             id: 1,
             text: "🎙 stop listening".to_string(),
@@ -8105,6 +8104,20 @@ mod tests {
             queue_mode: QueueMode::UntilReady,
         };
         assert!(prompt.requests_voice_close());
+
+        let malformed_close = PromptEnvelope {
+            metadata: tui::PromptMetadata {
+                voice: Some(tui::VoicePromptMetadata {
+                    event_id: "u-close".to_string(),
+                    duration_s: None,
+                    radio_cue: Some("over".to_string()),
+                    end_of_turn: Some(true),
+                    close_session_requested: Some(true),
+                }),
+            },
+            ..prompt
+        };
+        assert!(!malformed_close.requests_voice_close());
     }
 
     #[test]

--- a/core/crates/omegon/src/main.rs
+++ b/core/crates/omegon/src/main.rs
@@ -4962,6 +4962,8 @@ async fn run_interactive_command(cli: &Cli) -> anyhow::Result<()> {
                 }
 
                 while let Some(active) = runtime.maybe_start_next_turn() {
+                    stop_voice_session_if_requested(&active.prompt, &runtime_state.bus, &events_tx)
+                        .await;
                     mark_interactive_session_busy(&agent.dashboard_handles, true);
 
                     let mut quit_after_turn = false;
@@ -5025,11 +5027,18 @@ async fn run_interactive_command(cli: &Cli) -> anyhow::Result<()> {
                                             label: prompt.submitted_by.clone(),
                                         };
                                         let via = control_surface_from_via(prompt.via);
-                                        runtime.enqueue_prompt(prompt.text, prompt.image_paths, actor, via, prompt.metadata, Some(match prompt.queue_mode {
+                                        let prompt_id = runtime.enqueue_prompt(prompt.text, prompt.image_paths, actor, via, prompt.metadata, Some(match prompt.queue_mode {
                                             crate::tui::PromptQueueMode::InterruptAfterTurn => QueueMode::InterruptAfterTurn,
                                             crate::tui::PromptQueueMode::UntilReady => QueueMode::UntilReady,
                                             crate::tui::PromptQueueMode::Immediate => QueueMode::Immediate,
                                         }));
+                                        if let Some(queued_prompt) = runtime.queue.iter().find(|queued| queued.id == prompt_id)
+                                            && queued_prompt.requests_voice_close()
+                                        {
+                                            let _ = events_tx.send(AgentEvent::SystemNotification {
+                                                message: "Voice requested shutdown after this prompt; it will be stopped when the active turn completes.".to_string(),
+                                            });
+                                        }
                                     }
                                     tui::TuiCommand::Quit => {
                                         quit_after_turn = true;
@@ -5344,6 +5353,16 @@ struct PromptEnvelope {
     queue_mode: QueueMode,
 }
 
+impl PromptEnvelope {
+    fn requests_voice_close(&self) -> bool {
+        self.metadata
+            .voice
+            .as_ref()
+            .and_then(|voice| voice.close_session_requested)
+            .unwrap_or(false)
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum ActiveTurnPhase {
     Running,
@@ -5618,6 +5637,44 @@ async fn run_interactive_active_turn(
     });
 
     runtime_state
+}
+
+async fn stop_voice_session_if_requested(
+    prompt: &PromptEnvelope,
+    bus: &crate::bus::EventBus,
+    events_tx: &tokio::sync::broadcast::Sender<AgentEvent>,
+) {
+    if !prompt.requests_voice_close() {
+        return;
+    }
+
+    if !bus.has_tool("voice_session_stop") {
+        let _ = events_tx.send(AgentEvent::SystemNotification {
+            message: "Voice requested shutdown after this prompt, but no voice_session_stop tool is available.".to_string(),
+        });
+        return;
+    }
+
+    match bus
+        .execute_tool(
+            "voice_session_stop",
+            "voice-over-and-out-stop",
+            serde_json::json!({}),
+            tokio_util::sync::CancellationToken::new(),
+        )
+        .await
+    {
+        Ok(_) => {
+            let _ = events_tx.send(AgentEvent::SystemNotification {
+                message: "Voice session stop requested after over and out.".to_string(),
+            });
+        }
+        Err(err) => {
+            let _ = events_tx.send(AgentEvent::SystemNotification {
+                message: format!("Voice requested shutdown, but voice_session_stop failed: {err}"),
+            });
+        }
+    }
 }
 
 #[derive(Debug, Default)]
@@ -8026,6 +8083,28 @@ mod tests {
     fn interactive_resume_mode_fresh_overrides_resume_flag() {
         let cli = Cli::parse_from(["omegon", "--fresh", "--resume", "abc123"]);
         assert!(interactive_resume_mode(&cli).is_none());
+    }
+
+    #[test]
+    fn prompt_envelope_detects_voice_close_request() {
+        let prompt = PromptEnvelope {
+            id: 1,
+            text: "🎙 stop listening".to_string(),
+            image_paths: Vec::new(),
+            submitted_by: RuntimeActor::tui(),
+            via: ControlSurface::Tui,
+            metadata: tui::PromptMetadata {
+                voice: Some(tui::VoicePromptMetadata {
+                    event_id: "u-close".to_string(),
+                    duration_s: None,
+                    radio_cue: Some("over_and_out".to_string()),
+                    end_of_turn: Some(true),
+                    close_session_requested: Some(true),
+                }),
+            },
+            queue_mode: QueueMode::UntilReady,
+        };
+        assert!(prompt.requests_voice_close());
     }
 
     #[test]

--- a/core/crates/omegon/src/status.rs
+++ b/core/crates/omegon/src/status.rs
@@ -78,6 +78,9 @@ pub struct HarnessStatus {
     /// Latest voice extension lifecycle state reported through `voice/state`.
     /// This is extension-reported capture state, not OS/device/hardware truth.
     pub voice_state: Option<VoiceStateStatus>,
+    /// Latest spoken-output lifecycle state reported through `voice/tts_state`.
+    /// This is independent from microphone capture state.
+    pub voice_tts_state: Option<VoiceTtsStatus>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -85,6 +88,17 @@ pub struct VoiceStateStatus {
     pub extension: String,
     pub state: String,
     pub mic_open: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct VoiceTtsStatus {
+    pub extension: String,
+    pub state: String,
+    pub audio_output: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub backend: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub voice: Option<String>,
 }
 
 /// Summary of an active delegate process.
@@ -302,12 +316,16 @@ impl HarnessStatus {
             let label = match (voice.mic_open, voice.state.as_str()) {
                 (true, "listening") => "voice listening".to_string(),
                 (true, "processing") => "voice processing".to_string(),
-                (true, "speaking") => "voice speaking".to_string(),
                 (true, state) => format!("voice {state}"),
                 (false, "error") => "voice error".to_string(),
                 (false, state) => format!("voice {state}"),
             };
             parts.push(label);
+        }
+        if let Some(ref tts) = self.voice_tts_state
+            && tts.audio_output
+        {
+            parts.push(format!("voice {}", tts.state));
         }
 
         parts.push(self.context_class.clone());
@@ -838,6 +856,7 @@ impl Default for HarnessStatus {
             mutation_diagnostics: 0,
             active_delegates: vec![],
             voice_state: None,
+            voice_tts_state: None,
         }
     }
 }
@@ -876,6 +895,27 @@ mod tests {
     }
 
     #[test]
+    fn footer_summary_reports_tts_independent_from_mic_state() {
+        let status = HarnessStatus {
+            voice_state: Some(VoiceStateStatus {
+                extension: "omegon-voice".to_string(),
+                state: "listening".to_string(),
+                mic_open: true,
+            }),
+            voice_tts_state: Some(VoiceTtsStatus {
+                extension: "omegon-voice".to_string(),
+                state: "speaking".to_string(),
+                audio_output: true,
+                backend: Some("macos".to_string()),
+                voice: Some("Reed".to_string()),
+            }),
+            ..HarnessStatus::default()
+        };
+        let summary = status.footer_summary();
+        assert!(summary.contains("voice listening"), "{summary}");
+        assert!(summary.contains("voice speaking"), "{summary}");
+    }
+
     fn footer_summary_minimal() {
         let status = HarnessStatus::default();
         let footer = status.footer_summary();

--- a/core/crates/omegon/src/tui/conversation.rs
+++ b/core/crates/omegon/src/tui/conversation.rs
@@ -309,7 +309,20 @@ impl ConversationView {
         self.push_user_with_attachments(text, &[]);
     }
 
+    pub fn push_user_with_meta(&mut self, text: &str, meta: SegmentMeta) {
+        self.push_user_with_attachments_and_meta(text, &[], meta);
+    }
+
     pub fn push_user_with_attachments(&mut self, text: &str, attachments: &[std::path::PathBuf]) {
+        self.push_user_with_attachments_and_meta(text, attachments, SegmentMeta::default());
+    }
+
+    pub fn push_user_with_attachments_and_meta(
+        &mut self,
+        text: &str,
+        attachments: &[std::path::PathBuf],
+        meta: SegmentMeta,
+    ) {
         if !self.segments.is_empty() {
             self.segments.push(Segment::separator());
         }
@@ -323,7 +336,9 @@ impl ConversationView {
         };
 
         if !rendered.is_empty() || attachments.is_empty() {
-            self.segments.push(Segment::user_prompt(rendered));
+            let mut segment = Segment::user_prompt(rendered);
+            segment.meta = meta;
+            self.segments.push(segment);
         }
 
         for (idx, path) in attachments.iter().enumerate() {

--- a/core/crates/omegon/src/tui/mod.rs
+++ b/core/crates/omegon/src/tui/mod.rs
@@ -35,6 +35,7 @@ mod snapshot_tests;
 #[cfg(test)]
 mod tests;
 
+use segments::SegmentMeta;
 use std::io;
 use std::time::Duration;
 
@@ -315,6 +316,18 @@ pub(crate) struct QueuedPrompt {
     text: String,
     attachments: Vec<std::path::PathBuf>,
     metadata: PromptMetadata,
+}
+
+fn segment_meta_from_prompt_metadata(metadata: &PromptMetadata) -> SegmentMeta {
+    let mut meta = SegmentMeta::default();
+    if let Some(voice) = &metadata.voice {
+        meta.source_channel = Some("voice".to_string());
+        meta.radio_cue = voice.radio_cue.clone();
+        meta.voice_end_of_turn = voice.end_of_turn;
+        meta.voice_close_session_requested = voice.close_session_requested;
+        meta.voice_duration_s = voice.duration_s;
+    }
+    meta
 }
 
 pub(crate) fn voice_prompt_from_notification(
@@ -1959,6 +1972,11 @@ impl App {
                 .and_then(|r| r.active_persona().map(|p| p.id.clone())),
             branch: None,      // populated lazily if needed
             duration_ms: None, // set on completion
+            source_channel: None,
+            radio_cue: None,
+            voice_end_of_turn: None,
+            voice_close_session_requested: None,
+            voice_duration_s: None,
         }
     }
 
@@ -10050,10 +10068,14 @@ pub async fn run_tui(
             let attachments = queued.attachments;
             let metadata = queued.metadata;
             if attachments.is_empty() {
-                app.conversation.push_user(&text);
-            } else {
                 app.conversation
-                    .push_user_with_attachments(&text, &attachments);
+                    .push_user_with_meta(&text, segment_meta_from_prompt_metadata(&metadata));
+            } else {
+                app.conversation.push_user_with_attachments_and_meta(
+                    &text,
+                    &attachments,
+                    segment_meta_from_prompt_metadata(&metadata),
+                );
             }
             app.history.push(text.clone());
             app.history_idx = None;

--- a/core/crates/omegon/src/tui/mod.rs
+++ b/core/crates/omegon/src/tui/mod.rs
@@ -89,6 +89,20 @@ fn get_rss_mb() -> Option<f64> {
     }
 }
 
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct VoicePromptMetadata {
+    pub event_id: String,
+    pub duration_s: Option<f64>,
+    pub radio_cue: Option<String>,
+    pub end_of_turn: Option<bool>,
+    pub close_session_requested: Option<bool>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct PromptMetadata {
+    pub voice: Option<VoicePromptMetadata>,
+}
+
 #[derive(Debug, Clone)]
 pub struct PromptSubmission {
     pub text: String,
@@ -96,6 +110,7 @@ pub struct PromptSubmission {
     pub submitted_by: String,
     pub via: &'static str,
     pub queue_mode: PromptQueueMode,
+    pub metadata: PromptMetadata,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -104,25 +119,6 @@ pub enum PromptQueueMode {
     #[default]
     UntilReady,
     Immediate,
-}
-
-#[derive(Debug, Clone)]
-struct QueuedPrompt {
-    text: String,
-    attachments: Vec<std::path::PathBuf>,
-    submitted_by: String,
-    via: &'static str,
-}
-
-impl QueuedPrompt {
-    fn local_tui(text: String, attachments: Vec<std::path::PathBuf>) -> Self {
-        Self {
-            text,
-            attachments,
-            submitted_by: "local-tui".to_string(),
-            via: "tui",
-        }
-    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -221,7 +217,10 @@ pub enum TuiCommand {
         respond_to: Option<tokio::sync::oneshot::Sender<omegon_traits::ControlOutputResponse>>,
     },
     /// Voice transcription submitted by a process-local voice extension.
-    VoicePrompt { text: String, event_id: String },
+    VoicePrompt {
+        text: String,
+        metadata: VoicePromptMetadata,
+    },
     /// Start provider login flow.
     AuthLogin {
         provider: String,
@@ -311,6 +310,13 @@ struct OperatorEvent {
     expires_at: std::time::Instant,
 }
 
+#[derive(Debug, Clone)]
+pub(crate) struct QueuedPrompt {
+    text: String,
+    attachments: Vec<std::path::PathBuf>,
+    metadata: PromptMetadata,
+}
+
 pub(crate) fn voice_prompt_from_notification(
     notification: &crate::extensions::ExtensionNotification,
 ) -> Option<TuiCommand> {
@@ -328,9 +334,30 @@ pub(crate) fn voice_prompt_from_notification(
         .filter(|id| !id.trim().is_empty())
         .map(ToString::to_string)
         .unwrap_or_else(|| format!("{}:{}", notification.extension_name, notification.method));
+    let metadata = VoicePromptMetadata {
+        event_id,
+        duration_s: notification
+            .params
+            .get("duration_s")
+            .and_then(serde_json::Value::as_f64),
+        radio_cue: notification
+            .params
+            .get("radio_cue")
+            .and_then(serde_json::Value::as_str)
+            .filter(|cue| !cue.trim().is_empty())
+            .map(ToString::to_string),
+        end_of_turn: notification
+            .params
+            .get("end_of_turn")
+            .and_then(serde_json::Value::as_bool),
+        close_session_requested: notification
+            .params
+            .get("close_session_requested")
+            .and_then(serde_json::Value::as_bool),
+    };
     Some(TuiCommand::VoicePrompt {
         text: text.to_string(),
-        event_id,
+        metadata,
     })
 }
 
@@ -3748,8 +3775,11 @@ impl App {
 
     fn queue_prompt(&mut self, text: String, attachments: Vec<std::path::PathBuf>) {
         let preview = Self::queue_prompt_preview(&text, &attachments);
-        self.queued_prompts
-            .push_back(QueuedPrompt::local_tui(text, attachments));
+        self.queued_prompts.push_back(QueuedPrompt {
+            text,
+            attachments,
+            metadata: PromptMetadata::default(),
+        });
         let queued = self.queued_prompts.len();
         self.conversation.push_system(&format!(
             "⏳ Queued [{queued}]: {preview}\n   It will run after the active turn ends. Press Esc/Ctrl+C to interrupt the active turn."
@@ -3915,6 +3945,7 @@ impl App {
                 submitted_by: "local-tui".to_string(),
                 via: "tui",
                 queue_mode: self.queue_mode,
+                metadata: PromptMetadata::default(),
             }))
             .await;
         if let Some(ref mut overlay) = self.tutorial_overlay {
@@ -3934,16 +3965,8 @@ impl App {
         }
         let decorated = format!("🎙 {text}");
         if self.agent_active {
-            self.queued_prompts.push_back(QueuedPrompt {
-                text: decorated,
-                attachments: Vec::new(),
-                submitted_by: "voice".to_string(),
-                via: "voice",
-            });
-            let queued = self.queued_prompts.len();
-            self.conversation.push_system(&format!(
-                "⏳ Queued [{queued}]: 🎙 voice prompt\n   It will run after the active turn ends. Press Esc/Ctrl+C to interrupt the active turn."
-            ));
+            self.queue_prompt(decorated.clone(), Vec::new());
+            self.conversation.push_system("Voice prompt queued");
             return;
         }
 
@@ -3961,6 +3984,7 @@ impl App {
                 submitted_by: "voice".to_string(),
                 via: "voice",
                 queue_mode: self.queue_mode,
+                metadata: PromptMetadata::default(),
             }))
             .await;
     }
@@ -5957,8 +5981,11 @@ impl App {
                     // with the operator to create a new skill.
                     let cwd = self.cwd().to_path_buf();
                     let builder_prompt = crate::skills::skill_builder_prompt(&cwd);
-                    self.queued_prompts
-                        .push_back(QueuedPrompt::local_tui(builder_prompt, Vec::new()));
+                    self.queued_prompts.push_back(QueuedPrompt {
+                        text: builder_prompt,
+                        attachments: Vec::new(),
+                        metadata: PromptMetadata::default(),
+                    });
                     self.queue_mode = PromptQueueMode::UntilReady;
                     self.conversation.push_system("Starting skill builder...");
                     SlashResult::Handled
@@ -6258,8 +6285,11 @@ impl App {
             "persona" => {
                 if args == "create" || args == "new" {
                     let builder_prompt = crate::plugins::persona_loader::persona_builder_prompt();
-                    self.queued_prompts
-                        .push_back(QueuedPrompt::local_tui(builder_prompt, Vec::new()));
+                    self.queued_prompts.push_back(QueuedPrompt {
+                        text: builder_prompt,
+                        attachments: Vec::new(),
+                        metadata: PromptMetadata::default(),
+                    });
                     self.queue_mode = PromptQueueMode::UntilReady;
                     self.conversation.push_system("Starting persona builder...");
                     SlashResult::Handled
@@ -9538,6 +9568,7 @@ pub async fn run_tui(
                                                             submitted_by: "local-tui".to_string(),
                                                             via: "tui",
                                                             queue_mode: app.queue_mode,
+                                                            metadata: PromptMetadata::default(),
                                                         },
                                                     ))
                                                     .await;
@@ -9573,6 +9604,7 @@ pub async fn run_tui(
                                                             submitted_by: "local-tui".to_string(),
                                                             via: "tui",
                                                             queue_mode: app.queue_mode,
+                                                            metadata: PromptMetadata::default(),
                                                         },
                                                     ))
                                                     .await;
@@ -10013,11 +10045,10 @@ pub async fn run_tui(
 
         // Drain queued prompts only after authoritative AgentEnd (but not if quitting)
         if !app.agent_active && !app.should_quit && !app.queued_prompts.is_empty() {
-            let queued_prompt = app.queued_prompts.pop_front().unwrap();
-            let text = queued_prompt.text;
-            let attachments = queued_prompt.attachments;
-            let submitted_by = queued_prompt.submitted_by;
-            let via = queued_prompt.via;
+            let queued = app.queued_prompts.pop_front().unwrap();
+            let text = queued.text;
+            let attachments = queued.attachments;
+            let metadata = queued.metadata;
             if attachments.is_empty() {
                 app.conversation.push_user(&text);
             } else {
@@ -10035,9 +10066,10 @@ pub async fn run_tui(
                     .send(TuiCommand::SubmitPrompt(PromptSubmission {
                         text,
                         image_paths: Vec::new(),
-                        submitted_by: submitted_by.clone(),
-                        via,
+                        submitted_by: "local-tui".to_string(),
+                        via: "tui",
                         queue_mode: app.queue_mode,
+                        metadata,
                     }))
                     .await;
             } else {
@@ -10045,9 +10077,10 @@ pub async fn run_tui(
                     .send(TuiCommand::SubmitPrompt(PromptSubmission {
                         text,
                         image_paths: attachments,
-                        submitted_by,
-                        via,
+                        submitted_by: "local-tui".to_string(),
+                        via: "tui",
                         queue_mode: app.queue_mode,
+                        metadata,
                     }))
                     .await;
             }
@@ -10130,19 +10163,55 @@ mod voice_prompt_tests {
     fn voice_transcription_notification_becomes_voice_prompt() {
         let cmd = voice_prompt_from_notification(&notification(
             "voice/transcription",
-            json!({"text": " proceed ", "utterance_id": "u1"}),
+            json!({
+                "text": " proceed ",
+                "utterance_id": "u1",
+                "duration_s": 2.1,
+                "radio_cue": "over",
+                "end_of_turn": true,
+                "close_session_requested": false
+            }),
         ))
         .expect("voice prompt");
         match cmd {
-            TuiCommand::VoicePrompt { text, event_id } => {
+            TuiCommand::VoicePrompt { text, metadata } => {
                 assert_eq!(text, "proceed");
-                assert_eq!(event_id, "u1");
+                assert_eq!(metadata.event_id, "u1");
+                assert_eq!(metadata.duration_s, Some(2.1));
+                assert_eq!(metadata.radio_cue.as_deref(), Some("over"));
+                assert_eq!(metadata.end_of_turn, Some(true));
+                assert_eq!(metadata.close_session_requested, Some(false));
             }
             other => panic!("unexpected command: {other:?}"),
         }
     }
 
     #[test]
+    fn voice_prompt_metadata_preserves_over_and_out_close_intent() {
+        let cmd = voice_prompt_from_notification(&notification(
+            "voice/transcription",
+            json!({
+                "text": "stop listening",
+                "utterance_id": "u-close",
+                "radio_cue": "over_and_out",
+                "end_of_turn": true,
+                "close_session_requested": true
+            }),
+        ))
+        .expect("voice prompt");
+
+        match cmd {
+            TuiCommand::VoicePrompt { text, metadata } => {
+                assert_eq!(text, "stop listening");
+                assert_eq!(metadata.event_id, "u-close");
+                assert_eq!(metadata.radio_cue.as_deref(), Some("over_and_out"));
+                assert_eq!(metadata.end_of_turn, Some(true));
+                assert_eq!(metadata.close_session_requested, Some(true));
+            }
+            other => panic!("unexpected command: {other:?}"),
+        }
+    }
+
     fn non_transcription_and_malformed_voice_notifications_are_ignored() {
         assert!(
             voice_prompt_from_notification(&notification(

--- a/core/crates/omegon/src/tui/segments.rs
+++ b/core/crates/omegon/src/tui/segments.rs
@@ -979,6 +979,16 @@ pub struct SegmentMeta {
     pub branch: Option<String>,
     /// Duration of the operation (for tool calls: execution time).
     pub duration_ms: Option<u64>,
+    /// Source channel for externally-originated prompts, e.g. voice.
+    pub source_channel: Option<String>,
+    /// Voice radio cue metadata, e.g. over or over_and_out.
+    pub radio_cue: Option<String>,
+    /// Whether the voice extension marked the utterance as end-of-turn.
+    pub voice_end_of_turn: Option<bool>,
+    /// Whether the voice extension requested microphone/session closure.
+    pub voice_close_session_requested: Option<bool>,
+    /// Voice utterance duration in seconds.
+    pub voice_duration_s: Option<f64>,
 }
 
 /// A segment in the conversation — metadata wrapper + typed content.
@@ -1830,6 +1840,18 @@ pub fn build_meta_tag(meta: &SegmentMeta) -> String {
     }
     if let Some(ref persona) = meta.persona {
         parts.push(format!("⌘ {persona}"));
+    }
+    if let Some(ref channel) = meta.source_channel {
+        parts.push(format!("source:{channel}"));
+    }
+    if let Some(ref cue) = meta.radio_cue {
+        parts.push(format!("cue:{cue}"));
+    }
+    if meta.voice_close_session_requested == Some(true) {
+        parts.push("close-session".to_string());
+    }
+    if let Some(duration) = meta.voice_duration_s {
+        parts.push(format!("voice:{duration:.1}s"));
     }
     if let Some(ctx) = meta.context_percent.filter(|p| *p > 5.0) {
         parts.push(format!("ctx:{ctx:.0}%"));
@@ -6562,6 +6584,21 @@ After fence text.
     }
 
     #[test]
+    fn meta_tag_includes_voice_prompt_metadata() {
+        let meta = SegmentMeta {
+            source_channel: Some("voice".to_string()),
+            radio_cue: Some("over_and_out".to_string()),
+            voice_close_session_requested: Some(true),
+            voice_duration_s: Some(2.1),
+            ..SegmentMeta::default()
+        };
+        let tag = build_meta_tag(&meta);
+        assert!(tag.contains("source:voice"), "{tag}");
+        assert!(tag.contains("cue:over_and_out"), "{tag}");
+        assert!(tag.contains("close-session"), "{tag}");
+        assert!(tag.contains("voice:2.1s"), "{tag}");
+    }
+
     fn meta_tag_omits_thinking_off() {
         let meta = SegmentMeta {
             model_id: Some("gpt-4o".into()),

--- a/core/crates/omegon/src/tui/tests.rs
+++ b/core/crates/omegon/src/tui/tests.rs
@@ -437,8 +437,6 @@ fn queue_prompt_preserves_fifo_order() {
         .expect("second queued prompt");
 
     assert_eq!(first.text, "first");
-    assert_eq!(first.submitted_by, "local-tui");
-    assert_eq!(first.via, "tui");
     assert_eq!(second.text, "second");
 }
 

--- a/docs/design/voice-control-issue-98-index.md
+++ b/docs/design/voice-control-issue-98-index.md
@@ -1,0 +1,31 @@
++++
+id = "voice-control-issue-98-index"
+title = "Issue 98 design index"
+status = "exploring"
+parent = "voice-control-metadata-tts-lifecycle"
+issue_type = "index"
+priority = 1
+openspec_change = null
+tags = ["extensions", "voice", "index", "0.24", "issue-98"]
+aliases = ["issue-98-design-index"]
+imported_reference = false
+
+[publication]
+enabled = false
+visibility = "private"
++++
+
+# Issue 98 design index
+
+Design nodes for #98:
+
+- [[voice-control-metadata-tts-lifecycle]] — parent scope and issue framing.
+- [[voice-transcription-control-metadata]] — metadata preservation across bridge/TUI/prompt queue.
+- [[voice-over-and-out-shutdown]] — deterministic `close_session_requested` handling.
+- [[voice-tts-lifecycle-contract]] — spoken-output status contract.
+- [[voice-control-tests-issue-98]] — deterministic host-side test plan.
+
+Related prior nodes:
+
+- [[voice-mvp-integration-tests]] — #81 voice bridge trust-boundary tests.
+- [[extension-event-adapter-anchors]] — canonical daemon ingress invariant.

--- a/docs/design/voice-control-metadata-tts-lifecycle.md
+++ b/docs/design/voice-control-metadata-tts-lifecycle.md
@@ -1,0 +1,98 @@
++++
+id = "voice-control-metadata-tts-lifecycle"
+title = "Voice control metadata and TTS lifecycle — Issue 98"
+status = "exploring"
+parent = null
+issue_type = "github-issue"
+priority = 1
+openspec_change = null
+tags = ["extensions", "voice", "tui", "status", "0.24", "issue-98"]
+aliases = ["issue-98-voice-control", "voice-control-metadata"]
+imported_reference = false
+
+[publication]
+enabled = false
+visibility = "private"
++++
+
+# Voice control metadata and TTS lifecycle — Issue 98
+
+## Overview
+
+Issue #98 promotes voice transcription control fields and spoken-output state from extension-specific JSON details into deliberate host-side contracts.
+
+The current voice path is intentionally narrow:
+
+```text
+omegon-voice JSON-RPC notification
+→ ExtensionNotification
+→ extensions::voice_bridge
+→ DaemonEventEnvelope
+→ TUI VoicePrompt
+→ SubmitPrompt
+```
+
+That path is correct, but it currently drops or under-models control metadata at the prompt-routing boundary. `radio_cue`, `end_of_turn`, `close_session_requested`, and full utterance timing need to survive conversion, queueing, display, and acceptance. TTS/spoken-output state also needs a settled host contract so the footer/status model can represent microphone capture and speaker playback independently.
+
+## Current evidence
+
+- `core/crates/omegon/src/extensions/voice_bridge.rs` converts `voice/transcription` into `DaemonEventEnvelope` with `source = "voice"`, `trigger_kind = "prompt"`, `source_channel = "voice"`, and operator trust fields.
+- `voice_bridge.rs` currently preserves `text`, `duration_s`, `utterance_id`, `trust_level`, and `extension`, but not `radio_cue`, `end_of_turn`, or `close_session_requested`.
+- `core/crates/omegon/src/tui/mod.rs` maps `voice/transcription` notifications to `TuiCommand::VoicePrompt { text, event_id }`; the enum has no metadata field.
+- `core/crates/omegon/src/main.rs` normalizes `VoicePrompt` into `SubmitPrompt` with visible `🎙` decoration and `queue_mode = UntilReady`.
+- `core/crates/omegon/src/status.rs` has `VoiceStateStatus { extension, state, mic_open }` and footer rendering for `listening`, `processing`, and `speaking`, but no independent audio-output state.
+- `docs/design/extension-event-adapter-anchors.md` and `docs/design/voice-mvp-integration-tests.md` already establish the invariant that voice events use canonical daemon ingress, not a private prompt stream.
+
+## Scope decomposition
+
+This parent node owns the overall issue and links four child design nodes:
+
+1. [[voice-transcription-control-metadata]] — preserve transcription metadata across bridge, TUI command, prompt submission, queueing, and transcript rendering.
+2. [[voice-over-and-out-shutdown]] — define deterministic `close_session_requested` handling after prompt acceptance.
+3. [[voice-tts-lifecycle-contract]] — decide host contract for spoken-output state, preferably independent from microphone state.
+4. [[voice-control-tests-issue-98]] — encode acceptance criteria with focused tests.
+
+## Decisions
+
+### Decision: Keep voice input on canonical daemon ingress
+
+**Status:** accepted
+
+Voice transcription remains an extension event adapter that emits `DaemonEventEnvelope`. Issue #98 should not introduce a second voice-specific prompt bus or agent loop.
+
+### Decision: Treat recognized radio cues as metadata, not prompt text
+
+**Status:** accepted
+
+When `omegon-voice` recognizes cue words and strips them from `text`, Omegon core must preserve the cue metadata and submit only normalized operator text. The host must not re-append or leak trailing `over` / `over and out` into the prompt.
+
+### Decision: Model microphone capture and spoken output independently
+
+**Status:** accepted
+
+Use separate status fields for microphone capture and spoken output. `voice/state` remains the microphone/capture lifecycle. `voice/tts_state` becomes the spoken-output lifecycle. This avoids impossible composite states such as “listening and speaking” being forced into one enum value.
+
+## Boundary model
+
+Issue #98 crosses three boundaries. Treat them separately so the implementation does not sprawl:
+
+1. **Ingress boundary** — `voice_bridge` validates extension notifications and emits canonical daemon envelopes.
+2. **Prompt boundary** — TUI/runtime converts voice envelopes into `PromptSubmission` values without losing metadata.
+3. **Lifecycle boundary** — status/control paths represent microphone capture, close-session requests, and spoken output.
+
+The first implementation pass should finish the ingress and prompt boundaries before adding broader lifecycle behavior.
+
+## Open questions
+
+- [assumption] `close_session_requested=true` can be handled through an existing extension command/control path without adding a new public HostAction.
+- [assumption] `PromptSubmission` or adjacent transcript structures can carry metadata without forcing broad conversation model changes.
+- [assumption] The direct TUI idle-notification path and daemon event path can use the same metadata struct.
+- Should `voice/tts_state` be the final method name, or should host status use a more general `audio_output` event namespace?
+- Should close-after-accept run immediately after queue acceptance, or after the resulting agent turn finishes? Issue #98 says after prompt acceptance/turn handling; implementation needs one concrete lifecycle point.
+
+## Non-goals
+
+- Acoustic echo cancellation.
+- Cloud STT/TTS providers.
+- Multi-user voice routing.
+- Confirm-before-submit for all voice prompts.

--- a/docs/design/voice-control-tests-issue-98.md
+++ b/docs/design/voice-control-tests-issue-98.md
@@ -1,0 +1,83 @@
++++
+id = "voice-control-tests-issue-98"
+title = "Voice control tests — Issue 98"
+status = "exploring"
+parent = "voice-control-metadata-tts-lifecycle"
+issue_type = "test-plan"
+priority = 1
+openspec_change = null
+tags = ["extensions", "voice", "testing", "0.24", "issue-98"]
+aliases = ["issue-98-tests"]
+imported_reference = false
+
+[publication]
+enabled = false
+visibility = "private"
++++
+
+# Voice control tests — Issue 98
+
+## Overview
+
+This node scopes deterministic tests for voice metadata and lifecycle behavior. Tests must not require a microphone, Whisper model, macOS TCC approval, or audible TTS.
+
+## Test inventory
+
+### 1. Bridge preserves transcription metadata
+
+Synthetic `voice/transcription` notification includes:
+
+```json
+{
+  "text": "Assess this directory",
+  "radio_cue": "over",
+  "end_of_turn": true,
+  "close_session_requested": false,
+  "duration_s": 2.1,
+  "utterance_id": "u1"
+}
+```
+
+Assert the resulting `DaemonEventEnvelope` preserves all metadata and retains canonical voice ingress fields.
+
+### 2. TUI notification routing preserves metadata
+
+`voice_prompt_from_notification` should return a voice prompt command with normalized text and metadata. Empty/cue-only text remains ignored.
+
+### 3. `over` keeps session open
+
+A prompt with `radio_cue=over` and `close_session_requested=false` submits normally and does not stage a stop action.
+
+### 4. `over_and_out` stages shutdown
+
+A prompt with `radio_cue=over_and_out` and `close_session_requested=true` submits normally and stages or invokes voice shutdown at the chosen lifecycle point.
+
+### 5. Busy/queued routing preserves close intent
+
+When a voice prompt is queued because the agent is busy, metadata survives until acceptance and close intent is still honored.
+
+### 6. Status-only events stay status-only
+
+`voice/state` and `voice/tts_state` update harness status but never create daemon prompt events.
+
+### 7. TTS lifecycle updates and clears status
+
+Synthetic TTS start/completion notifications update `HarnessStatus` and broadcast `HarnessStatusChanged`.
+
+## Implementation targets
+
+- `core/crates/omegon/src/extensions/voice_bridge.rs` unit tests.
+- `core/crates/omegon/src/tui/mod.rs` unit tests near existing voice prompt tests.
+- `core/crates/omegon/src/status.rs` tests for footer/status serialization if status shape changes.
+- Focused main-loop tests only if close-after-accept requires runtime behavior that cannot be isolated.
+
+## Open questions
+
+- [assumption] Close-after-accept behavior can be unit-tested without launching a full TUI runtime.
+- Which existing test seam best represents busy/queued prompt acceptance?
+
+## Acceptance criteria
+
+- All issue #98 acceptance criteria have at least one host-side deterministic test.
+- Tests encode that voice state and TTS state are status-only.
+- Tests encode that cue metadata is not submitted as prompt text.

--- a/docs/design/voice-over-and-out-shutdown.md
+++ b/docs/design/voice-over-and-out-shutdown.md
@@ -1,0 +1,93 @@
++++
+id = "voice-over-and-out-shutdown"
+title = "Voice over-and-out shutdown"
+status = "exploring"
+parent = "voice-control-metadata-tts-lifecycle"
+issue_type = "implementation-slice"
+priority = 1
+openspec_change = null
+tags = ["extensions", "voice", "lifecycle", "0.24", "issue-98"]
+aliases = ["voice-close-session-requested", "over-and-out"]
+imported_reference = false
+
+[publication]
+enabled = false
+visibility = "private"
++++
+
+# Voice over-and-out shutdown
+
+## Overview
+
+This node scopes deterministic handling for `close_session_requested=true`, normally emitted when the operator says `over and out`.
+
+The core behavior must be deliberate: process the prompt normally, then close or stage closure of the voice session. Dropping the field leaves the microphone open after the operator explicitly requested shutdown.
+
+## Desired behavior
+
+Given:
+
+```json
+{
+  "text": "Stop listening after this message",
+  "radio_cue": "over_and_out",
+  "end_of_turn": true,
+  "close_session_requested": true
+}
+```
+
+Then:
+
+1. Submit `Stop listening after this message` as the operator prompt.
+2. Render it as voice-originated.
+3. Preserve close intent while queued/busy.
+4. Close the voice session after prompt acceptance or after the resulting turn is handled.
+5. Update voice status to idle / mic closed, or surface a deterministic pending-stop action if direct control is not available.
+
+## Implementation targets
+
+- Locate extension control path for invoking `voice_session_stop` or equivalent host-side stop command.
+- Add a small lifecycle hook for “voice stop requested after prompt acceptance”.
+- Ensure busy queue mode preserves close intent until the queued prompt is accepted.
+- Emit a visible system/status notification if stop cannot be executed directly.
+
+## Lifecycle options
+
+### Option 1: Stop after queue acceptance
+
+Fastest feedback: once the prompt is accepted into the runtime queue, invoke/stage voice shutdown. Cost: the mic may close before the resulting agent turn actually completes.
+
+### Option 2: Stop after turn completion
+
+Closest reading of “after the turn is handled”: carry close intent through prompt execution and stop after `AgentEnd`. Cost: requires metadata to survive deeper into runtime turn state.
+
+### Option 3: Stage agent-visible stop action
+
+If direct host-side extension invocation is not available, emit a deterministic pending action/system notification rather than silently dropping the request. Cost: closure may depend on a follow-up mechanism.
+
+## Decisions
+
+### Decision: `over` and `over_and_out` differ only by close intent
+
+**Status:** accepted
+
+`radio_cue=over` submits normally and keeps listening. `radio_cue=over_and_out` submits normally and requests session closure after safe handoff.
+
+### Decision: Stop after queue acceptance for the first implementation
+
+**Status:** accepted
+
+The first implementation should invoke or stage voice shutdown once the prompt has been accepted into the runtime queue. That satisfies the operator’s explicit “over and out” request with less runtime coupling than carrying a post-turn callback through agent execution. If later UX shows the mic must remain open until `AgentEnd`, this can be revised as a follow-up.
+
+## Open questions
+
+- [assumption] The voice extension exposes a callable `voice_session_stop` tool in the same host process that can be invoked without agent mediation.
+- What exact lifecycle point is “safe handoff”: queue acceptance, prompt submission to agent loop, or turn completion?
+- If the stop call fails, should the TUI retry, show a persistent warning, or require explicit operator action?
+
+## Acceptance criteria
+
+- `close_session_requested=true` is not silently dropped.
+- Queued voice prompts retain close intent.
+- `over` leaves mic state unchanged.
+- `over_and_out` transitions voice state toward idle/mic closed or exposes a deterministic pending-stop state.

--- a/docs/design/voice-transcription-control-metadata.md
+++ b/docs/design/voice-transcription-control-metadata.md
@@ -1,0 +1,106 @@
++++
+id = "voice-transcription-control-metadata"
+title = "Voice transcription control metadata"
+status = "exploring"
+parent = "voice-control-metadata-tts-lifecycle"
+issue_type = "implementation-slice"
+priority = 1
+openspec_change = null
+tags = ["extensions", "voice", "tui", "metadata", "0.24", "issue-98"]
+aliases = ["voice-radio-cue-metadata"]
+imported_reference = false
+
+[publication]
+enabled = false
+visibility = "private"
++++
+
+# Voice transcription control metadata
+
+## Overview
+
+This node scopes the metadata-preservation slice of issue #98. `voice/transcription` already becomes a trusted local operator prompt; the missing piece is preserving control metadata deliberately across every boundary that currently reduces the event to plain text.
+
+## Required metadata
+
+For a normalized transcription payload:
+
+```json
+{
+  "text": "Assess this directory",
+  "duration_s": 2.1,
+  "radio_cue": "over",
+  "end_of_turn": true,
+  "close_session_requested": false
+}
+```
+
+The host should submit/display:
+
+```text
+🎙 Assess this directory
+```
+
+and preserve metadata equivalent to:
+
+```json
+{
+  "source_channel": "voice",
+  "radio_cue": "over",
+  "end_of_turn": true,
+  "close_session_requested": false,
+  "duration_s": 2.1
+}
+```
+
+## Implementation targets
+
+- `core/crates/omegon/src/extensions/voice_bridge.rs`
+  - Copy optional `radio_cue`, `end_of_turn`, and `close_session_requested` into `DaemonEventEnvelope.payload`.
+  - Keep `duration_s` and `utterance_id` behavior.
+  - Add explicit payload `source_channel = "voice"` so downstream consumers do not need to infer it from envelope fields after conversion.
+- `core/crates/omegon/src/tui/mod.rs`
+  - Introduce a small `VoicePromptMetadata` struct with `event_id`, `duration_s`, `radio_cue`, `end_of_turn`, and `close_session_requested`.
+  - Replace `TuiCommand::VoicePrompt { text, event_id }` with `VoicePrompt { text, metadata }`.
+  - Update `voice_prompt_from_notification` to preserve recognized cue fields when notifications are routed directly in TUI idle mode.
+  - Replace `queued_prompts: VecDeque<(String, Vec<PathBuf>)>` with a queued prompt struct if metadata must survive TUI-side queueing.
+- `core/crates/omegon/src/main.rs`
+  - Preserve metadata when normalizing `VoicePrompt` into `SubmitPrompt`.
+  - Preserve metadata in runtime busy/queued routing (`PromptQueueMode::UntilReady`).
+- Prompt transcript/details rendering
+  - Keep visible prompt voice-originated via `🎙`.
+  - Do not append cue words to submitted text.
+  - Make cue metadata available in details/audit only if the current prompt model has a narrow hook; otherwise preserve it in runtime metadata first and defer UI details.
+
+## Decisions
+
+### Decision: Cue words stay out of submitted text
+
+**Status:** accepted
+
+The extension owns cue recognition and strips cue words from `text`. Core should trust the normalized `text` field and carry cue details only as metadata.
+
+### Decision: Metadata is optional and backwards-compatible
+
+**Status:** accepted
+
+Older voice extensions may emit only `text` and `duration_s`. Host parsing should treat the new fields as optional and should ignore malformed optional fields rather than rejecting otherwise valid transcriptions.
+
+### Decision: Constrain known radio cues at behavior boundaries
+
+**Status:** accepted
+
+Preserve unknown `radio_cue` strings for audit/debug metadata, but only `over` and `over_and_out` drive host behavior. Unknown values must not trigger shutdown or other control actions.
+
+## Open questions
+
+- [assumption] Existing prompt submission/history types can tolerate an optional JSON metadata field without large storage migrations.
+- Where is the narrowest transcript/details surface for exposing prompt metadata today?
+- Should `radio_cue` be constrained to known values (`over`, `over_and_out`) or preserved as an arbitrary string for forward compatibility?
+
+## Acceptance criteria
+
+- `radio_cue=over` survives bridge conversion and TUI prompt normalization.
+- `duration_s`, `end_of_turn`, and `close_session_requested` survive queueing.
+- Voice prompt visible text remains `🎙 <normalized text>`.
+- Recognized cue text does not leak into submitted prompt text.

--- a/docs/design/voice-tts-lifecycle-contract.md
+++ b/docs/design/voice-tts-lifecycle-contract.md
@@ -1,0 +1,105 @@
++++
+id = "voice-tts-lifecycle-contract"
+title = "Voice TTS lifecycle contract"
+status = "exploring"
+parent = "voice-control-metadata-tts-lifecycle"
+issue_type = "contract"
+priority = 2
+openspec_change = null
+tags = ["extensions", "voice", "tts", "status", "0.24", "issue-98"]
+aliases = ["voice-spoken-output-state", "voice-tts-state"]
+imported_reference = false
+
+[publication]
+enabled = false
+visibility = "private"
++++
+
+# Voice TTS lifecycle contract
+
+## Overview
+
+This node scopes the host-side contract for spoken-output lifecycle notifications. The goal is to make TTS state visible without conflating it with microphone capture state or corrupting terminal output.
+
+## Contract options
+
+### Option A: Expand `voice/state`
+
+Allow extension state values such as:
+
+```text
+idle
+listening
+processing
+speaking
+error
+```
+
+Payload example:
+
+```json
+{
+  "state": "speaking",
+  "mic_open": true,
+  "audio_output": true,
+  "backend": "macos",
+  "voice": "Reed (English (US))"
+}
+```
+
+Cost: a single state enum can blur independent mic and speaker lifecycles.
+
+### Option B: Separate `voice/tts_state`
+
+Use a separate notification for spoken output:
+
+```json
+{
+  "state": "speaking",
+  "audio_output": true,
+  "backend": "macos",
+  "voice": "Reed (English (US))"
+}
+```
+
+and completion:
+
+```json
+{
+  "state": "idle",
+  "audio_output": false
+}
+```
+
+Benefit: microphone state and speaker state remain independently knowable.
+
+## Proposed decision
+
+### Decision: Use `voice/tts_state` for spoken-output status
+
+**Status:** accepted
+
+Adopt Option B. `voice/state` remains capture/mic status. `voice/tts_state` reports speaker playback with `state`, `audio_output`, optional `backend`, and optional `voice`. The host may accept expanded `voice/state` as a compatibility fallback later, but the documented contract is separate.
+
+## Implementation targets
+
+- `core/crates/omegon/src/extensions/voice_bridge.rs`
+  - Parse `voice/tts_state` as status-only, not as a prompt event.
+- `core/crates/omegon/src/status.rs`
+  - Add a separate `VoiceTtsStatus` / audio-output status field with backend and voice metadata.
+  - Footer/status summary can render `voice speaking` when audio output is active while preserving mic status.
+- TUI/status event propagation
+  - Broadcast `HarnessStatusChanged` when spoken output starts and clears.
+
+## Open questions
+
+- [assumption] `omegon-voice` can emit `voice/tts_state` for async speech start/completion.
+- Should the host also accept expanded `voice/state` as a compatibility fallback?
+- Should status include queued TTS output, or only currently active playback?
+
+## Acceptance criteria
+
+- TTS start updates host status to show active audio output.
+- TTS completion clears audio-output state.
+- `voice/tts_state` never creates an agent prompt.
+- Mic state remains separately visible from speaker state.


### PR DESCRIPTION
## Summary
- preserve voice transcription control metadata through bridge, TUI prompt routing, runtime queueing, and prompt detail metadata
- add status-only voice/tts_state handling independent from mic capture state
- handle over_and_out close intent only when both radio_cue=over_and_out and close_session_requested=true are present
- stop lifecycle read/status paths from dirtying ai/lifecycle/state.json via idempotent progress writes and mutating OpenSpec snapshots
- bump patch release to 0.24.7

## Validation
- cargo check -p omegon --message-format=short
- cargo check -p omegon-opsx --message-format=short
- cargo test -p omegon-opsx update_change_progress -- --nocapture
- cargo test -p omegon lifecycle::read_model -- --nocapture
- cargo test -p omegon voice -- --nocapture
- cargo test -p omegon prompt_envelope_requires_over_and_out_for_voice_close_request -- --nocapture
- cargo test -p omegon meta_tag_includes_voice_prompt_metadata -- --nocapture
- cargo test -p omegon footer_summary_reports_tts_independent_from_mic_state -- --nocapture
- cargo fmt --check
- git diff --check

Full workspace tests were not captured before PR due harness timeouts, but targeted lifecycle/voice checks and cargo check passed.