### PR TITLE
fix(terminal): expose background session placement and inspection hints

### DIFF
--- a/core/crates/omegon-extension/src/actions/terminal.rs
+++ b/core/crates/omegon-extension/src/actions/terminal.rs
@@ -64,6 +64,8 @@ pub enum TerminalPlacement {
     BottomPane,
     /// Open in a new tab/window when supported.
     NewTab,
+    /// Run as a managed background terminal session with transcript inspection.
+    BackgroundSession,
 }
 
 /// Result payload for `terminal.create@1`.
@@ -99,6 +101,20 @@ mod tests {
         let json = serde_json::to_value(&params).unwrap();
         assert_eq!(json["command"], "bookokrat");
         assert_eq!(json["placement"], "side_pane");
+
+        let background = TerminalCreateParams {
+            command: "bookokrat".to_string(),
+            args: Vec::new(),
+            cwd: None,
+            env: BTreeMap::new(),
+            title: None,
+            placement: Some(TerminalPlacement::BackgroundSession),
+            reuse_key: None,
+        };
+        assert_eq!(
+            serde_json::to_value(background).unwrap()["placement"],
+            "background_session"
+        );
         let parsed: TerminalCreateParams = serde_json::from_value(json).unwrap();
         assert_eq!(parsed, params);
     }

--- a/core/crates/omegon/src/extensions/host_actions.rs
+++ b/core/crates/omegon/src/extensions/host_actions.rs
@@ -749,11 +749,15 @@ impl TerminalCreateBackend for RealTerminalCreateBackend {
         })
         .join()
         .map_err(|_| "terminal backend worker panicked".to_string())??;
+        let mut warnings = response.warnings;
+        if response.actual_placement == "background_session" {
+            warnings.push(response.inspect_hint.clone());
+        }
         Ok(omegon_extension::actions::terminal::TerminalCreateResult {
             terminal_id: response.terminal_id,
             backend: response.backend,
             actual_placement: response.actual_placement,
-            warnings: response.warnings,
+            warnings,
         })
     }
 }

--- a/core/crates/omegon/src/extensions/host_actions.rs
+++ b/core/crates/omegon/src/extensions/host_actions.rs
@@ -878,9 +878,9 @@ impl TerminalCreateLaunchPlan {
             Some(omegon_extension::actions::terminal::TerminalPlacement::NewTab) => {
                 TerminalPlacementCapability::NewTab
             }
-            Some(omegon_extension::actions::terminal::TerminalPlacement::Default) | None => {
-                TerminalPlacementCapability::BackgroundSession
-            }
+            Some(omegon_extension::actions::terminal::TerminalPlacement::Default)
+            | Some(omegon_extension::actions::terminal::TerminalPlacement::BackgroundSession)
+            | None => TerminalPlacementCapability::BackgroundSession,
         }
     }
 }
@@ -1558,6 +1558,13 @@ allowed = [{allowed}]
         let result = outcome.result.unwrap();
         assert_eq!(result["backend"], "portable_pty");
         assert_eq!(result["actual_placement"], "background_session");
+        let warnings = result["warnings"].as_array().expect("warnings array");
+        assert!(
+            warnings.iter().any(|warning| warning
+                .as_str()
+                .is_some_and(|text| text.contains("placement degraded"))),
+            "warnings: {warnings:?}"
+        );
         assert!(
             result["warnings"][0]
                 .as_str()
@@ -1590,6 +1597,109 @@ allowed = [{allowed}]
         assert_eq!(result["backend"], "flynt_side_pane");
         assert_eq!(result["actual_placement"], "side_pane");
         assert!(result["warnings"].as_array().is_none_or(Vec::is_empty));
+    }
+
+    #[test]
+    fn terminal_create_background_result_includes_inspection_hint() {
+        let manifest = terminal_manifest(&["printf"], &["${workspace}"], &[]);
+        let outcome = process_host_action_candidate_with_approval_decision(
+            json!({
+                "id": "open-bg",
+                "type": "terminal.create@1",
+                "execution": "manual",
+                "params": {
+                    "command": "printf",
+                    "args": ["visible"],
+                    "cwd": ".",
+                    "placement": "background_session"
+                }
+            }),
+            &manifest,
+            ScopedHostActionId {
+                origin: HostActionOrigin::native_extension("reader"),
+                session_id: "test-session".into(),
+                tool_call_id: "tc1".into(),
+                action_id: "open-bg".into(),
+            },
+            &RuntimeHostActionPolicy::default(),
+            &HostActionExecutorRegistry::with_real_terminal_backend(
+                std::env::current_dir().unwrap(),
+            ),
+            crate::extensions::approval::HostActionApprovalDecision::Approved,
+        );
+
+        assert_eq!(
+            outcome.status,
+            omegon_extension::HostActionStatus::Completed,
+            "outcome: {outcome:?}"
+        );
+        let result = outcome.result.expect("result");
+        assert_eq!(result["actual_placement"], "background_session");
+        let warnings = result["warnings"].as_array().expect("warnings array");
+        let warning_text = warnings
+            .iter()
+            .filter_map(|v| v.as_str())
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(
+            !warning_text.contains("placement degraded"),
+            "{warning_text}"
+        );
+        assert!(warning_text.contains("terminal.read"), "{warning_text}");
+        assert!(warning_text.contains("terminal.stop"), "{warning_text}");
+        assert!(warning_text.contains("open transcript"), "{warning_text}");
+    }
+
+    #[test]
+    fn terminal_create_side_pane_degradation_includes_inspection_hint() {
+        let manifest = terminal_manifest(&["printf"], &["${workspace}"], &[]);
+        let outcome = process_host_action_candidate_with_approval_decision(
+            json!({
+                "id": "open-side",
+                "type": "terminal.create@1",
+                "execution": "manual",
+                "params": {
+                    "command": "printf",
+                    "args": ["side-visible"],
+                    "cwd": ".",
+                    "placement": "side_pane"
+                }
+            }),
+            &manifest,
+            ScopedHostActionId {
+                origin: HostActionOrigin::native_extension("reader"),
+                session_id: "test-session".into(),
+                tool_call_id: "tc1".into(),
+                action_id: "open-side".into(),
+            },
+            &RuntimeHostActionPolicy::default(),
+            &HostActionExecutorRegistry::with_real_terminal_backend(
+                std::env::current_dir().unwrap(),
+            ),
+            crate::extensions::approval::HostActionApprovalDecision::Approved,
+        );
+
+        assert_eq!(
+            outcome.status,
+            omegon_extension::HostActionStatus::Completed,
+            "outcome: {outcome:?}"
+        );
+        let result = outcome.result.expect("result");
+        assert_eq!(result["actual_placement"], "background_session");
+        let warning_text = result["warnings"]
+            .as_array()
+            .expect("warnings array")
+            .iter()
+            .filter_map(|v| v.as_str())
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(
+            warning_text.contains("placement degraded"),
+            "{warning_text}"
+        );
+        assert!(warning_text.contains("terminal.read"), "{warning_text}");
+        assert!(warning_text.contains("terminal.stop"), "{warning_text}");
+        assert!(warning_text.contains("open transcript"), "{warning_text}");
     }
 
     #[test]

--- a/core/crates/omegon/src/tools/terminal.rs
+++ b/core/crates/omegon/src/tools/terminal.rs
@@ -63,6 +63,9 @@ pub struct HostTerminalCreateResponse {
     pub backend: String,
     pub actual_placement: String,
     pub warnings: Vec<String>,
+    pub transcript: String,
+    pub tail: String,
+    pub inspect_hint: String,
 }
 
 pub fn host_terminal_runtime_available() -> Result<(), String> {
@@ -153,7 +156,7 @@ pub async fn start_host_terminal(
         cwd: request.cwd,
         pid,
         started: Instant::now(),
-        transcript_path,
+        transcript_path: transcript_path.clone(),
         child: Mutex::new(child),
         writer: Mutex::new(writer),
         _master: Mutex::new(pair.master),
@@ -165,11 +168,19 @@ pub async fn start_host_terminal(
     spawn_reader(session.clone(), reader);
     registry().lock().unwrap().insert(id.clone(), session);
 
+    let inspect_hint = format!(
+        "Use terminal.read with session_id={id} to inspect output, terminal.stop with session_id={id} to stop it, or open transcript {}.",
+        transcript_path.display()
+    );
+
     Ok(HostTerminalCreateResponse {
         terminal_id: id,
         backend: "portable_pty".to_string(),
         actual_placement: "background_session".to_string(),
         warnings: Vec::new(),
+        transcript: transcript_path.display().to_string(),
+        tail: String::new(),
+        inspect_hint,
     })
 }
 


### PR DESCRIPTION
## Summary

Closes #104 by making background terminal sessions first-class and inspectable when `terminal.create@1` uses or degrades to the portable PTY backend.

## What changed

- Adds `background_session` as a valid `terminal.create@1` requested placement.
- Returns background inspection metadata from the host terminal backend.
- Surfaces inspection guidance through existing `TerminalCreateResult.warnings`, including:
  - `terminal.read` session hint
  - `terminal.stop` session hint
  - transcript path hint
- Keeps visual placement degradation explicit: `side_pane` -> `background_session` still reports placement degraded and now also reports inspection guidance.

## Validation

- `cargo test -p omegon-extension terminal_create -- --nocapture`
- `cargo test -p omegon terminal_create_background -- --nocapture`
- `cargo test -p omegon terminal_create_side_pane_degradation -- --nocapture`
- `cargo test -p omegon terminal_create -- --nocapture`
- `just lint`
