### PR TITLE
fix(tui): roll up miscellaneous behavioral fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [Semantic V
 - Replace unclear Slim plan footer actions with plan pin/tracking/OpenSpec/design-lifecycle status labels.
 - Add explicit Slim footer labels for directory and git branch fields, and render OODA phase as a dim acronym with the active letter highlighted.
 - Dispatch filesystem read/view tools serially so multiple outside-workspace permission prompts cannot overwrite each other and fail before the operator responds.
+- Disambiguate Slim turn status while waiting on provider request setup, stream opening, answer/thinking streaming, tools, and upstream retry backoff.
 - Keep read-only OpenSpec status and lifecycle snapshot calls from materializing discovered file-backed changes into `ai/lifecycle/state.json`.
 
 ## [0.24.7] - 2026-05-27

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [Semantic V
 
 - Show elapsed wall-clock time in the Slim active-tool stream header while tools are running.
 - Replace unclear Slim plan footer actions with plan pin/tracking/OpenSpec/design-lifecycle status labels.
+- Add explicit Slim footer labels for directory and git branch fields, and render OODA phase as a dim acronym with the active letter highlighted.
 - Keep read-only OpenSpec status and lifecycle snapshot calls from materializing discovered file-backed changes into `ai/lifecycle/state.json`.
 
 ## [0.24.7] - 2026-05-27

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [Semantic V
 - Show elapsed wall-clock time in the Slim active-tool stream header while tools are running.
 - Replace unclear Slim plan footer actions with plan pin/tracking/OpenSpec/design-lifecycle status labels.
 - Add explicit Slim footer labels for directory and git branch fields, and render OODA phase as a dim acronym with the active letter highlighted.
+- Dispatch filesystem read/view tools serially so multiple outside-workspace permission prompts cannot overwrite each other and fail before the operator responds.
 - Keep read-only OpenSpec status and lifecycle snapshot calls from materializing discovered file-backed changes into `ai/lifecycle/state.json`.
 
 ## [0.24.7] - 2026-05-27

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [Semantic V
 ### Fixed
 
 - Show elapsed wall-clock time in the Slim active-tool stream header while tools are running.
+- Replace unclear Slim plan footer actions with plan pin/tracking/OpenSpec/design-lifecycle status labels.
 - Keep read-only OpenSpec status and lifecycle snapshot calls from materializing discovered file-backed changes into `ai/lifecycle/state.json`.
 
 ## [0.24.7] - 2026-05-27

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [Semantic V
 
 ## [Unreleased]
 
+### Fixed
+
+- Show elapsed wall-clock time in the Slim active-tool stream header while tools are running.
+- Keep read-only OpenSpec status and lifecycle snapshot calls from materializing discovered file-backed changes into `ai/lifecycle/state.json`.
+
 ## [0.24.7] - 2026-05-27
 
 ### Changed

--- a/core/crates/omegon/src/extensions/host_actions.rs
+++ b/core/crates/omegon/src/extensions/host_actions.rs
@@ -739,7 +739,11 @@ impl TerminalCreateBackend for RealTerminalCreateBackend {
         &self,
         plan: TerminalCreateLaunchPlan,
     ) -> Result<omegon_extension::actions::terminal::TerminalCreateResult, String> {
-        let request = terminal_backend_request_from_plan(plan, &self.workspace_cwd, None);
+        let request = terminal_backend_request_from_plan(
+            plan.clone(),
+            &self.workspace_cwd,
+            plan.name.clone(),
+        );
         let response = std::thread::spawn(move || {
             let runtime = tokio::runtime::Builder::new_current_thread()
                 .enable_all()
@@ -864,6 +868,7 @@ pub(super) struct TerminalCreateLaunchPlan {
     pub cwd: Option<String>,
     pub env: Vec<(String, String)>,
     pub placement: Option<omegon_extension::actions::terminal::TerminalPlacement>,
+    pub name: Option<String>,
 }
 
 impl TerminalCreateLaunchPlan {
@@ -944,6 +949,7 @@ pub(super) fn validate_terminal_create_policy(
         cwd: params.cwd,
         env: params.env.into_iter().collect(),
         placement: params.placement,
+        name: params.reuse_key.or(params.title),
     })
 }
 
@@ -1302,6 +1308,7 @@ allowed = [{allowed}]
                 cwd: Some("books".to_string()),
                 env: vec![("BOOKOKRAT_THEME".to_string(), "dark".to_string())],
                 placement: None,
+                name: None,
             },
             std::path::Path::new("/workspace"),
             Some("reader".to_string()),
@@ -1671,7 +1678,7 @@ allowed = [{allowed}]
                     "args": ["side-visible"],
                     "cwd": ".",
                     "placement": "side_pane",
-                    "name": terminal_name
+                    "reuse_key": terminal_name
                 }
             }),
             &manifest,

--- a/core/crates/omegon/src/features/lifecycle.rs
+++ b/core/crates/omegon/src/features/lifecycle.rs
@@ -2248,8 +2248,8 @@ mod tests {
         let text = result.content[0].as_text().unwrap();
         assert!(text.contains("auth"), "should list spec domain: {text}");
         let change: Value = serde_json::from_str(text).unwrap();
-        assert_eq!(change["state"].as_str(), Some("specced"));
-        assert_eq!(change["stage"].as_str(), Some("specced"));
+        assert_eq!(change["state"].as_str(), Some("specified"));
+        assert_eq!(change["stage"].as_str(), Some("specified"));
         assert_eq!(change["file_stage"].as_str(), Some("specified"));
     }
 
@@ -2272,8 +2272,8 @@ mod tests {
         let text = result.content[0].as_text().unwrap();
         let changes: Vec<Value> = serde_json::from_str(text).unwrap();
         assert_eq!(changes[0]["name"].as_str(), Some("legacy-change"));
-        assert_eq!(changes[0]["state"].as_str(), Some("specced"));
-        assert_eq!(changes[0]["stage"].as_str(), Some("specced"));
+        assert_eq!(changes[0]["state"].as_str(), Some("specified"));
+        assert_eq!(changes[0]["stage"].as_str(), Some("specified"));
         assert_eq!(changes[0]["file_stage"].as_str(), Some("specified"));
     }
 

--- a/core/crates/omegon/src/features/lifecycle.rs
+++ b/core/crates/omegon/src/features/lifecycle.rs
@@ -1107,7 +1107,6 @@ impl LifecycleFeature {
                 if changes.is_empty() {
                     return Ok(text_result("No active OpenSpec changes."));
                 }
-                self.sync_opsx_changes_from_info(changes)?;
                 let opsx_states = self.opsx_change_states();
                 let list: Vec<Value> = changes
                     .iter()
@@ -1138,7 +1137,6 @@ impl LifecycleFeature {
                     .ok_or_else(|| anyhow::anyhow!("change_name required"))?;
                 let change = spec::get_change(&self.repo_path, name)
                     .ok_or_else(|| anyhow::anyhow!("Change '{name}' not found"))?;
-                self.sync_opsx_changes_from_info(std::slice::from_ref(&change))?;
                 let state = self
                     .opsx_change_states()
                     .get(name)
@@ -2138,6 +2136,29 @@ mod tests {
         assert_eq!(
             result.details["findings"][0]["node_id"].as_str(),
             Some("stale-node")
+        );
+    }
+
+    #[test]
+    fn openspec_status_does_not_materialize_discovered_changes() {
+        let (_dir, repo) = setup_test_repo();
+        let change_dir = repo.join("openspec/changes/discovered");
+        fs::create_dir_all(&change_dir).unwrap();
+        fs::write(change_dir.join("proposal.md"), "# Discovered\n").unwrap();
+        fs::write(change_dir.join("tasks.md"), "- [ ] pending\n").unwrap();
+        let feature = LifecycleFeature::new(&repo);
+
+        let result = feature
+            .execute_openspec_manage(&json!({"action": "status"}))
+            .unwrap();
+        let text = result.content[0].as_text().unwrap();
+        assert!(
+            text.contains("discovered"),
+            "should list file-backed change: {text}"
+        );
+        assert!(
+            !repo.join("ai/lifecycle/state.json").exists(),
+            "read-only status must not write lifecycle state"
         );
     }
 

--- a/core/crates/omegon/src/features/lifecycle.rs
+++ b/core/crates/omegon/src/features/lifecycle.rs
@@ -2248,8 +2248,8 @@ mod tests {
         let text = result.content[0].as_text().unwrap();
         assert!(text.contains("auth"), "should list spec domain: {text}");
         let change: Value = serde_json::from_str(text).unwrap();
-        assert_eq!(change["state"].as_str(), Some("specified"));
-        assert_eq!(change["stage"].as_str(), Some("specified"));
+        assert_eq!(change["state"].as_str(), Some("specced"));
+        assert_eq!(change["stage"].as_str(), Some("specced"));
         assert_eq!(change["file_stage"].as_str(), Some("specified"));
     }
 

--- a/core/crates/omegon/src/lifecycle/read_model.rs
+++ b/core/crates/omegon/src/lifecycle/read_model.rs
@@ -243,39 +243,6 @@ fn is_archived_change(change: &ChangeInfo) -> bool {
     false
 }
 
-fn sync_opsx_change_from_info(
-    opsx: &mut OpsxLifecycle<JsonFileStore>,
-    change: &ChangeInfo,
-) -> anyhow::Result<()> {
-    if !opsx.state().changes.iter().any(|c| c.name == change.name) {
-        opsx.create_change(&change.name, &change.name, None)?;
-    }
-    for spec in &change.specs {
-        opsx.add_spec(&change.name, &spec.domain)?;
-    }
-    opsx.update_change_progress(&change.name, change.total_tasks, change.done_tasks)?;
-
-    if opsx_change_state(opsx, &change.name) == Some(ChangeState::Proposed)
-        && !change.specs.is_empty()
-    {
-        opsx.transition_change(&change.name, ChangeState::Specced)?;
-    }
-    if opsx_change_state(opsx, &change.name) == Some(ChangeState::Specced) && change.total_tasks > 0
-    {
-        opsx.transition_change(&change.name, ChangeState::Planned)?;
-    }
-
-    Ok(())
-}
-
-fn opsx_change_state(opsx: &OpsxLifecycle<JsonFileStore>, name: &str) -> Option<ChangeState> {
-    opsx.state()
-        .changes
-        .iter()
-        .find(|c| c.name == name)
-        .map(|c| c.state)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -344,6 +311,33 @@ mod tests {
         assert_eq!(snapshot.changes.len(), 1);
         assert_eq!(snapshot.changes[0].lifecycle_state, "proposed");
         assert!(handle.opsx.lock().unwrap().state().changes.is_empty());
+    }
+
+    #[test]
+    fn openspec_snapshot_does_not_materialize_discovered_changes() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = dir.path();
+        let change_dir = repo.join("openspec/changes/discovered-change");
+        fs::create_dir_all(&change_dir).unwrap();
+        fs::write(change_dir.join("proposal.md"), "# Discovered\n").unwrap();
+        fs::write(change_dir.join("tasks.md"), "- [ ] pending\n").unwrap();
+
+        let provider = Arc::new(Mutex::new(LifecycleContextProvider::new(repo)));
+        let opsx = Arc::new(Mutex::new(
+            OpsxLifecycle::load(JsonFileStore::new(repo)).unwrap(),
+        ));
+        let handle = LifecycleReadHandle::new(provider, opsx, repo.to_path_buf());
+
+        let snapshot = handle
+            .openspec_snapshot(SnapshotOptions::default())
+            .unwrap();
+        assert_eq!(snapshot.changes.len(), 1);
+        assert_eq!(snapshot.changes[0].name, "discovered-change");
+        assert_eq!(snapshot.changes[0].lifecycle_state, "proposed");
+        assert!(
+            !repo.join("ai/lifecycle/state.json").exists(),
+            "read-only snapshot must not write lifecycle state"
+        );
     }
 
     #[test]

--- a/core/crates/omegon/src/loop.rs
+++ b/core/crates/omegon/src/loop.rs
@@ -2291,7 +2291,12 @@ async fn dispatch_tools(
 }
 
 fn is_parallel_safe_read_only_tool(name: &str) -> bool {
-    matches!(name, "read" | "view" | "web_search" | "whoami" | "chronos")
+    // File reads can hit workspace-boundary permission prompts. Those prompts
+    // are interactive and single-pending in the TUI, so dispatching read/view
+    // in parallel can overwrite the visible responder and leave earlier reads
+    // blocked until timeout. Keep filesystem reads serial; only inherently
+    // permissionless read-only tools may run concurrently.
+    matches!(name, "web_search" | "whoami" | "chronos")
 }
 
 fn enrich_plan_list_tool_results(
@@ -4312,7 +4317,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn parallel_safe_read_only_tools_dispatch_concurrently() {
+    async fn non_filesystem_read_only_tools_dispatch_concurrently() {
         use omegon_traits::ToolResult;
         use tokio::time::{Duration, Instant, sleep};
 
@@ -4323,16 +4328,16 @@ mod tests {
             fn tools(&self) -> Vec<omegon_traits::ToolDefinition> {
                 vec![
                     omegon_traits::ToolDefinition {
-                        name: "read".into(),
-                        label: "read".into(),
-                        description: "read file".into(),
+                        name: "whoami".into(),
+                        label: "whoami".into(),
+                        description: "identity".into(),
                         parameters: serde_json::json!({}),
                         capabilities: vec![],
                     },
                     omegon_traits::ToolDefinition {
-                        name: "view".into(),
-                        label: "view".into(),
-                        description: "view file".into(),
+                        name: "chronos".into(),
+                        label: "chronos".into(),
+                        description: "clock".into(),
                         parameters: serde_json::json!({}),
                         capabilities: vec![],
                     },
@@ -4367,13 +4372,13 @@ mod tests {
         let calls = vec![
             ToolCall {
                 id: "1".into(),
-                name: "read".into(),
-                arguments: serde_json::json!({"path": "a.txt"}),
+                name: "whoami".into(),
+                arguments: serde_json::json!({}),
             },
             ToolCall {
                 id: "2".into(),
-                name: "view".into(),
-                arguments: serde_json::json!({"path": "b.txt"}),
+                name: "chronos".into(),
+                arguments: serde_json::json!({}),
             },
         ];
 
@@ -4387,8 +4392,14 @@ mod tests {
             elapsed < Duration::from_millis(260),
             "expected parallel dispatch, got {elapsed:?}"
         );
-        assert_eq!(dispatch.results[0].tool_name, "read");
-        assert_eq!(dispatch.results[1].tool_name, "view");
+        assert_eq!(dispatch.results[0].tool_name, "whoami");
+        assert_eq!(dispatch.results[1].tool_name, "chronos");
+    }
+
+    #[tokio::test]
+    async fn filesystem_read_tools_dispatch_serially_to_preserve_permission_prompts() {
+        assert!(!is_parallel_safe_read_only_tool("read"));
+        assert!(!is_parallel_safe_read_only_tool("view"));
     }
 
     // ── Turn limit + config tests ──────────────────────────────────────

--- a/core/crates/omegon/src/tui/mod.rs
+++ b/core/crates/omegon/src/tui/mod.rs
@@ -1699,6 +1699,44 @@ enum SlimPlanHintState {
     Complete,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct SlimPlanContext {
+    pinned: bool,
+    tracked: bool,
+    openspec_changes: usize,
+    focused_design: bool,
+}
+
+impl SlimPlanContext {
+    fn from_dashboard(
+        pinned: bool,
+        active_changes: &[dashboard::ChangeSummary],
+        focused_node: Option<&dashboard::FocusedNodeSummary>,
+    ) -> Self {
+        Self {
+            pinned,
+            tracked: pinned || !active_changes.is_empty() || focused_node.is_some(),
+            openspec_changes: active_changes.len(),
+            focused_design: focused_node.is_some(),
+        }
+    }
+
+    fn labels(&self) -> Vec<String> {
+        let mut labels = Vec::new();
+        labels.push(if self.pinned { "pinned" } else { "unpinned" }.to_string());
+        if self.tracked {
+            labels.push("tracked".to_string());
+        }
+        if self.openspec_changes > 0 {
+            labels.push(format!("OpenSpec×{}", self.openspec_changes));
+        }
+        if self.focused_design {
+            labels.push("design-linked".to_string());
+        }
+        labels
+    }
+}
+
 fn slim_completed_plan_hint_available(completed_plan_history_available: bool) -> bool {
     completed_plan_history_available
 }
@@ -1708,7 +1746,7 @@ fn slim_operator_hint(
     pending_operator_wait: bool,
     terminal_copy_mode: bool,
     plan_state: SlimPlanHintState,
-    automation: &str,
+    plan_context: &SlimPlanContext,
 ) -> String {
     if pending_permission {
         "permission · y once · a always · n deny".to_string()
@@ -1719,15 +1757,19 @@ fn slim_operator_hint(
     } else {
         match plan_state {
             SlimPlanHintState::Active { next_visible: true } => {
-                format!("plan active · advance · suspend · {automation}")
+                let mut labels = vec!["plan active".to_string()];
+                labels.extend(plan_context.labels());
+                labels.join(" · ")
             }
             SlimPlanHintState::Active {
                 next_visible: false,
             } => {
-                format!("plan: next · advance · {automation}")
+                let mut labels = vec!["plan active".to_string(), "next below".to_string()];
+                labels.extend(plan_context.labels());
+                labels.join(" · ")
             }
-            SlimPlanHintState::Complete => "plan done · view".to_string(),
-            SlimPlanHintState::None => format!("copy · transcript · {automation}"),
+            SlimPlanHintState::Complete => "plan complete · history available".to_string(),
+            SlimPlanHintState::None => "transcript live · no pinned plan".to_string(),
         }
     }
 }
@@ -4388,7 +4430,6 @@ impl App {
                 None
             };
             self.status_line.turn_state = Some(self.slim_turn_state.label());
-            let automation = self.settings().automation_level.as_str();
             let plan_state = slim_plan_snapshot
                 .as_ref()
                 .map(|snapshot| snapshot.hint_state(slim_plan_area.height))
@@ -4399,12 +4440,17 @@ impl App {
                         SlimPlanHintState::None
                     }
                 });
+            let plan_context = SlimPlanContext::from_dashboard(
+                slim_plan_snapshot.is_some(),
+                &self.dashboard.active_changes,
+                self.dashboard.focused_node.as_ref(),
+            );
             self.status_line.operator_hint = Some(slim_operator_hint(
                 self.pending_permission.is_some(),
                 self.pending_operator_wait.is_some(),
                 self.terminal_copy_mode,
                 plan_state,
-                automation,
+                &plan_context,
             ));
             self.status_line
                 .render(status_area, frame, self.theme.as_ref());
@@ -10284,11 +10330,12 @@ mod slash_command_parsing_tests {
     use super::TuiCommand;
     use super::canonical_slash_command;
     use super::{
-        ActiveToolStream, PlanDisplayItem, PlanDisplaySnapshot, PlanDisplayStatus,
-        SlimPlanHintState, format_permission_prompt, permission_persist_scope_label,
+        ActiveToolStream, PlanDisplayItem, PlanDisplaySnapshot, PlanDisplayStatus, SlimPlanContext,
+        SlimPlanHintState, dashboard, format_permission_prompt, permission_persist_scope_label,
         permission_response_for_key, slim_completed_plan_hint_available, slim_operator_hint,
         slim_pinned_plan_snapshot, slim_plan_rows,
     };
+    use crate::lifecycle::types::NodeStatus;
     use crossterm::event::{KeyCode, KeyModifiers};
     use tokio::sync::mpsc;
 
@@ -10594,21 +10641,27 @@ mod slash_command_parsing_tests {
     #[test]
     fn slim_operator_hint_prioritizes_blocking_prompts() {
         let active = SlimPlanHintState::Active { next_visible: true };
+        let context = SlimPlanContext {
+            pinned: true,
+            tracked: true,
+            openspec_changes: 2,
+            focused_design: true,
+        };
         assert_eq!(
-            slim_operator_hint(true, true, true, active, "assistive"),
+            slim_operator_hint(true, true, true, active, &context),
             "permission · y once · a always · n deny"
         );
         assert_eq!(
-            slim_operator_hint(false, true, true, active, "assistive"),
+            slim_operator_hint(false, true, true, active, &context),
             "manual wait · Enter done · Esc cancel"
         );
         assert_eq!(
-            slim_operator_hint(false, false, true, active, "assistive"),
+            slim_operator_hint(false, false, true, active, &context),
             "copy mode · select text · /mouse on exits"
         );
         assert_eq!(
-            slim_operator_hint(false, false, false, active, "assistive"),
-            "plan active · advance · suspend · assistive"
+            slim_operator_hint(false, false, false, active, &context),
+            "plan active · pinned · tracked · OpenSpec×2 · design-linked"
         );
         assert_eq!(
             slim_operator_hint(
@@ -10618,24 +10671,47 @@ mod slash_command_parsing_tests {
                 SlimPlanHintState::Active {
                     next_visible: false
                 },
-                "assistive"
+                &context
             ),
-            "plan: next · advance · assistive"
+            "plan active · next below · pinned · tracked · OpenSpec×2 · design-linked"
         );
         assert_eq!(
-            slim_operator_hint(
-                false,
-                false,
-                false,
-                SlimPlanHintState::Complete,
-                "assistive"
-            ),
-            "plan done · view"
+            slim_operator_hint(false, false, false, SlimPlanHintState::Complete, &context),
+            "plan complete · history available"
         );
         assert_eq!(
-            slim_operator_hint(false, false, false, SlimPlanHintState::None, "assistive"),
-            "copy · transcript · assistive"
+            slim_operator_hint(false, false, false, SlimPlanHintState::None, &context),
+            "transcript live · no pinned plan"
         );
+    }
+
+    #[test]
+    fn slim_plan_context_labels_pin_tracking_and_lifecycle_links() {
+        let changes = vec![dashboard::ChangeSummary {
+            name: "rollup".into(),
+            stage: "implementing".into(),
+            done_tasks: 1,
+            total_tasks: 3,
+        }];
+        let focused = dashboard::FocusedNodeSummary {
+            id: "node".into(),
+            title: "Node".into(),
+            status: NodeStatus::Exploring,
+            open_questions: 0,
+            assumptions: 0,
+            decisions: 1,
+            readiness: 1.0,
+            openspec_change: Some("rollup".into()),
+        };
+
+        let context = SlimPlanContext::from_dashboard(true, &changes, Some(&focused));
+        assert_eq!(
+            context.labels(),
+            vec!["pinned", "tracked", "OpenSpec×1", "design-linked"]
+        );
+
+        let context = SlimPlanContext::from_dashboard(false, &[], None);
+        assert_eq!(context.labels(), vec!["unpinned"]);
     }
 
     #[test]

--- a/core/crates/omegon/src/tui/mod.rs
+++ b/core/crates/omegon/src/tui/mod.rs
@@ -1443,7 +1443,9 @@ enum PlanDisplayStatus {
 enum SlimTurnState {
     #[default]
     Ready,
-    Running,
+    RequestingProvider,
+    OpeningStream,
+    UpstreamRetrying(String),
     Thinking,
     Responding,
     Tool(String),
@@ -1454,12 +1456,37 @@ impl SlimTurnState {
     fn label(&self) -> String {
         match self {
             Self::Ready => "ready".to_string(),
-            Self::Running => "turn running".to_string(),
-            Self::Thinking => "thinking".to_string(),
-            Self::Responding => "responding".to_string(),
+            Self::RequestingProvider => "waiting: provider request".to_string(),
+            Self::OpeningStream => "waiting: stream open".to_string(),
+            Self::UpstreamRetrying(detail) => format!("retrying upstream {detail}"),
+            Self::Thinking => "streaming thinking".to_string(),
+            Self::Responding => "streaming answer".to_string(),
             Self::Tool(name) => format!("running {name}"),
             Self::Finished(reason) => format!("turn {reason}"),
         }
+    }
+}
+
+fn upstream_retry_hint(message: &str) -> Option<String> {
+    if !(message.contains("— retrying") || message.starts_with("Retrying")) {
+        return None;
+    }
+    let attempt = message
+        .split("attempt ")
+        .nth(1)
+        .and_then(|rest| rest.split([',', ')']).next())
+        .map(str::trim)
+        .filter(|s| !s.is_empty());
+    let delay = message
+        .split("delay ")
+        .nth(1)
+        .and_then(|rest| rest.split("ms").next())
+        .map(str::trim)
+        .filter(|s| !s.is_empty());
+    match (attempt, delay) {
+        (Some(attempt), Some(delay)) => Some(format!("attempt {attempt} · {delay}ms")),
+        (Some(attempt), None) => Some(format!("attempt {attempt}")),
+        _ => Some("active".to_string()),
     }
 }
 
@@ -7574,7 +7601,7 @@ impl App {
         match event {
             AgentEvent::TurnStart { turn } => {
                 self.agent_active = true;
-                self.slim_turn_state = SlimTurnState::Running;
+                self.slim_turn_state = SlimTurnState::RequestingProvider;
                 if let Ok(mut ss) = self.dashboard_handles.session.lock() {
                     ss.busy = true;
                 }
@@ -7666,6 +7693,9 @@ impl App {
                 // Detect if the agent is asking for confirmation and offer
                 // a one-key continuation affordance in the editor.
                 self.detect_continuation_request();
+            }
+            AgentEvent::MessageStart { .. } => {
+                self.slim_turn_state = SlimTurnState::OpeningStream;
             }
             AgentEvent::MessageChunk { text } => {
                 self.slim_turn_state = SlimTurnState::Responding;
@@ -7943,7 +7973,7 @@ impl App {
                     self.active_tool_stream = None;
                 }
                 if self.agent_active {
-                    self.slim_turn_state = SlimTurnState::Running;
+                    self.slim_turn_state = SlimTurnState::RequestingProvider;
                 }
             }
             AgentEvent::AgentEnd => {
@@ -8006,6 +8036,9 @@ impl App {
                 }
             }
             AgentEvent::SystemNotification { message } => {
+                if let Some(detail) = upstream_retry_hint(&message) {
+                    self.slim_turn_state = SlimTurnState::UpstreamRetrying(detail);
+                }
                 // Transient retry notifications → toast (operator sees them but they
                 // don't clutter the conversation). Milestone warnings and other
                 // persistent messages → conversation.

--- a/core/crates/omegon/src/tui/mod.rs
+++ b/core/crates/omegon/src/tui/mod.rs
@@ -1377,6 +1377,7 @@ fn slim_plan_snapshot_height(snapshot: &PlanDisplaySnapshot, width: u16) -> u16 
 struct ActiveToolStream {
     id: String,
     name: String,
+    started_at: std::time::Instant,
     lines: Vec<String>,
 }
 
@@ -1385,6 +1386,7 @@ impl ActiveToolStream {
         Self {
             id: id.into(),
             name: name.into(),
+            started_at: std::time::Instant::now(),
             lines: Vec::new(),
         }
     }
@@ -1730,6 +1732,17 @@ fn slim_operator_hint(
     }
 }
 
+fn format_short_elapsed(duration: std::time::Duration) -> String {
+    let secs = duration.as_secs();
+    if secs < 60 {
+        format!("{secs}s")
+    } else {
+        let mins = secs / 60;
+        let rem = secs % 60;
+        format!("{mins}m{rem:02}s")
+    }
+}
+
 fn render_active_tool_stream_panel(
     area: Rect,
     frame: &mut Frame,
@@ -1750,6 +1763,10 @@ fn render_active_tool_stream_panel(
                 .fg(t.accent())
                 .bg(bg)
                 .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(
+            format!(" · {}", format_short_elapsed(stream.started_at.elapsed())),
+            Style::default().fg(t.muted()).bg(bg),
         ),
     ]));
     let max_tail = area.height.saturating_sub(1) as usize;

--- a/core/crates/omegon/src/tui/statusline.rs
+++ b/core/crates/omegon/src/tui/statusline.rs
@@ -128,7 +128,10 @@ impl StatusLine {
 
         // CWD basename (≥55)
         if w >= 55 && !self.cwd_basename.is_empty() {
-            let field = Span::styled(self.cwd_basename.clone(), Style::default().fg(t.muted()));
+            let field = Span::styled(
+                format!("dir {}", self.cwd_basename),
+                Style::default().fg(t.muted()),
+            );
             let cost = sect.width() + field.width();
             if used + cost < w {
                 spans.push(sect.clone());
@@ -141,7 +144,7 @@ impl StatusLine {
         if w >= 65
             && let Some(ref branch) = self.git_branch
         {
-            let field = Span::styled(branch.clone(), Style::default().fg(t.muted()));
+            let field = Span::styled(format!("git {branch}"), Style::default().fg(t.muted()));
             let cost = sep.width() + field.width();
             if used + cost < w {
                 spans.push(sep.clone());
@@ -168,17 +171,11 @@ impl StatusLine {
         if w >= 85
             && let Some(phase) = &self.phase
         {
-            let (label, color) = match phase {
-                OodaPhase::Act => ("Act", t.accent()),
-                OodaPhase::Observe => ("Observe", t.muted()),
-                OodaPhase::Orient => ("Orient", t.muted()),
-                OodaPhase::Decide => ("Decide", t.muted()),
-            };
-            let field = Span::styled(label, Style::default().fg(color));
-            let cost = sep.width() + field.width();
+            let ooda = ooda_phase_spans(*phase, t);
+            let cost = sep.width() + ooda.iter().map(|span| span.width()).sum::<usize>();
             if used + cost < w {
                 spans.push(sep.clone());
-                spans.push(field);
+                spans.extend(ooda);
                 used += cost;
             }
         }
@@ -244,6 +241,39 @@ fn fmt_tokens(count: u64) -> String {
     widgets::format_tokens_compact(count as usize)
 }
 
+fn ooda_phase_spans(phase: OodaPhase, t: &dyn Theme) -> Vec<Span<'static>> {
+    let active = match phase {
+        OodaPhase::Observe => 0,
+        OodaPhase::Orient => 1,
+        OodaPhase::Decide => 2,
+        OodaPhase::Act => 3,
+    };
+    let label = match phase {
+        OodaPhase::Observe => "Observe",
+        OodaPhase::Orient => "Orient",
+        OodaPhase::Decide => "Decide",
+        OodaPhase::Act => "Act",
+    };
+    let letters = ['o', 'o', 'd', 'a'];
+    let mut spans = Vec::new();
+    for (idx, ch) in letters.into_iter().enumerate() {
+        if idx == active {
+            spans.push(Span::styled(
+                ch.to_ascii_uppercase().to_string(),
+                Style::default().fg(t.accent()),
+            ));
+        } else {
+            spans.push(Span::styled(ch.to_string(), Style::default().fg(t.dim())));
+        }
+    }
+    spans.push(Span::styled(" ".to_string(), Style::default().fg(t.dim())));
+    spans.push(Span::styled(
+        label.to_string(),
+        Style::default().fg(t.accent()),
+    ));
+    spans
+}
+
 fn file_activity_label(read: usize, modified: usize, width: usize) -> String {
     let total = read + modified;
     if width >= 115 && read > 0 && modified > 0 {
@@ -278,6 +308,53 @@ mod tests {
         assert!(sl.viewport_hint.is_none());
         assert!(sl.turn_state.is_none());
         assert!(sl.operator_hint.is_none());
+    }
+
+    #[test]
+    fn ooda_phase_label_lights_active_letter() {
+        let t = super::super::theme::Alpharius;
+        let rendered = |phase| {
+            ooda_phase_spans(phase, &t)
+                .into_iter()
+                .map(|span| span.content.to_string())
+                .collect::<String>()
+        };
+
+        assert_eq!(rendered(OodaPhase::Observe), "Ooda Observe");
+        assert_eq!(rendered(OodaPhase::Orient), "oOda Orient");
+        assert_eq!(rendered(OodaPhase::Decide), "ooDa Decide");
+        assert_eq!(rendered(OodaPhase::Act), "oodA Act");
+    }
+
+    #[test]
+    fn status_line_icons_label_directory_branch_and_ooda() {
+        let mut sl = StatusLine {
+            context_percent: 50.0,
+            turn: 8,
+            model_short: "gpt".into(),
+            session_input_tokens: 32_000,
+            session_output_tokens: 2_000,
+            cwd_basename: "omegon".into(),
+            git_branch: Some("fix/footer".into()),
+            phase: Some(OodaPhase::Act),
+            ..Default::default()
+        };
+        sl.operator_hint = Some("plan active".into());
+
+        let backend = ratatui::backend::TestBackend::new(160, 1);
+        let mut terminal = ratatui::Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| sl.render(frame.area(), frame, &super::super::theme::Alpharius))
+            .unwrap();
+        let buf = terminal.backend().buffer();
+        let mut text = String::new();
+        for x in 0..160 {
+            text.push_str(buf[(x, 0)].symbol());
+        }
+
+        assert!(text.contains("dir omegon"), "{text}");
+        assert!(text.contains("git fix/footer"), "{text}");
+        assert!(text.contains("oodA Act"), "{text}");
     }
 
     #[test]

--- a/core/crates/omegon/src/tui/tests.rs
+++ b/core/crates/omegon/src/tui/tests.rs
@@ -176,6 +176,33 @@ fn editor_inline_attachment_tokens_submit_as_multimodal_prompt() {
 #[test]
 fn session_reset_clears_instrument_panel_tool_activity() {
     let mut app = test_app();
+    let waiting = render_app_to_string(&mut app, 140, 18);
+    assert!(
+        waiting.contains("waiting: provider request")
+            || waiting.contains("transcript live · no pinned plan"),
+        "{waiting}"
+    );
+
+    app.handle_agent_event(AgentEvent::MessageStart {
+        role: "assistant".into(),
+    });
+    let opening = render_app_to_string(&mut app, 140, 18);
+    assert!(
+        opening.contains("waiting: stream open")
+            || opening.contains("transcript live · no pinned plan"),
+        "{opening}"
+    );
+
+    app.handle_agent_event(AgentEvent::MessageChunk {
+        text: "hello".into(),
+    });
+    let responding = render_app_to_string(&mut app, 140, 18);
+    assert!(
+        responding.contains("streaming answer")
+            || responding.contains("transcript live · no pinned plan"),
+        "{responding}"
+    );
+
     app.handle_agent_event(AgentEvent::ToolStart {
         id: "tool-1".into(),
         name: "context_clear".into(),
@@ -1024,7 +1051,7 @@ fn completed_plan_update_enables_done_view_hint_without_pinning() {
     assert!(app.completed_plan_history_available);
     assert!(app.slim_plan_snapshot.is_none());
     let text = render_app_to_string(&mut app, 120, 18);
-    assert!(text.contains("plan done · view"), "{text}");
+    assert!(text.contains("plan complete · history available"), "{text}");
     assert!(
         !text.contains("remember me"),
         "completed history should not pin active lane: {text}"
@@ -4477,6 +4504,21 @@ fn recovery_hint_context_window() {
     assert!(
         hint.contains("/context compact"),
         "should suggest context compact: {hint}"
+    );
+}
+
+#[test]
+fn retry_notification_marks_turn_state_as_upstream_retry() {
+    let mut app = test_app();
+    app.handle_agent_event(AgentEvent::TurnStart { turn: 1 });
+    app.handle_agent_event(AgentEvent::SystemNotification {
+        message: "⚠ Upstream rate_limit — retrying (attempt 3, delay 1500ms): provider busy".into(),
+    });
+
+    let rendered = render_app_to_string(&mut app, 150, 18);
+    assert!(
+        rendered.contains("retrying upstream attempt 3 · 1500ms"),
+        "{rendered}"
     );
 }
 

--- a/core/crates/omegon/src/tui/tests.rs
+++ b/core/crates/omegon/src/tui/tests.rs
@@ -1083,8 +1083,12 @@ fn slim_status_line_marks_turn_state() {
         name: "bash".into(),
         args: serde_json::json!({"command":"cargo test"}),
     });
+    if let Some(stream) = app.active_tool_stream.as_mut() {
+        stream.started_at -= std::time::Duration::from_secs(54);
+    }
     let running = render_app_to_string(&mut app, 140, 18);
     assert!(running.contains("running bash"), "{running}");
+    assert!(running.contains("active tool bash · 54s"), "{running}");
 
     app.handle_agent_event(AgentEvent::TurnEnd(Box::new(
         omegon_traits::AgentEventTurnEnd {


### PR DESCRIPTION
## Summary
- show elapsed time and clearer wait states for active turns/tools in Slim mode
- replace unclear Slim plan footer actions with plan/lifecycle status labels
- label Slim footer telemetry fields for directory, git branch, and OODA phase
- prevent lifecycle read-path churn in OpenSpec status/snapshot reads
- serialize filesystem read/view tools so permission prompts cannot overwrite each other

## Validation
- cargo test -p omegon --bin omegon slim_status_line_marks_turn_state
- cargo test -p omegon --bin omegon retry_notification_marks_turn_state_as_upstream_retry
- cargo test -p omegon --bin omegon filesystem_read_tools_dispatch_serially_to_preserve_permission_prompts
- cargo test -p omegon --bin omegon non_filesystem_read_only_tools_dispatch_concurrently
- cargo test -p omegon --bin omegon ooda_phase_label_lights_active_letter
- cargo test -p omegon --bin omegon status_line_icons_label_directory_branch_and_ooda
- cargo test -p omegon --bin omegon slim_operator_hint_prioritizes_blocking_prompts
- cargo test -p omegon --bin omegon slim_plan_context_labels_pin_tracking_and_lifecycle_links
- cargo test -p omegon --bin omegon openspec_status_does_not_materialize_discovered_changes
- cargo test -p omegon --bin omegon openspec_snapshot_does_not_materialize_discovered_changes
- cargo test -p omegon-opsx update_change_progress