### PR TITLE
ci: update GitHub actions to Node 24 releases

### DIFF
--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -21,12 +21,12 @@ jobs:
 
     steps:
       - name: Checkout omegon (for release_manifest.py)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: omegon
 
       - name: Checkout homebrew-tap
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: styrene-lab/homebrew-tap
           token: ${{ secrets.RELEASE_GITHUB_TOKEN }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/provider-drift.yml
+++ b/.github/workflows/provider-drift.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: recursive
 
@@ -74,7 +74,7 @@ jobs:
 
       - name: Upload provider drift report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: provider-drift-report
           path: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
             archive: tar.gz
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.tag_name || github.ref }}
 
@@ -199,7 +199,7 @@ jobs:
           fi
 
       - name: Upload build artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: build-${{ matrix.target }}
           path: |
@@ -217,7 +217,7 @@ jobs:
     timeout-minutes: 40
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.tag_name || github.ref }}
 
@@ -276,7 +276,7 @@ jobs:
           sha256sum "$EXT_ARCHIVE" > "$EXT_ARCHIVE.sha256"
 
       - name: Upload build artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: build-aarch64-unknown-linux-gnu
           path: |
@@ -299,7 +299,7 @@ jobs:
       OLLAMA_API_KEY: ${{ secrets.OLLAMA_API_KEY }}
       OLLAMA_HOST: ${{ secrets.OLLAMA_HOST }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.tag_name || github.ref }}
 
@@ -314,7 +314,7 @@ jobs:
 
       - name: Upload live upstream smoke log
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: live-upstream-smoke-log
           path: /tmp/live-upstream-smoke.log
@@ -353,7 +353,7 @@ jobs:
             install_cmd: dnf install -y glibc libgcc file ca-certificates
 
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v6
         with:
           name: build-x86_64-unknown-linux-gnu
           path: abi-artifacts
@@ -391,10 +391,10 @@ jobs:
       attestations: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Download primary build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           path: artifacts
           pattern: build-*
@@ -566,7 +566,7 @@ jobs:
             description: "Full-stack agent"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.tag_name || github.ref }}
 

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -25,9 +25,9 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '22'
           cache: 'npm'
@@ -93,9 +93,9 @@ jobs:
       packages: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '22'
           cache: 'npm'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
       - name: Build omegon binary
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
       - name: Run omegon tests
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
       - name: Run omegon integration tests
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
       - name: Standalone crate compilation (no workspace deps)
@@ -62,7 +62,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
       - name: Extension install integration tests
@@ -71,9 +71,9 @@ jobs:
   daemon-smoke:
     name: Smoke reference daemon launcher
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
       - name: Build omegon binary
@@ -92,7 +92,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Validate benchmark task definitions
         run: python3 scripts/validate_benchmarks.py
       - name: Validate benchmark harness loads

--- a/.github/workflows/upstream-versions.yml
+++ b/.github/workflows/upstream-versions.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Check upstream versions
         id: check

--- a/.github/workflows/verify-bundle.yml
+++ b/.github/workflows/verify-bundle.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Detect changed bundles
         id: changed
@@ -57,7 +57,7 @@ jobs:
 
       - name: Upload verification artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: bundle-verification
           path: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [Semantic V
 
 ### Changed
 
+- Update first-party GitHub Actions workflow dependencies to Node 24-backed major releases (`checkout@v6`, `setup-node@v6`, `upload-artifact@v6`, `download-artifact@v6`) and keep the daemon smoke job timeout aligned with cold build time.
 - Split Rust CI into focused build, unit, integration, standalone-crate, extension-install, daemon-smoke, and benchmark-validation jobs so hangs identify the failing bucket instead of cancelling the entire test sequence.
 
 ### Fixed


### PR DESCRIPTION
## Summary

Fixes #118.

Updates first-party GitHub Actions workflow dependencies from Node 20-backed v4 majors to Node 24-backed v6 majors:

- actions/checkout@v6
- actions/setup-node@v6
- actions/upload-artifact@v6
- actions/download-artifact@v6

## Assessment

- Chose v6 as the Node 24-backed floor for all four actions instead of jumping to latest artifact majors.
- Avoids upload-artifact@v7 direct-upload/ESM changes and download-artifact@v8 digest-mismatch/direct-download behavior changes.
- GitHub-hosted runners satisfy the v6 artifact action runner requirement.

## Validation

- Verified all four v6 tags exist upstream via GitHub API.
- Verified no remaining targeted checkout/setup-node/upload-artifact/download-artifact @v4/@v5 refs.
- Parsed all .github/workflows/*.yml with PyYAML.
- git diff --check.