### PR TITLE
fix(ci): let upstream version sync create PRs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [Semantic V
 
 ## [Unreleased]
 
+### Fixed
+
+- Keep the Claude Code OAuth user-agent version in sync with upstream `@anthropic-ai/claude-code` 2.1.153, and let the scheduled upstream-version workflow create update PRs instead of failing as soon as drift is detected.
+
 ## [0.24.8] - 2026-05-28
 
 ### Fixed

--- a/core/crates/omegon/src/providers.rs
+++ b/core/crates/omegon/src/providers.rs
@@ -18,7 +18,7 @@ use crate::bridge::{LlmBridge, LlmEvent, LlmMessage, StreamOptions};
 /// Claude Code CLI version for OAuth user-agent header.
 /// Must match what Anthropic expects for subscription recognition.
 /// Update when upstream Claude Code advances.
-const CLAUDE_CODE_UA: &str = "claude-cli/2.1.119";
+const CLAUDE_CODE_UA: &str = "claude-cli/2.1.153";
 use omegon_traits::ToolDefinition;
 
 /// Anthropic credential mode — records what credential source is active.

--- a/scripts/check_upstream_versions.py
+++ b/scripts/check_upstream_versions.py
@@ -5,7 +5,8 @@ Checks:
   - Claude Code CLI version (npm: @anthropic-ai/claude-code)
 
 Outputs JSON: {"updates": [{"name": ..., "current": ..., "latest": ..., "file": ..., "pattern": ...}]}
-Exit code 0 = all up to date, 1 = updates available, 2 = check failed.
+Exit code 0 = check completed, including when updates are available.
+Exit code 2 = check failed.
 """
 
 import json
@@ -39,17 +40,21 @@ def get_current_claude_code_ua() -> str | None:
     return m.group(1) if m else None
 
 
-def check_claude_code() -> dict | None:
-    """Check if Claude Code CLI version is up to date."""
+def check_claude_code() -> tuple[dict | None, bool]:
+    """Check if Claude Code CLI version is up to date.
+
+    Returns (update, failed). An upstream mismatch is an update, not a
+    check failure; failure means we could not inspect local or upstream state.
+    """
     current = get_current_claude_code_ua()
     if not current:
         print("WARNING: Could not extract current Claude Code UA version", file=sys.stderr)
-        return None
+        return None, True
 
     latest = get_npm_latest("@anthropic-ai/claude-code")
     if not latest:
         print("WARNING: Could not fetch latest Claude Code version from npm", file=sys.stderr)
-        return None
+        return None, True
 
     if current != latest:
         return {
@@ -59,28 +64,33 @@ def check_claude_code() -> dict | None:
             "file": str(PROVIDERS_RS.relative_to(REPO_ROOT)),
             "pattern": f'claude-cli/{current}',
             "replacement": f'claude-cli/{latest}',
-        }
-    return None
+        }, False
+    return None, False
 
 
 def main():
     updates = []
+    checks_failed = False
 
-    result = check_claude_code()
+    result, failed = check_claude_code()
     if result:
         updates.append(result)
+    checks_failed = checks_failed or failed
 
     output = {"updates": updates}
     print(json.dumps(output, indent=2))
+
+    if checks_failed:
+        print("\nOne or more upstream version checks failed.", file=sys.stderr)
+        sys.exit(2)
 
     if updates:
         print(f"\n{len(updates)} update(s) available:", file=sys.stderr)
         for u in updates:
             print(f"  {u['name']}: {u['current']} -> {u['latest']}", file=sys.stderr)
-        sys.exit(1)
     else:
         print("\nAll upstream versions up to date.", file=sys.stderr)
-        sys.exit(0)
+    sys.exit(0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Keeps Claude Code OAuth UA tracking in lockstep with upstream and fixes the scheduled upstream-version workflow so drift opens an update PR instead of failing before the apply step.

## What changed

- Updates `CLAUDE_CODE_UA` from `claude-cli/2.1.119` to upstream `claude-cli/2.1.153`.
- Changes `scripts/check_upstream_versions.py` so version drift exits 0 with JSON updates; actual inspection failures still exit 2.
- Refactors the Claude Code check to return `(update, failed)` so the script does not fetch npm twice.
- Updates the changelog.

## Validation

- `python3 scripts/check_upstream_versions.py` returns no updates with the current version.
- Temporarily set the local UA to `claude-cli/0.0.0` and verified the script emits an update JSON payload while exiting 0, which allows `.github/workflows/upstream-versions.yml` to continue into its Apply updates / Create PR steps.
