### PR TITLE
fix(secrets): make secret operations idempotent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [Semantic V
 
 ## [Unreleased]
 
+### Fixed
+
+- Strip TOML frontmatter from design lifecycle documents and generated site legal/changelog pages so publication metadata does not leak into rendered content or duplicate design-node titles.
+
 ## [0.26.3] - 2026-06-04
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [Semantic V
 
 ### Fixed
 
+- Make harness secret storage idempotent across recipes, keyring values, session caches, redaction, and process-env projection so named secret repairs can recover orphaned keychain entries without scanning the whole keychain.
 - Strip TOML frontmatter from design lifecycle documents and generated site legal/changelog pages so publication metadata does not leak into rendered content or duplicate design-node titles.
 
 ## [0.26.3] - 2026-06-04

--- a/core/crates/omegon-secrets/src/lib.rs
+++ b/core/crates/omegon-secrets/src/lib.rs
@@ -62,6 +62,30 @@ pub struct SessionSecretDiagnostic {
     pub used_by: Vec<SecretUse>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SecretRecipeStatus {
+    Resolved,
+    Missing,
+    Deferred,
+}
+
+impl SecretRecipeStatus {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Resolved => "resolves",
+            Self::Missing => "missing",
+            Self::Deferred => "deferred",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct SecretRecipeDiagnostic {
+    pub name: String,
+    pub recipe: String,
+    pub status: SecretRecipeStatus,
+}
+
 /// Central secrets manager — owns the redaction set, recipes, guards, and Vault client.
 pub struct SecretsManager {
     /// Resolved secret values for redaction (name → SecretString).
@@ -589,6 +613,42 @@ impl SecretsManager {
             .collect()
     }
 
+    /// List configured secret recipes with bounded diagnostics.
+    ///
+    /// This checks only declared recipes, never the whole keychain. Vault recipes
+    /// are marked deferred because they require async resolution and may depend
+    /// on external service availability.
+    pub fn list_recipe_diagnostics(&self) -> Vec<SecretRecipeDiagnostic> {
+        let recipes: Vec<(String, crate::recipes::Recipe)> = self
+            .recipes
+            .read()
+            .unwrap()
+            .iter()
+            .map(|(name, recipe)| (name.clone(), recipe.clone()))
+            .collect();
+
+        let mut diagnostics: Vec<_> = recipes
+            .into_iter()
+            .map(|(name, recipe)| {
+                let recipe_text = recipe.as_string();
+                let status = if recipe.is_vault() {
+                    SecretRecipeStatus::Deferred
+                } else if resolve::execute_recipe(&name, &recipe).is_some() {
+                    SecretRecipeStatus::Resolved
+                } else {
+                    SecretRecipeStatus::Missing
+                };
+                SecretRecipeDiagnostic {
+                    name,
+                    recipe: recipe_text,
+                    status,
+                }
+            })
+            .collect();
+        diagnostics.sort_by(|a, b| a.name.cmp(&b.name));
+        diagnostics
+    }
+
     /// Resolve well-known provider secrets into process environment variables
     /// so legacy env-based integrations (web search, provider clients) can use
     /// secrets stored in Omegon's keyring/recipe system.
@@ -619,19 +679,37 @@ impl SecretsManager {
 
     /// Store a raw value in the OS keyring and create a keyring: recipe for it.
     pub fn set_keyring_secret(&self, name: &str, value: &str) -> anyhow::Result<()> {
-        // Store in keyring
+        // Upsert in keyring first. If a previous run left an orphaned keychain
+        // item without a recipe, this still succeeds and repairs the metadata.
         store_in_keyring(name, value)?;
-        // Create recipe pointing to keyring
-        self.set_recipe(name, &format!("keyring:{name}"))?;
-        // Inject the value directly — refresh_redaction_set() skips keyring:
-        // recipes to avoid prompts, but here we already have the raw value.
+        self.recipes
+            .write()
+            .unwrap()
+            .set_string(name.to_string(), format!("keyring:{name}"))?;
+
+        let secret = SecretString::from(value.to_string());
         self.redaction_set
             .write()
             .unwrap()
-            .insert(name.to_string(), SecretString::from(value));
-        // Rebuild the Aho-Corasick automaton so redact() catches this value
-        // immediately. Without this, the automaton is stale and the secret
-        // passes through unredacted until the next preflight.
+            .insert(name.to_string(), secret.clone());
+        self.session_cache
+            .write()
+            .unwrap()
+            .insert(name.to_string(), secret);
+        self.session_meta
+            .write()
+            .unwrap()
+            .entry(name.to_string())
+            .and_modify(|m| {
+                m.warmed = true;
+                m.used_by.insert(SecretUse::Other);
+            })
+            .or_insert_with(|| CachedSecretMeta {
+                source: "keyring",
+                warmed: true,
+                required_at_startup: false,
+                used_by: HashSet::from([SecretUse::Other]),
+            });
         self.rebuild_redactor();
         self.hydrate_process_env();
         Ok(())
@@ -661,11 +739,15 @@ impl SecretsManager {
         tracing::info!(evicted = ?names, "evicted secrets from session cache");
     }
 
-    /// Delete a secret recipe (and try to remove from keyring if applicable).
+    /// Delete a secret recipe and any same-name keyring entry.
+    ///
+    /// Deletion is idempotent across the secrets surface: absent recipes and
+    /// absent keychain entries are success states. The same-name keyring cleanup
+    /// handles repaired/orphaned harness-managed secrets without keychain scans.
     pub fn delete_recipe(&self, name: &str) -> anyhow::Result<()> {
-        // Try to remove from keyring
-        let _ = delete_from_keyring(name); // best-effort
+        delete_from_keyring(name)?;
         self.recipes.write().unwrap().remove(name).map(|_| ())?;
+        self.evict_secrets(&[name]);
         self.refresh_redaction_set();
         if resolve::STATIC_SECRET_ENVS.contains(&name)
             || resolve::REFRESHABLE_OAUTH_SECRET_ENVS.contains(&name)
@@ -777,6 +859,91 @@ mod tests {
         let client = secrets.vault_client().await;
         assert!(client.is_some());
         assert!(client.as_ref().unwrap().is_authenticated());
+    }
+
+    #[test]
+    fn keyring_secret_set_repairs_missing_recipe_and_is_idempotent() {
+        let _guard = ENV_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let dir = tempfile::tempdir().unwrap();
+        let mgr = SecretsManager::new(dir.path()).unwrap();
+
+        // Simulate the split-brain state: secure storage has a value, but the
+        // recipe store has no declaration for the secret.
+        store_in_keyring("BRAVE_API_KEY", "old-value").unwrap();
+        assert!(mgr.list_recipes().is_empty());
+        assert!(mgr.resolve("BRAVE_API_KEY").is_none());
+
+        mgr.set_keyring_secret("BRAVE_API_KEY", "new-value")
+            .unwrap();
+        assert_eq!(
+            mgr.list_recipes(),
+            vec![(
+                "BRAVE_API_KEY".to_string(),
+                "keyring:BRAVE_API_KEY".to_string()
+            )]
+        );
+        assert_eq!(mgr.resolve("BRAVE_API_KEY").as_deref(), Some("new-value"));
+        assert_eq!(
+            std::env::var("BRAVE_API_KEY").ok().as_deref(),
+            Some("new-value")
+        );
+        assert_eq!(
+            mgr.redact("Authorization: Bearer new-value"),
+            "Authorization: Bearer [REDACTED:BRAVE_API_KEY]"
+        );
+
+        mgr.set_keyring_secret("BRAVE_API_KEY", "newer-value")
+            .unwrap();
+        assert_eq!(mgr.resolve("BRAVE_API_KEY").as_deref(), Some("newer-value"));
+
+        // SAFETY: cleanup for isolated test env vars.
+        unsafe { std::env::remove_var("BRAVE_API_KEY") };
+    }
+
+    #[test]
+    fn delete_recipe_is_idempotent_and_clears_same_name_keyring_secret() {
+        let _guard = ENV_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let dir = tempfile::tempdir().unwrap();
+        let mgr = SecretsManager::new(dir.path()).unwrap();
+
+        mgr.set_keyring_secret("BRAVE_API_KEY", "delete-me")
+            .unwrap();
+        assert_eq!(mgr.resolve("BRAVE_API_KEY").as_deref(), Some("delete-me"));
+
+        mgr.delete_recipe("BRAVE_API_KEY").unwrap();
+        mgr.delete_recipe("BRAVE_API_KEY").unwrap();
+
+        assert!(mgr.resolve("BRAVE_API_KEY").is_none());
+        assert!(mgr.list_recipes().is_empty());
+        assert!(std::env::var("BRAVE_API_KEY").is_err());
+        assert_eq!(mgr.redact("delete-me"), "delete-me");
+    }
+
+    #[test]
+    fn list_recipe_diagnostics_reports_bounded_status() {
+        let _guard = ENV_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let dir = tempfile::tempdir().unwrap();
+        let mgr = SecretsManager::new(dir.path()).unwrap();
+
+        mgr.set_keyring_secret("BRAVE_API_KEY", "diagnostic-value")
+            .unwrap();
+        mgr.set_recipe("TAVILY_API_KEY", "env:OMEGON_TEST_MISSING_TAVILY")
+            .unwrap();
+
+        let diagnostics = mgr.list_recipe_diagnostics();
+        assert!(diagnostics.iter().any(|entry| {
+            entry.name == "BRAVE_API_KEY"
+                && entry.recipe == "keyring:BRAVE_API_KEY"
+                && entry.status == SecretRecipeStatus::Resolved
+        }));
+        assert!(diagnostics.iter().any(|entry| {
+            entry.name == "TAVILY_API_KEY"
+                && entry.recipe == "env:OMEGON_TEST_MISSING_TAVILY"
+                && entry.status == SecretRecipeStatus::Missing
+        }));
+
+        // SAFETY: cleanup for isolated test env vars.
+        unsafe { std::env::remove_var("BRAVE_API_KEY") };
     }
 
     #[test]

--- a/core/crates/omegon-secrets/src/resolve.rs
+++ b/core/crates/omegon-secrets/src/resolve.rs
@@ -392,17 +392,48 @@ pub async fn resolve_vault_secret(
     }
 }
 
-/// Store a secret value in the cross-platform keyring.
+/// Store or replace a secret value in the cross-platform keyring.
+///
+/// Keychain backends differ on whether `set_password` overwrites existing
+/// entries or returns a duplicate-item error. Treat `store_in_keyring` as an
+/// idempotent upsert so callers can repair missing recipe metadata even when
+/// the sensitive value already exists in secure storage.
 pub fn store_in_keyring(name: &str, value: &str) -> anyhow::Result<()> {
-    keyring_set(KEYRING_SERVICE, name, value)?;
-    tracing::info!(name = name, "stored secret in keyring");
-    Ok(())
+    match keyring_set(KEYRING_SERVICE, name, value) {
+        Ok(()) => {
+            tracing::info!(name = name, "stored secret in keyring");
+            Ok(())
+        }
+        Err(first_err) => {
+            tracing::debug!(
+                name = name,
+                error = %first_err,
+                "initial keyring write failed; retrying as delete-then-set upsert"
+            );
+            let _ = keyring_delete(KEYRING_SERVICE, name);
+            keyring_set(KEYRING_SERVICE, name, value).map_err(|retry_err| {
+                anyhow::anyhow!(
+                    "keyring upsert failed for {name}: initial write failed: {first_err}; retry failed: {retry_err}"
+                )
+            })?;
+            tracing::info!(name = name, "replaced existing secret in keyring");
+            Ok(())
+        }
+    }
 }
 
 /// Delete a secret from the cross-platform keyring.
+///
+/// Deletion is intentionally idempotent: absent keychain entries should not
+/// make higher-level cleanup fail after recipe metadata has already drifted.
 pub fn delete_from_keyring(name: &str) -> anyhow::Result<()> {
-    keyring_delete(KEYRING_SERVICE, name)?;
-    Ok(())
+    match keyring_delete(KEYRING_SERVICE, name) {
+        Ok(()) => Ok(()),
+        Err(e) => {
+            tracing::debug!(name = name, error = %e, "keyring delete skipped or entry absent");
+            Ok(())
+        }
+    }
 }
 
 /// Expose a SecretString's value for operations that need it (e.g., redaction set building).

--- a/core/crates/omegon/src/lifecycle/design.rs
+++ b/core/crates/omegon/src/lifecycle/design.rs
@@ -286,11 +286,10 @@ pub fn parse_sections(body: &str) -> DocumentSections {
 
     for (heading, content) in h2_blocks {
         match heading {
-            "" => {
-                if sections.overview.is_empty() {
-                    sections.overview = content.trim().to_string();
-                }
+            "" if sections.overview.is_empty() => {
+                sections.overview = content.trim().to_string();
             }
+            "" => {}
             "Overview" => sections.overview = content.trim().to_string(),
             "Research" => sections.research = parse_research(&content),
             "Decisions" => sections.decisions = parse_decisions(&content),

--- a/core/crates/omegon/src/lifecycle/design.rs
+++ b/core/crates/omegon/src/lifecycle/design.rs
@@ -9,13 +9,37 @@ use std::path::{Path, PathBuf};
 
 use super::types::*;
 
-/// Parse YAML frontmatter from a markdown document.
+/// Parse YAML or TOML frontmatter from a markdown document.
 /// Returns None if no frontmatter delimiter found.
 pub fn parse_frontmatter(content: &str) -> Option<HashMap<String, FrontmatterValue>> {
-    let rest = content.strip_prefix("---\n")?;
-    let end = rest.find("\n---")?;
-    let yaml = &rest[..end];
+    let (kind, frontmatter, _body) = split_markdown_frontmatter(content)?;
+    match kind {
+        FrontmatterKind::Yaml => Some(parse_yaml_frontmatter(frontmatter)),
+        FrontmatterKind::Toml => Some(parse_toml_frontmatter(frontmatter)),
+    }
+}
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FrontmatterKind {
+    Yaml,
+    Toml,
+}
+
+fn split_markdown_frontmatter(content: &str) -> Option<(FrontmatterKind, &str, &str)> {
+    if let Some(rest) = content.strip_prefix("---\n") {
+        let end = rest.find("\n---")?;
+        let body = rest[end + 4..].trim_start_matches('\n');
+        return Some((FrontmatterKind::Yaml, &rest[..end], body));
+    }
+    if let Some(rest) = content.strip_prefix("+++\n") {
+        let end = rest.find("\n+++")?;
+        let body = rest[end + 4..].trim_start_matches('\n');
+        return Some((FrontmatterKind::Toml, &rest[..end], body));
+    }
+    None
+}
+
+fn parse_yaml_frontmatter(yaml: &str) -> HashMap<String, FrontmatterValue> {
     let mut result = HashMap::new();
     let mut current_key: Option<String> = None;
     let mut current_array: Vec<String> = Vec::new();
@@ -72,7 +96,53 @@ pub fn parse_frontmatter(content: &str) -> Option<HashMap<String, FrontmatterVal
         result.insert(key, FrontmatterValue::List(current_array));
     }
 
-    Some(result)
+    result
+}
+
+fn parse_toml_frontmatter(toml: &str) -> HashMap<String, FrontmatterValue> {
+    let mut result = HashMap::new();
+    let mut section: Option<&str> = None;
+
+    for line in toml.lines() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        if line.starts_with('[') && line.ends_with(']') {
+            section = Some(line.trim_matches(&['[', ']'][..]).trim());
+            continue;
+        }
+
+        let Some((key, value)) = line.split_once('=') else {
+            continue;
+        };
+        let key = key.trim();
+
+        // Codex/Flynt exports put lifecycle fields under [data], while older
+        // docs put them at the top level. Publication metadata is deliberately
+        // ignored by the design lifecycle parser.
+        if section.is_some_and(|name| name != "data") {
+            continue;
+        }
+
+        let value = value.trim();
+        let parsed = if value == "[]" {
+            FrontmatterValue::List(vec![])
+        } else if value.starts_with('[') && value.ends_with(']') {
+            FrontmatterValue::List(
+                value[1..value.len() - 1]
+                    .split(',')
+                    .map(|s| strip_quotes(s.trim()))
+                    .filter(|s| !s.is_empty())
+                    .collect(),
+            )
+        } else {
+            FrontmatterValue::Scalar(strip_quotes(value))
+        };
+        result.entry(key.to_string()).or_insert(parsed);
+    }
+
+    result
 }
 
 /// A frontmatter value — either scalar or list.
@@ -108,18 +178,11 @@ fn strip_quotes(s: &str) -> String {
     }
 }
 
-/// Extract the body after the frontmatter.
+/// Extract the body after YAML or TOML frontmatter.
 pub fn extract_body(content: &str) -> &str {
-    if let Some(rest) = content.strip_prefix("---\n") {
-        if let Some(end) = rest.find("\n---") {
-            let after = &rest[end + 4..];
-            after.trim_start_matches('\n')
-        } else {
-            content
-        }
-    } else {
-        content
-    }
+    split_markdown_frontmatter(content)
+        .map(|(_kind, _frontmatter, body)| body)
+        .unwrap_or(content)
 }
 
 /// Build a DesignNode from parsed frontmatter.
@@ -193,12 +256,18 @@ pub fn node_from_frontmatter(
 pub fn parse_sections(body: &str) -> DocumentSections {
     let mut sections = DocumentSections::default();
 
-    // Split body into h2 sections
+    // Split body into h2 sections. Ignore an existing top-level document title;
+    // serialize_document writes the canonical title from frontmatter.
     let mut current_heading = "";
     let mut current_content = String::new();
     let mut h2_blocks: Vec<(&str, String)> = Vec::new();
 
     for line in body.lines() {
+        if current_heading.is_empty() && current_content.trim().is_empty() && line.starts_with("# ")
+        {
+            continue;
+        }
+
         if let Some(heading) = line.strip_prefix("## ") {
             if !current_heading.is_empty() || !current_content.trim().is_empty() {
                 h2_blocks.push((current_heading, std::mem::take(&mut current_content)));
@@ -210,12 +279,18 @@ pub fn parse_sections(body: &str) -> DocumentSections {
             current_content.push('\n');
         }
     }
+
     if !current_heading.is_empty() || !current_content.trim().is_empty() {
         h2_blocks.push((current_heading, current_content));
     }
 
     for (heading, content) in h2_blocks {
         match heading {
+            "" => {
+                if sections.overview.is_empty() {
+                    sections.overview = content.trim().to_string();
+                }
+            }
             "Overview" => sections.overview = content.trim().to_string(),
             "Research" => sections.research = parse_research(&content),
             "Decisions" => sections.decisions = parse_decisions(&content),
@@ -952,6 +1027,86 @@ Content of the second topic.
         let body = extract_body(SAMPLE_DOC);
         assert!(body.starts_with("# Test Node"));
         assert!(!body.contains("---\nid:"));
+    }
+
+    #[test]
+    fn parses_toml_frontmatter_and_strips_it_from_body() {
+        let content = r#"+++
+id = "toml-node"
+kind = "design_node"
+tags = ["docs", "hygiene"]
+
+[publication]
+enabled = false
+visibility = "private"
+
+[data]
+title = "TOML Node"
+status = "exploring"
+open_questions = ["What remains?"]
++++
+
+# TOML Node
+
+## Overview
+
+Body text.
+"#;
+        let fm = parse_frontmatter(content).unwrap();
+        assert_eq!(fm.get("id").unwrap().as_str(), Some("toml-node"));
+        assert_eq!(fm.get("title").unwrap().as_str(), Some("TOML Node"));
+        assert_eq!(fm.get("status").unwrap().as_str(), Some("exploring"));
+        assert_eq!(fm.get("tags").unwrap().as_list(), &["docs", "hygiene"]);
+        assert_eq!(
+            fm.get("open_questions").unwrap().as_list(),
+            &["What remains?"]
+        );
+        let body = extract_body(content);
+        assert!(body.starts_with("# TOML Node"));
+        assert!(!body.contains("[publication]"));
+        assert!(!body.contains("+++"));
+    }
+
+    #[test]
+    fn parse_sections_ignores_existing_top_level_title() {
+        let sections = parse_sections("# Existing Title\n\n## Overview\n\nClean overview.\n");
+        assert_eq!(sections.overview, "Clean overview.");
+    }
+
+    #[test]
+    fn parse_sections_uses_plain_body_as_overview_when_no_sections_exist() {
+        let sections = parse_sections("Plain body without headings.\n");
+        assert_eq!(sections.overview, "Plain body without headings.");
+    }
+
+    #[test]
+    fn serialize_document_is_idempotent_for_toml_converted_body() {
+        let content = r#"+++
+id = "toml-node"
+title = "TOML Node"
+status = "exploring"
+open_questions = ["What remains?"]
++++
+
+# TOML Node
+
+## Overview
+
+Body text.
+
+## Open Questions
+
+- What remains?
+"#;
+        let fm = parse_frontmatter(content).unwrap();
+        let node = node_from_frontmatter(&fm, PathBuf::from("docs/toml-node.md")).unwrap();
+        let once = serialize_document(&node, &parse_sections(extract_body(content)));
+        let twice = serialize_document(&node, &parse_sections(extract_body(&once)));
+        assert_eq!(once, twice);
+        assert_eq!(once.matches("# TOML Node").count(), 1);
+        assert_eq!(once.matches("## Overview").count(), 1);
+        assert_eq!(once.matches("## Open Questions").count(), 1);
+        assert!(!once.contains("+++"));
     }
 
     #[test]

--- a/core/crates/omegon/src/tools/secret_tools.rs
+++ b/core/crates/omegon/src/tools/secret_tools.rs
@@ -128,19 +128,34 @@ impl ToolProvider for SecretToolsProvider {
                 }
             }
             crate::tool_registry::secrets::SECRET_LIST => {
-                let entries = self.secrets.list_recipes();
+                let entries = self.secrets.list_recipe_diagnostics();
                 let text = if entries.is_empty() {
                     "No harness-managed secrets configured.".to_string()
                 } else {
                     let mut out = String::from("Harness-managed secrets:\n");
-                    for (name, recipe) in &entries {
-                        out.push_str(&format!("- {name}: {recipe}\n"));
+                    for entry in &entries {
+                        out.push_str(&format!(
+                            "- {}: {} [{}]\n",
+                            entry.name,
+                            entry.recipe,
+                            entry.status.as_str()
+                        ));
                     }
                     out.trim_end().to_string()
                 };
+                let details = json!({
+                    "count": entries.len(),
+                    "entries": entries.iter().map(|entry| {
+                        json!({
+                            "name": entry.name,
+                            "recipe": entry.recipe,
+                            "status": entry.status.as_str(),
+                        })
+                    }).collect::<Vec<_>>()
+                });
                 Ok(ToolResult {
                     content: vec![ContentBlock::Text { text }],
-                    details: json!({ "count": entries.len() }),
+                    details,
                 })
             }
             crate::tool_registry::secrets::SECRET_DELETE => {
@@ -212,6 +227,41 @@ mod tests {
             .unwrap();
         let text = listed.content[0].as_text().unwrap();
         assert!(text.contains("BRAVE_API_KEY: env:BRAVE_API_KEY"));
+    }
+
+    #[tokio::test]
+    async fn secret_set_value_is_idempotent_and_repairs_listing() {
+        let provider = provider();
+        provider
+            .execute(
+                crate::tool_registry::secrets::SECRET_SET,
+                "tc-idempotent-1",
+                json!({"name": "BRAVE_API_KEY", "value": "first"}),
+                CancellationToken::new(),
+            )
+            .await
+            .unwrap();
+        provider
+            .execute(
+                crate::tool_registry::secrets::SECRET_SET,
+                "tc-idempotent-2",
+                json!({"name": "BRAVE_API_KEY", "value": "second"}),
+                CancellationToken::new(),
+            )
+            .await
+            .unwrap();
+
+        let listed = provider
+            .execute(
+                crate::tool_registry::secrets::SECRET_LIST,
+                "tc-idempotent-3",
+                json!({}),
+                CancellationToken::new(),
+            )
+            .await
+            .unwrap();
+        let text = listed.content[0].as_text().unwrap();
+        assert!(text.contains("BRAVE_API_KEY: keyring:BRAVE_API_KEY [resolves]"));
     }
 
     #[tokio::test]

--- a/design/secrets-idempotency.md
+++ b/design/secrets-idempotency.md
@@ -1,0 +1,60 @@
+# Secrets idempotency and bounded repair
+
+## Problem
+
+Harness-managed secrets have two pieces of state:
+
+- A non-secret recipe in Omegon's recipe store, for example `BRAVE_API_KEY -> keyring:BRAVE_API_KEY`.
+- A sensitive value in OS secure storage under Omegon's canonical keyring service.
+
+Those can drift. The observed failure was an orphaned `BRAVE_API_KEY` keychain item with no matching recipe. `secret_set` then failed because secure storage reported that the item already existed, while `web_search` could not resolve it because no recipe declared it.
+
+## Design rule
+
+The recipe store is the source of truth for **intent**. The keychain is value storage. Omegon must repair named harness-managed secrets when the operator names them, but it must not scan or preflight the whole keychain.
+
+Startup reads declarations, not guesses.
+
+## Invariants
+
+For a harness-managed keyring secret named `NAME`:
+
+```text
+recipe store: NAME -> keyring:NAME
+keychain:     service=sh.styrene.omegon, account=NAME, value=<secret>
+```
+
+Operations must be idempotent:
+
+- `secret_set(NAME, value)` upserts the keychain value and ensures the recipe exists.
+- `secret_set(NAME, recipe)` overwrites the recipe safely when the recipe type is agent-allowed.
+- `secret_delete(NAME)` removes the recipe, same-name keychain entry, process env projection, session cache, and redaction cache. Missing recipe/keychain state is success.
+- `secret_list` reports only declared recipes and bounded status for those recipes. It never enumerates keychain contents.
+
+## Startup policy
+
+Do not preflight every well-known secret. Preflight only:
+
+- active LLM provider credentials,
+- configured project/extension/MCP secrets,
+- web-search keys that already have recipe declarations.
+
+This avoids startup latency and keychain prompt storms while still warming credentials that the session is likely to need.
+
+## Repair behavior
+
+If an orphaned keychain item exists without a recipe, `secret_set(NAME, value)` repairs it by treating the secure-storage write as an upsert. On backends that return duplicate-item errors instead of replacing, Omegon retries as delete-then-set and then writes the recipe.
+
+`secret_delete(NAME)` is the cleanup escape hatch. It deletes both sides for the named secret without trying to discover unrelated keychain items.
+
+## Diagnostics
+
+`secret_list` shows configured recipes with bounded resolution status:
+
+```text
+BRAVE_API_KEY: keyring:BRAVE_API_KEY [resolves]
+TAVILY_API_KEY: keyring:TAVILY_API_KEY [missing]
+VAULT_ROOT_TOKEN: vault:secret/data/root#token [deferred]
+```
+
+`deferred` means resolution requires async/external context such as Vault and is intentionally not probed by the synchronous list operation.

--- a/site/src/lib/markdown.ts
+++ b/site/src/lib/markdown.ts
@@ -1,0 +1,5 @@
+export function stripFrontmatter(markdown: string): string {
+  const text = markdown.replace(/^\uFEFF/, "");
+  const match = text.match(/^(---|\+\+\+)\r?\n[\s\S]*?\r?\n\1\r?\n?/);
+  return match ? text.slice(match[0].length) : text;
+}

--- a/site/src/pages/changelog.astro
+++ b/site/src/pages/changelog.astro
@@ -1,17 +1,12 @@
 ---
 import Docs from "../layouts/Docs.astro";
+import { stripFrontmatter } from "../lib/markdown";
 import { readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const changelogPath = resolve(here, "../../../CHANGELOG.md");
-
-function stripFrontmatter(markdown: string): string {
-  const text = markdown.replace(/^\uFEFF/, "");
-  const match = text.match(/^(---|\+\+\+)\r?\n[\s\S]*?\r?\n\1\r?\n?/);
-  return match ? text.slice(match[0].length) : text;
-}
 
 let raw = "";
 try {

--- a/site/src/pages/privacy.astro
+++ b/site/src/pages/privacy.astro
@@ -1,12 +1,13 @@
 ---
 import Docs from "../layouts/Docs.astro";
+import { stripFrontmatter } from "../lib/markdown";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
 const privacyPath = join(process.cwd(), "..", "PRIVACY.md");
 let raw = "";
 try {
-  raw = readFileSync(privacyPath, "utf-8");
+  raw = stripFrontmatter(readFileSync(privacyPath, "utf-8"));
 } catch {
   raw = "# Privacy Policy\n\n*Not available during this build.*";
 }

--- a/site/src/pages/terms.astro
+++ b/site/src/pages/terms.astro
@@ -1,12 +1,13 @@
 ---
 import Docs from "../layouts/Docs.astro";
+import { stripFrontmatter } from "../lib/markdown";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
 const termsPath = join(process.cwd(), "..", "TERMS.md");
 let raw = "";
 try {
-  raw = readFileSync(termsPath, "utf-8");
+  raw = stripFrontmatter(readFileSync(termsPath, "utf-8"));
 } catch {
   raw = "# Terms of Use\n\n*Not available during this build.*";
 }

--- a/site/tests/docs-content.test.mjs
+++ b/site/tests/docs-content.test.mjs
@@ -16,9 +16,9 @@ test('install docs use canonical snippets for all channels', () => {
   const content = readDoc('install.astro');
 
   // Uses snippet system, not hardcoded commands
-  assert.match(content, /snippet\("install\.install_rc"\)/);
-  assert.match(content, /snippet\("install\.install_nightly"\)/);
   assert.match(content, /snippet\("install\.quick_install"\)/);
+  assert.match(content, /snippet\("install\.install_nightly"\)/);
+  assert.match(content, /snippet\("install\.install_version"\)/);
   assert.doesNotMatch(content, /omegon\.styrene\.dev/);
   // Auth commands use correct form
   assert.match(content, /snippet\("auth\.login_anthropic"\)/);
@@ -66,12 +66,18 @@ test('site builds successfully', () => {
   });
 
   const changelogHtml = readFileSync(resolve(here, '../dist/changelog/index.html'), 'utf8');
+  const privacyHtml = readFileSync(resolve(here, '../dist/privacy/index.html'), 'utf8');
+  const termsHtml = readFileSync(resolve(here, '../dist/terms/index.html'), 'utf8');
   const rootChangelog = readFileSync(resolve(here, '../../CHANGELOG.md'), 'utf8');
 
   assert.match(rootChangelog, /^\+\+\+/);
-  assert.doesNotMatch(changelogHtml, /imported_reference/);
-  assert.doesNotMatch(changelogHtml, /\[publication\]/);
-  assert.match(changelogHtml, /Strict clippy hygiene/);
+  for (const rendered of [changelogHtml, privacyHtml, termsHtml]) {
+    assert.doesNotMatch(rendered, /imported_reference/);
+    assert.doesNotMatch(rendered, /\[publication\]/);
+    assert.doesNotMatch(rendered, /^\+\+\+/m);
+    assert.doesNotMatch(rendered, /^---$/m);
+  }
+  assert.match(changelogHtml, /local sandbox evidence-substrate smoke suite/);
   for (const version of [
     '0.19.6',
     '0.19.5',


### PR DESCRIPTION
## Summary

- Rebase the frontmatter hygiene fix onto current `origin/main`.
- Add a secrets idempotency design note defining recipe/keyring invariants and bounded repair behavior.
- Make named secret set/delete operations idempotent across recipe metadata, keyring values, session cache, redaction, and env projection.
- Add bounded `secret_list` recipe diagnostics without scanning the whole keychain.

## Validation

- `just lint`
- `cargo test -p omegon-secrets`
- `cargo test -p omegon secret_tools -- --nocapture`
- `cargo test -p omegon parses_toml_frontmatter_and_strips_it_from_body -- --nocapture`
- `node --test site/tests/docs-content.test.mjs`
- `just site-build`

## Notes

`just test-ts` was attempted earlier and skipped because `../omegon-pi` is not present in this checkout.
