### PR TITLE
docs(site): refresh release data for 0.24.8

### DIFF
--- a/site/src/data/releases.json
+++ b/site/src/data/releases.json
@@ -1,130 +1,121 @@
 {
   "latestStable": {
-    "tag": "v0.21.3",
-    "date": "2026-05-16",
-    "url": "https://github.com/styrene-lab/omegon/releases/tag/v0.21.3"
+    "tag": "v0.24.8",
+    "date": "2026-05-28",
+    "url": "https://github.com/styrene-lab/omegon/releases/tag/v0.24.8"
+  },
+  "latestRc": {
+    "tag": "v0.22.0-rc.1",
+    "date": "2026-05-14",
+    "url": "https://github.com/styrene-lab/omegon/releases/tag/v0.22.0-rc.1"
   },
   "latestNightly": null,
   "releases": [
     {
-      "tag": "v0.21.3",
+      "tag": "v0.24.8",
       "channel": "stable",
       "prerelease": false,
-      "date": "2026-05-16",
-      "url": "https://github.com/styrene-lab/omegon/releases/tag/v0.21.3"
+      "date": "2026-05-28",
+      "url": "https://github.com/styrene-lab/omegon/releases/tag/v0.24.8"
     },
     {
-      "tag": "v0.21.2",
+      "tag": "v0.24.7",
       "channel": "stable",
       "prerelease": false,
-      "date": "2026-05-15",
-      "url": "https://github.com/styrene-lab/omegon/releases/tag/v0.21.2"
+      "date": "2026-05-27",
+      "url": "https://github.com/styrene-lab/omegon/releases/tag/v0.24.7"
     },
     {
-      "tag": "v0.21.1",
+      "tag": "v0.24.6",
       "channel": "stable",
       "prerelease": false,
-      "date": "2026-05-14",
-      "url": "https://github.com/styrene-lab/omegon/releases/tag/v0.21.1"
+      "date": "2026-05-27",
+      "url": "https://github.com/styrene-lab/omegon/releases/tag/v0.24.6"
     },
     {
-      "tag": "v0.21.0",
+      "tag": "v0.24.5",
       "channel": "stable",
       "prerelease": false,
-      "date": "2026-05-14",
-      "url": "https://github.com/styrene-lab/omegon/releases/tag/v0.21.0"
+      "date": "2026-05-26",
+      "url": "https://github.com/styrene-lab/omegon/releases/tag/v0.24.5"
     },
     {
-      "tag": "v0.20.1",
+      "tag": "v0.24.4",
       "channel": "stable",
       "prerelease": false,
-      "date": "2026-05-13",
-      "url": "https://github.com/styrene-lab/omegon/releases/tag/v0.20.1"
+      "date": "2026-05-26",
+      "url": "https://github.com/styrene-lab/omegon/releases/tag/v0.24.4"
     },
     {
-      "tag": "v0.20.0",
+      "tag": "v0.24.3",
       "channel": "stable",
       "prerelease": false,
-      "date": "2026-05-12",
-      "url": "https://github.com/styrene-lab/omegon/releases/tag/v0.20.0"
+      "date": "2026-05-26",
+      "url": "https://github.com/styrene-lab/omegon/releases/tag/v0.24.3"
     },
     {
-      "tag": "v0.19.6",
+      "tag": "v0.24.2",
       "channel": "stable",
       "prerelease": false,
-      "date": "2026-05-11",
-      "url": "https://github.com/styrene-lab/omegon/releases/tag/v0.19.6"
+      "date": "2026-05-26",
+      "url": "https://github.com/styrene-lab/omegon/releases/tag/v0.24.2"
     },
     {
-      "tag": "v0.19.5",
+      "tag": "v0.24.1",
       "channel": "stable",
       "prerelease": false,
-      "date": "2026-05-10",
-      "url": "https://github.com/styrene-lab/omegon/releases/tag/v0.19.5"
+      "date": "2026-05-25",
+      "url": "https://github.com/styrene-lab/omegon/releases/tag/v0.24.1"
     },
     {
-      "tag": "v0.19.0",
+      "tag": "v0.24.0",
       "channel": "stable",
       "prerelease": false,
-      "date": "2026-05-07",
-      "url": "https://github.com/styrene-lab/omegon/releases/tag/v0.19.0"
+      "date": "2026-05-25",
+      "url": "https://github.com/styrene-lab/omegon/releases/tag/v0.24.0"
     },
     {
-      "tag": "v0.18.6",
+      "tag": "v0.23.9",
       "channel": "stable",
       "prerelease": false,
-      "date": "2026-05-05",
-      "url": "https://github.com/styrene-lab/omegon/releases/tag/v0.18.6"
+      "date": "2026-05-25",
+      "url": "https://github.com/styrene-lab/omegon/releases/tag/v0.23.9"
     },
     {
-      "tag": "v0.18.5",
+      "tag": "v0.23.7",
       "channel": "stable",
       "prerelease": false,
-      "date": "2026-05-05",
-      "url": "https://github.com/styrene-lab/omegon/releases/tag/v0.18.5"
+      "date": "2026-05-24",
+      "url": "https://github.com/styrene-lab/omegon/releases/tag/v0.23.7"
     },
     {
-      "tag": "v0.18.4",
+      "tag": "v0.23.6",
       "channel": "stable",
       "prerelease": false,
-      "date": "2026-05-04",
-      "url": "https://github.com/styrene-lab/omegon/releases/tag/v0.18.4"
+      "date": "2026-05-24",
+      "url": "https://github.com/styrene-lab/omegon/releases/tag/v0.23.6"
     },
     {
-      "tag": "v0.18.3",
+      "tag": "v0.23.5",
       "channel": "stable",
       "prerelease": false,
-      "date": "2026-05-01",
-      "url": "https://github.com/styrene-lab/omegon/releases/tag/v0.18.3"
+      "date": "2026-05-23",
+      "url": "https://github.com/styrene-lab/omegon/releases/tag/v0.23.5"
     },
     {
-      "tag": "v0.18.2",
+      "tag": "v0.23.4",
       "channel": "stable",
       "prerelease": false,
-      "date": "2026-05-01",
-      "url": "https://github.com/styrene-lab/omegon/releases/tag/v0.18.2"
+      "date": "2026-05-23",
+      "url": "https://github.com/styrene-lab/omegon/releases/tag/v0.23.4"
     },
     {
-      "tag": "v0.18.1",
+      "tag": "v0.23.3",
       "channel": "stable",
       "prerelease": false,
-      "date": "2026-05-01",
-      "url": "https://github.com/styrene-lab/omegon/releases/tag/v0.18.1"
-    },
-    {
-      "tag": "v0.18.0",
-      "channel": "stable",
-      "prerelease": false,
-      "date": "2026-04-30",
-      "url": "https://github.com/styrene-lab/omegon/releases/tag/v0.18.0"
-    },
-    {
-      "tag": "v0.17.10",
-      "channel": "stable",
-      "prerelease": false,
-      "date": "2026-04-30",
-      "url": "https://github.com/styrene-lab/omegon/releases/tag/v0.17.10"
+      "date": "2026-05-23",
+      "url": "https://github.com/styrene-lab/omegon/releases/tag/v0.23.3"
     }
   ],
-  "fetchedAt": "2026-05-14T23:23:01.382Z"
+  "fetchedAt": "2026-05-28T14:04:53.741Z"
 }

--- a/site/src/data/stats.json
+++ b/site/src/data/stats.json
@@ -1,7 +1,7 @@
 {
   "crateCount": 8,
-  "downloadMB": 14,
-  "releaseTag": "v0.21.1",
+  "downloadMB": 15,
+  "releaseTag": "v0.24.8",
   "providerCount": 14,
   "providerNames": [
     "Anthropic/Claude",
@@ -35,8 +35,8 @@
     "ollama",
     "ollama-cloud"
   ],
-  "toolFiles": 20,
+  "toolFiles": 21,
   "skillCount": 10,
   "searchProviderCount": 5,
-  "collectedAt": "2026-05-14T23:23:01.589Z"
+  "collectedAt": "2026-05-28T14:04:53.957Z"
 }


### PR DESCRIPTION
## Summary

Refreshes committed site release data after the v0.24.8 release.

## What changed

- Rebuilds `site/src/data/releases.json` from the GitHub Releases API so the site points at `v0.24.8` as the latest stable release.
- Refreshes `site/src/data/stats.json` so homepage stats report the v0.24.8 release asset size and current provider/tool counts.

## Validation

- `cd site && npm run build`
