### PR TITLE
feat(subagents): expose cleave delegate progress and execution evals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [Semantic V
 - Add a read-only capability inventory substrate and ACP `_capabilities/inventory` surface for installed extensions, Armory assets, and catalog agents to support future console/TUI capability views.
 - Register provider retry/failure and turn-cancelled ACP telemetry surfaces in the backend endpoint registry so clients can discover issue #128 notification contracts.
 - Add a metadata-only backend endpoint registry for ACP/runtime/lifecycle/provider/extension/secret/package/plan/task surfaces, including planned HTTP aliases for lifecycle projections.
-- Add cleave and delegate execution-evaluation tests with injected child binaries.
+- Add cleave and delegate execution-evaluation tests with injected child binaries, including timeout and cancellation coverage.
 - Add richer cleave/delegate status visibility for subagent progress, including child activity, task progress, and runtime state.
 - Add headless ACP lifecycle read surfaces for lifecycle snapshots and design-node list/get/ready/blocked/frontier projections.
 - Route design-tree implement scaffolding through the lifecycle mutation service while preserving existing OpenSpec proposal behavior.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [Semantic V
 - Add a read-only capability inventory substrate and ACP `_capabilities/inventory` surface for installed extensions, Armory assets, and catalog agents to support future console/TUI capability views.
 - Register provider retry/failure and turn-cancelled ACP telemetry surfaces in the backend endpoint registry so clients can discover issue #128 notification contracts.
 - Add a metadata-only backend endpoint registry for ACP/runtime/lifecycle/provider/extension/secret/package/plan/task surfaces, including planned HTTP aliases for lifecycle projections.
+- Add cleave and delegate execution-evaluation tests with injected child binaries.
 - Add richer cleave/delegate status visibility for subagent progress, including child activity, task progress, and runtime state.
 - Add headless ACP lifecycle read surfaces for lifecycle snapshots and design-node list/get/ready/blocked/frontier projections.
 - Route design-tree implement scaffolding through the lifecycle mutation service while preserving existing OpenSpec proposal behavior.
@@ -47,6 +48,10 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [Semantic V
 - Add `just test-profile` to statically summarize Rust test/coupling hotspots before choosing validation or extraction targets.
 - Add Python unit coverage for the affected-crate and test-profile developer tooling.
 - Add a Codebase Mind design node defining durable structural repository memory, freshness, and projection policy.
+
+### Fixed
+
+- Create cleave git worktree branches explicitly before adding libgit2 worktrees, and report failed children with no salvaged changes as skipped instead of successful no-op merges.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [Semantic V
 - Add a read-only capability inventory substrate and ACP `_capabilities/inventory` surface for installed extensions, Armory assets, and catalog agents to support future console/TUI capability views.
 - Register provider retry/failure and turn-cancelled ACP telemetry surfaces in the backend endpoint registry so clients can discover issue #128 notification contracts.
 - Add a metadata-only backend endpoint registry for ACP/runtime/lifecycle/provider/extension/secret/package/plan/task surfaces, including planned HTTP aliases for lifecycle projections.
+- Add richer cleave/delegate status visibility for subagent progress, including child activity, task progress, and runtime state.
 - Add headless ACP lifecycle read surfaces for lifecycle snapshots and design-node list/get/ready/blocked/frontier projections.
 - Route design-tree implement scaffolding through the lifecycle mutation service while preserving existing OpenSpec proposal behavior.
 - Add a design node planning the future lifecycle `implement` service extraction pass.

--- a/core/crates/omegon-git/src/worktree.rs
+++ b/core/crates/omegon-git/src/worktree.rs
@@ -150,14 +150,24 @@ pub fn create(repo_path: &Path, worktree_path: &Path, branch: &str) -> Result<Wo
         let _ = std::fs::remove_dir_all(worktree_path);
     }
 
-    // Create the worktree with a new branch from HEAD.
-    // git2's worktree() creates both the branch and the worktree atomically.
+    // Create the branch from HEAD before adding the worktree. libgit2's
+    // worktree add expects `reference` to name an existing ref; unlike
+    // `git worktree add -b`, it does not create the branch for us.
     let head = repo.head().context("failed to read HEAD")?;
-    let head_ref = head.resolve().context("failed to resolve HEAD")?;
+    let head_commit = head
+        .peel_to_commit()
+        .context("failed to resolve HEAD commit")?;
+    repo.branch(branch, &head_commit, true)
+        .with_context(|| format!("failed to create branch {branch}"))?;
+    let branch_ref = repo
+        .find_branch(branch, git2::BranchType::Local)
+        .with_context(|| format!("failed to find created branch {branch}"))?
+        .into_reference();
     let mut opts = git2::WorktreeAddOptions::new();
-    opts.reference(Some(&head_ref));
+    opts.reference(Some(&branch_ref));
 
-    repo.worktree(branch, worktree_path, Some(&opts))
+    let worktree_name = branch.replace('/', "-");
+    repo.worktree(&worktree_name, worktree_path, Some(&opts))
         .with_context(|| format!("failed to create worktree at {}", worktree_path.display()))?;
 
     Ok(WorktreeInfo {

--- a/core/crates/omegon/src/cleave/orchestrator.rs
+++ b/core/crates/omegon/src/cleave/orchestrator.rs
@@ -77,6 +77,7 @@ pub struct CleaveResult {
     pub duration_secs: f64,
 }
 
+#[derive(Debug)]
 pub enum MergeOutcome {
     Success,
     NoChanges,
@@ -680,14 +681,28 @@ pub async fn run_cleave(
                 });
             }
             Ok(worktree::MergeResult::NoChanges) => {
-                tracing::info!(child = %child.label, "child completed without repo changes");
-                let _ = worktree::delete_branch(repo_path, branch);
-                merge_results.push((child.label.clone(), MergeOutcome::NoChanges));
-                config.progress_sink.emit(&ProgressEvent::MergeResult {
-                    child: child.label.clone(),
-                    success: true,
-                    detail: Some("no changes".to_string()),
-                });
+                if is_salvage {
+                    tracing::info!(child = %child.label, "failed child had no salvaged repo changes");
+                    let _ = worktree::delete_branch(repo_path, branch);
+                    merge_results.push((
+                        child.label.clone(),
+                        MergeOutcome::Skipped("failed child produced no salvaged changes".into()),
+                    ));
+                    config.progress_sink.emit(&ProgressEvent::MergeResult {
+                        child: child.label.clone(),
+                        success: false,
+                        detail: Some("failed child produced no salvaged changes".to_string()),
+                    });
+                } else {
+                    tracing::info!(child = %child.label, "child completed without repo changes");
+                    let _ = worktree::delete_branch(repo_path, branch);
+                    merge_results.push((child.label.clone(), MergeOutcome::NoChanges));
+                    config.progress_sink.emit(&ProgressEvent::MergeResult {
+                        child: child.label.clone(),
+                        success: true,
+                        detail: Some("no changes".to_string()),
+                    });
+                }
             }
             Ok(worktree::MergeResult::Conflict(detail)) => {
                 tracing::warn!(child = %child.label, "merge conflict");
@@ -1652,3 +1667,176 @@ fn nanoid(len: usize) -> String {
     }
     result
 }
+
+fn write_fake_child(dir: &Path, name: &str, body: &str) -> PathBuf {
+        let path = dir.join(name);
+        std::fs::write(&path, body).unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = std::fs::metadata(&path).unwrap().permissions();
+            perms.set_mode(0o755);
+            std::fs::set_permissions(&path, perms).unwrap();
+        }
+        path
+    }
+
+    fn init_git_repo(dir: &Path) {
+        std::process::Command::new("git")
+            .args(["init"])
+            .current_dir(dir)
+            .output()
+            .expect("git init should run");
+        std::fs::write(dir.join("README.md"), "# cleave execution eval\n").unwrap();
+        let add = std::process::Command::new("git")
+            .args(["add", "README.md"])
+            .current_dir(dir)
+            .output()
+            .expect("git add should run");
+        assert!(add.status.success(), "git add failed: {}", String::from_utf8_lossy(&add.stderr));
+        let commit = std::process::Command::new("git")
+            .args([
+                "-c",
+                "user.name=Omegon Test",
+                "-c",
+                "user.email=omegon-test@example.invalid",
+                "commit",
+                "-m",
+                "initial",
+            ])
+            .current_dir(dir)
+            .output()
+            .expect("git commit should run");
+        assert!(
+            commit.status.success(),
+            "git commit failed: {}",
+            String::from_utf8_lossy(&commit.stderr)
+        );
+    }
+
+    fn one_child_plan() -> crate::cleave::plan::CleavePlan {
+        crate::cleave::plan::CleavePlan {
+            children: vec![crate::cleave::plan::ChildPlan {
+                label: "alpha".into(),
+                description: "Run fake child".into(),
+                scope: vec!["README.md".into()],
+                depends_on: vec![],
+                model: Some("test:model".into()),
+                runtime: None,
+            }],
+            rationale: "execution eval".into(),
+            default_model: Some("test:model".into()),
+        }
+    }
+
+    fn test_config(
+        fake_child: PathBuf,
+        events: std::sync::Arc<std::sync::Mutex<Vec<crate::cleave::progress::ProgressEvent>>>,
+    ) -> CleaveConfig {
+        CleaveConfig {
+            agent_binary: fake_child,
+            bridge_path: PathBuf::new(),
+            node: String::new(),
+            model: "test:model".into(),
+            max_parallel: 1,
+            timeout_secs: 30,
+            idle_timeout_secs: 10,
+            max_turns: 3,
+            inventory: None,
+            inherited_env: vec![],
+            injected_env: vec![],
+            child_runtime: crate::cleave::CleaveChildRuntimeProfile::default(),
+            progress_sink: crate::cleave::progress::callback_progress_sink(move |event| {
+                events.lock().unwrap().push(event.clone());
+            }),
+            workflow: None,
+            sandbox: false,
+        }
+    }
+
+    #[tokio::test]
+    async fn run_cleave_executes_injected_child_successfully() {
+        let repo = tempfile::tempdir().unwrap();
+        init_git_repo(repo.path());
+        let workspace = tempfile::tempdir().unwrap();
+        let fake_child = write_fake_child(
+            repo.path(),
+            "fake-cleave-success.sh",
+            "#!/bin/sh\necho cleave-child-ok\n",
+        );
+        let events = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let config = test_config(fake_child, std::sync::Arc::clone(&events));
+
+        let result = run_cleave(
+            &one_child_plan(),
+            "prove cleave child execution",
+            repo.path(),
+            workspace.path(),
+            &config,
+            CancellationToken::new(),
+            None,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result.state.children.len(), 1);
+        let child = &result.state.children[0];
+        assert_eq!(
+            child.status,
+            crate::cleave::state::ChildStatus::Completed,
+            "child failed unexpectedly: {:?}",
+            child.error
+        );
+        assert!(child.stdout.as_deref().unwrap_or_default().contains("cleave-child-ok"));
+        assert!(workspace.path().join("state.json").exists());
+        assert!(workspace.path().join("0-task.md").exists());
+        let events = events.lock().unwrap();
+        assert!(events.iter().any(|event| matches!(event, crate::cleave::progress::ProgressEvent::ChildSpawned { child, .. } if child == "alpha")));
+        assert!(events.iter().any(|event| matches!(event, crate::cleave::progress::ProgressEvent::ChildStatus { child, status: crate::cleave::progress::ChildProgressStatus::Completed, .. } if child == "alpha")));
+        assert!(result.merge_results.iter().any(|(label, outcome)| {
+            label == "alpha" && matches!(outcome, MergeOutcome::NoChanges | MergeOutcome::Success)
+        }));
+    }
+
+    #[tokio::test]
+    async fn run_cleave_records_injected_child_failure() {
+        let repo = tempfile::tempdir().unwrap();
+        init_git_repo(repo.path());
+        let workspace = tempfile::tempdir().unwrap();
+        let fake_child = write_fake_child(
+            repo.path(),
+            "fake-cleave-fail.sh",
+            "#!/bin/sh\necho cleave child failed >&2\nexit 9\n",
+        );
+        let events = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let config = test_config(fake_child, std::sync::Arc::clone(&events));
+
+        let result = run_cleave(
+            &one_child_plan(),
+            "prove cleave child failure reporting",
+            repo.path(),
+            workspace.path(),
+            &config,
+            CancellationToken::new(),
+            None,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result.state.children.len(), 1);
+        let child = &result.state.children[0];
+        assert_eq!(child.status, crate::cleave::state::ChildStatus::Failed);
+        assert!(child.error.as_deref().unwrap_or_default().contains("cleave child failed"));
+        let events = events.lock().unwrap();
+        assert!(events.iter().any(|event| matches!(event, crate::cleave::progress::ProgressEvent::ChildSpawned { child, .. } if child == "alpha")));
+        assert!(events.iter().any(|event| matches!(event, crate::cleave::progress::ProgressEvent::ChildStatus { child, status: crate::cleave::progress::ChildProgressStatus::Failed, .. } if child == "alpha")));
+        assert!(
+            result.merge_results.is_empty()
+                || result
+                    .merge_results
+                    .iter()
+                    .any(|(label, outcome)| label == "alpha" && matches!(outcome, MergeOutcome::Skipped(_))),
+            "failed children should not be merged: {:?}",
+            result.merge_results
+        );
+    }

--- a/core/crates/omegon/src/cleave/orchestrator.rs
+++ b/core/crates/omegon/src/cleave/orchestrator.rs
@@ -1754,6 +1754,20 @@ fn write_fake_child(dir: &Path, name: &str, body: &str) -> PathBuf {
         }
     }
 
+
+
+    fn progress_from_events(
+        events: &[crate::cleave::progress::ProgressEvent],
+    ) -> crate::features::cleave::CleaveProgress {
+        let shared = std::sync::Arc::new(std::sync::Mutex::new(
+            crate::features::cleave::CleaveProgress::default(),
+        ));
+        for event in events {
+            crate::features::cleave::apply_progress_event(&shared, event);
+        }
+        shared.lock().unwrap().clone()
+    }
+
     #[tokio::test]
     async fn run_cleave_executes_injected_child_successfully() {
         let repo = tempfile::tempdir().unwrap();
@@ -1841,6 +1855,13 @@ fn write_fake_child(dir: &Path, name: &str, body: &str) -> PathBuf {
         );
         let events = events.lock().unwrap();
         assert!(events.iter().any(|event| matches!(event, crate::cleave::progress::ProgressEvent::ChildStatus { child, status: crate::cleave::progress::ChildProgressStatus::Failed, error: Some(error), .. } if child == "alpha" && error.contains("Wall-clock timeout"))));
+        let progress = progress_from_events(&events);
+        assert!(!progress.active, "timeout should clear active progress");
+        assert_eq!(progress.failed, 1);
+        let child_progress = progress.children.iter().find(|c| c.label == "alpha").unwrap();
+        assert_eq!(child_progress.status, "failed");
+        assert_eq!(child_progress.pid, None);
+        assert_eq!(child_progress.supervision_mode, None);
     }
 
     #[tokio::test]
@@ -1884,6 +1905,13 @@ fn write_fake_child(dir: &Path, name: &str, body: &str) -> PathBuf {
         );
         let events = events.lock().unwrap();
         assert!(events.iter().any(|event| matches!(event, crate::cleave::progress::ProgressEvent::ChildStatus { child, status: crate::cleave::progress::ChildProgressStatus::Failed, error: Some(error), .. } if child == "alpha" && error.contains("Cancelled"))));
+        let progress = progress_from_events(&events);
+        assert!(!progress.active, "cancellation should clear active progress");
+        assert_eq!(progress.failed, 1);
+        let child_progress = progress.children.iter().find(|c| c.label == "alpha").unwrap();
+        assert_eq!(child_progress.status, "failed");
+        assert_eq!(child_progress.pid, None);
+        assert_eq!(child_progress.supervision_mode, None);
     }
 
     #[tokio::test]

--- a/core/crates/omegon/src/cleave/orchestrator.rs
+++ b/core/crates/omegon/src/cleave/orchestrator.rs
@@ -1798,6 +1798,94 @@ fn write_fake_child(dir: &Path, name: &str, body: &str) -> PathBuf {
         }));
     }
 
+
+
+    #[tokio::test]
+    async fn run_cleave_times_out_and_kills_silent_child() {
+        let repo = tempfile::tempdir().unwrap();
+        init_git_repo(repo.path());
+        let workspace = tempfile::tempdir().unwrap();
+        let fake_child = write_fake_child(
+            repo.path(),
+            "fake-cleave-silent-timeout.sh",
+            "#!/bin/sh\nexec sleep 10\n",
+        );
+        let events = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let mut config = test_config(fake_child, std::sync::Arc::clone(&events));
+        config.timeout_secs = 1;
+        config.idle_timeout_secs = 30;
+
+        let result = run_cleave(
+            &one_child_plan(),
+            "prove cleave child wall timeout",
+            repo.path(),
+            workspace.path(),
+            &config,
+            CancellationToken::new(),
+            None,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result.state.children.len(), 1);
+        let child = &result.state.children[0];
+        assert_eq!(child.status, crate::cleave::state::ChildStatus::Failed);
+        assert!(
+            child
+                .error
+                .as_deref()
+                .unwrap_or_default()
+                .contains("Wall-clock timeout"),
+            "unexpected child error: {:?}",
+            child.error
+        );
+        let events = events.lock().unwrap();
+        assert!(events.iter().any(|event| matches!(event, crate::cleave::progress::ProgressEvent::ChildStatus { child, status: crate::cleave::progress::ChildProgressStatus::Failed, error: Some(error), .. } if child == "alpha" && error.contains("Wall-clock timeout"))));
+    }
+
+    #[tokio::test]
+    async fn run_cleave_cancellation_kills_running_child() {
+        let repo = tempfile::tempdir().unwrap();
+        init_git_repo(repo.path());
+        let workspace = tempfile::tempdir().unwrap();
+        let fake_child = write_fake_child(
+            repo.path(),
+            "fake-cleave-cancel.sh",
+            "#!/bin/sh\nexec sleep 10\n",
+        );
+        let events = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let config = test_config(fake_child, std::sync::Arc::clone(&events));
+        let cancel = CancellationToken::new();
+        let cancel_clone = cancel.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
+            cancel_clone.cancel();
+        });
+
+        let result = run_cleave(
+            &one_child_plan(),
+            "prove cleave child cancellation",
+            repo.path(),
+            workspace.path(),
+            &config,
+            cancel,
+            None,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result.state.children.len(), 1);
+        let child = &result.state.children[0];
+        assert_eq!(child.status, crate::cleave::state::ChildStatus::Failed);
+        assert!(
+            child.error.as_deref().unwrap_or_default().contains("Cancelled"),
+            "unexpected child error: {:?}",
+            child.error
+        );
+        let events = events.lock().unwrap();
+        assert!(events.iter().any(|event| matches!(event, crate::cleave::progress::ProgressEvent::ChildStatus { child, status: crate::cleave::progress::ChildProgressStatus::Failed, error: Some(error), .. } if child == "alpha" && error.contains("Cancelled"))));
+    }
+
     #[tokio::test]
     async fn run_cleave_records_injected_child_failure() {
         let repo = tempfile::tempdir().unwrap();

--- a/core/crates/omegon/src/features/cleave.rs
+++ b/core/crates/omegon/src/features/cleave.rs
@@ -729,6 +729,81 @@ impl CleaveFeature {
         self.progress.lock().unwrap().clone()
     }
 
+
+    fn render_status(progress: &CleaveProgress) -> String {
+        if !progress.active && progress.total_children == 0 {
+            return "No active cleave run.".into();
+        }
+        let mut lines = Vec::new();
+        if progress.active {
+            lines.push(format!(
+                "Cleave active: {}/{} children ({} completed, {} failed)",
+                progress.completed + progress.failed,
+                progress.total_children,
+                progress.completed,
+                progress.failed
+            ));
+        } else {
+            lines.push(format!(
+                "Last cleave: {} completed, {} failed of {}",
+                progress.completed, progress.failed, progress.total_children
+            ));
+        }
+        for child in &progress.children {
+            let icon = match child.status.as_str() {
+                "completed" | "merged_after_failure" => "✓",
+                "failed" | "upstream_exhausted" => "✗",
+                "running" => "⏳",
+                _ => "○",
+            };
+            let dur = child
+                .duration_secs
+                .map(|d| format!(" duration={:.0}s", d))
+                .unwrap_or_default();
+            let pid = child
+                .pid
+                .map(|pid| format!(" pid={pid}"))
+                .unwrap_or_default();
+            let supervision = child
+                .supervision_mode
+                .map(|mode| format!(" supervision={mode:?}"))
+                .unwrap_or_default();
+            let last_tool = child
+                .last_tool
+                .as_deref()
+                .map(|tool| format!(" tool={tool}"))
+                .unwrap_or_default();
+            let last_turn = child
+                .last_turn
+                .map(|turn| format!(" turn={turn}"))
+                .unwrap_or_default();
+            let tasks = if child.tasks.is_empty() {
+                String::new()
+            } else {
+                format!(" tasks={}/{}", child.tasks_done, child.tasks.len())
+            };
+            let tokens = if child.tokens_in > 0 || child.tokens_out > 0 {
+                format!(" tokens={}/{}", child.tokens_in, child.tokens_out)
+            } else {
+                String::new()
+            };
+            lines.push(format!(
+                "  {} {} [{}]{}{}{}{}{}{}{}",
+                icon,
+                child.label,
+                child.status,
+                dur,
+                pid,
+                supervision,
+                last_tool,
+                last_turn,
+                tasks,
+                tokens
+            ));
+        }
+        lines.join("\n")
+    }
+
     /// Get a shared handle to the progress for live dashboard updates.
     pub fn shared_progress(&self) -> Arc<Mutex<CleaveProgress>> {
         Arc::clone(&self.progress)
@@ -2294,4 +2369,158 @@ mod assessment_tests {
             "confidence should be (0,1]: {conf}"
         );
     }
+
+    #[test]
+    fn apply_progress_event_tracks_spawn_activity_tasks_failure_and_done() {
+        let shared = Arc::new(Mutex::new(CleaveProgress::default()));
+
+        apply_progress_event(
+            &shared,
+            &ProgressEvent::ChildSpawned {
+                child: "alpha".into(),
+                pid: 4242,
+            },
+        );
+        {
+            let progress = shared.lock().unwrap();
+            assert!(progress.active);
+            assert_eq!(progress.total_children, 1);
+            let child = &progress.children[0];
+            assert_eq!(child.label, "alpha");
+            assert_eq!(child.status, "running");
+            assert_eq!(child.pid, Some(4242));
+            assert_eq!(child.supervision_mode, Some(ChildSupervisionMode::Attached));
+        }
+
+        apply_progress_event(
+            &shared,
+            &ProgressEvent::ChildTaskInventory {
+                child: "alpha".into(),
+                total_tasks: 2,
+                scope_files: 1,
+                tasks: vec![
+                    crate::cleave::progress::ChildTaskItem {
+                        description: "Inspect".into(),
+                        done: false,
+                    },
+                    crate::cleave::progress::ChildTaskItem {
+                        description: "Report".into(),
+                        done: false,
+                    },
+                ],
+            },
+        );
+        apply_progress_event(
+            &shared,
+            &ProgressEvent::ChildActivity {
+                child: "alpha".into(),
+                turn: Some(2),
+                tool: Some("bash".into()),
+                target: Some("cargo test".into()),
+            },
+        );
+        apply_progress_event(
+            &shared,
+            &ProgressEvent::ChildTokens {
+                child: "alpha".into(),
+                input_tokens: 11,
+                output_tokens: 7,
+            },
+        );
+        {
+            let progress = shared.lock().unwrap();
+            assert_eq!(progress.total_tokens_in, 11);
+            assert_eq!(progress.total_tokens_out, 7);
+            let child = &progress.children[0];
+            assert_eq!(child.last_turn, Some(2));
+            assert_eq!(child.last_tool.as_deref(), Some("bash"));
+            assert_eq!(child.tasks_done, 1);
+            assert_eq!(child.tokens_in, 11);
+            assert_eq!(child.tokens_out, 7);
+        }
+
+        apply_progress_event(
+            &shared,
+            &ProgressEvent::ChildStatus {
+                child: "alpha".into(),
+                status: ChildProgressStatus::Failed,
+                duration_secs: Some(3.5),
+                error: Some("non-zero exit".into()),
+            },
+        );
+        {
+            let progress = shared.lock().unwrap();
+            assert_eq!(progress.completed, 0);
+            assert_eq!(progress.failed, 1);
+            let child = &progress.children[0];
+            assert_eq!(child.status, "failed");
+            assert_eq!(child.pid, None);
+            assert_eq!(child.supervision_mode, None);
+            assert_eq!(child.duration_secs, Some(3.5));
+        }
+
+        apply_progress_event(
+            &shared,
+            &ProgressEvent::Done {
+                completed: 0,
+                failed: 1,
+                duration_secs: 4.0,
+            },
+        );
+        let progress = shared.lock().unwrap();
+        assert!(!progress.active);
+        assert_eq!(progress.failed, 1);
+    }
+
+
+    #[test]
+    fn cleave_status_render_exposes_child_runtime_activity_and_tasks() {
+        let mut progress = CleaveProgress {
+            active: true,
+            run_id: "run-test".into(),
+            total_children: 1,
+            completed: 0,
+            failed: 0,
+            children: vec![ChildProgress {
+                label: "alpha".into(),
+                status: "running".into(),
+                duration_secs: Some(12.0),
+                supervision_mode: Some(ChildSupervisionMode::Attached),
+                pid: Some(1234),
+                last_tool: Some("bash".into()),
+                last_turn: Some(3),
+                tasks: vec![
+                    crate::cleave::progress::ChildTaskItem { description: "Inspect".into(), done: true },
+                    crate::cleave::progress::ChildTaskItem { description: "Patch".into(), done: false },
+                ],
+                tasks_done: 1,
+                started_at: None,
+                last_activity_at: None,
+                tokens_in: 20,
+                tokens_out: 5,
+                runtime: None,
+            }],
+            total_tokens_in: 20,
+            total_tokens_out: 5,
+        };
+
+        let rendered = CleaveFeature::render_status(&progress);
+
+        assert!(rendered.contains("Cleave active: 0/1 children"), "{rendered}");
+        assert!(rendered.contains("alpha [running]"), "{rendered}");
+        assert!(rendered.contains("pid=1234"), "{rendered}");
+        assert!(rendered.contains("supervision=Attached"), "{rendered}");
+        assert!(rendered.contains("tool=bash"), "{rendered}");
+        assert!(rendered.contains("turn=3"), "{rendered}");
+        assert!(rendered.contains("tasks=1/2"), "{rendered}");
+        assert!(rendered.contains("tokens=20/5"), "{rendered}");
+
+        progress.active = false;
+        progress.completed = 1;
+        progress.children[0].status = "completed".into();
+        let rendered = CleaveFeature::render_status(&progress);
+        assert!(rendered.contains("Last cleave: 1 completed, 0 failed of 1"), "{rendered}");
+        assert!(rendered.contains("alpha [completed]"), "{rendered}");
+    }
+
 }

--- a/core/crates/omegon/src/features/cleave.rs
+++ b/core/crates/omegon/src/features/cleave.rs
@@ -370,7 +370,7 @@ fn recompute_progress_counts(progress: &mut CleaveProgress) {
         .count();
 }
 
-fn apply_progress_event(shared: &Arc<Mutex<CleaveProgress>>, event: &ProgressEvent) {
+pub(crate) fn apply_progress_event(shared: &Arc<Mutex<CleaveProgress>>, event: &ProgressEvent) {
     let mut progress = shared.lock().unwrap();
 
     match event {

--- a/core/crates/omegon/src/features/delegate.rs
+++ b/core/crates/omegon/src/features/delegate.rs
@@ -1609,40 +1609,75 @@ impl Feature for DelegateFeature {
             }
 
             crate::tool_registry::delegate::DELEGATE_STATUS => {
-                let tasks = self.result_store.list_all_tasks();
+                let snapshot = self.result_store.progress_snapshot();
                 let mut status_text = String::from(
-                    "# Delegate Tasks\n\n| Task ID | Agent | Status | Description |\n|---------|-------|--------|-------------|\n",
+                    "# Delegate Tasks
+
+| Task ID | Agent | Status | Last Tool | Turn | Tasks | Description |
+|---------|-------|--------|-----------|------|-------|-------------|
+",
                 );
 
-                for task in tasks {
-                    let agent = task.agent_name.as_deref().unwrap_or("default");
-                    let status = match task.status {
-                        DelegateTaskStatus::Running => "🔄 Running".to_string(),
-                        DelegateTaskStatus::Completed { success: true } => {
-                            "✅ Completed".to_string()
-                        }
-                        DelegateTaskStatus::Completed { success: false } => "❌ Failed".to_string(),
-                        DelegateTaskStatus::Failed { .. } => "❌ Error".to_string(),
+                for child in &snapshot.children {
+                    let task = self.result_store.get_task(&child.task_id);
+                    let agent = task
+                        .as_ref()
+                        .and_then(|t| t.agent_name.as_deref())
+                        .unwrap_or("default");
+                    let description = task
+                        .as_ref()
+                        .map(|t| {
+                            if t.task_description.len() > 50 {
+                                crate::util::truncate(&t.task_description, 50)
+                            } else {
+                                t.task_description.clone()
+                            }
+                        })
+                        .unwrap_or_else(|| child.label.clone());
+                    let status = match child.status.as_str() {
+                        "running" => "🔄 Running",
+                        "completed" => "✅ Completed",
+                        "failed" => "❌ Failed",
+                        other => other,
                     };
-                    let description = if task.task_description.len() > 50 {
-                        crate::util::truncate(&task.task_description, 50)
-                    } else {
-                        task.task_description.clone()
-                    };
-
+                    let last_tool = child.last_tool.as_deref().unwrap_or("-");
+                    let last_turn = child
+                        .last_turn
+                        .map(|turn| turn.to_string())
+                        .unwrap_or_else(|| "-".to_string());
+                    let task_progress = format!("{}/{}", child.tasks_done, child.tasks.len());
                     status_text.push_str(&format!(
-                        "| {} | {} | {} | {} |\n",
-                        task.task_id, agent, status, description
+                        "| {} | {} | {} | {} | {} | {} | {} |
+",
+                        child.task_id, agent, status, last_tool, last_turn, task_progress, description
                     ));
                 }
 
-                if self.result_store.list_all_tasks().is_empty() {
-                    status_text.push_str("\nNo delegate tasks found.\n");
+                if snapshot.children.is_empty() {
+                    status_text.push_str("
+No delegate tasks found.
+");
                 }
 
                 Ok(ToolResult {
                     content: vec![ContentBlock::Text { text: status_text }],
-                    details: json!({ "task_count": self.result_store.list_all_tasks().len() }),
+                    details: json!({
+                        "active": snapshot.active,
+                        "running": snapshot.running,
+                        "completed": snapshot.completed,
+                        "failed": snapshot.failed,
+                        "task_count": snapshot.children.len(),
+                        "children": snapshot.children.iter().map(|child| json!({
+                            "task_id": child.task_id,
+                            "label": child.label,
+                            "status": child.status,
+                            "last_tool": child.last_tool,
+                            "last_turn": child.last_turn,
+                            "result_summary": child.result_summary,
+                            "tasks_done": child.tasks_done,
+                            "tasks_total": child.tasks.len(),
+                        })).collect::<Vec<_>>(),
+                    }),
                 })
             }
 
@@ -2279,4 +2314,67 @@ This agent runs in write mode and can modify files.
             );
         }
     }
+
+    #[test]
+    fn progress_snapshot_exposes_running_completed_and_failed_delegate_state() {
+        let store = DelegateResultStore::new();
+        let now = SystemTime::now();
+        store.store_task(DelegateTask {
+            task_id: "delegate_1".into(),
+            agent_name: Some("scout".into()),
+            task_description: "- [ ] Inspect files\n- [ ] Report findings".into(),
+            status: DelegateTaskStatus::Running,
+            result: None,
+            started_at: now,
+            completed_at: None,
+            last_tool: None,
+            last_turn: None,
+            tasks: crate::cleave::progress::extract_task_items("- [ ] Inspect files\n- [ ] Report findings"),
+        });
+        store.update_task_live_state("delegate_1", Some("read".into()), Some(2));
+        store.store_task(DelegateTask {
+            task_id: "delegate_2".into(),
+            agent_name: Some("verify".into()),
+            task_description: "Run checks".into(),
+            status: DelegateTaskStatus::Completed { success: true },
+            result: Some("Validation passed with a long enough result summary to truncate".into()),
+            started_at: now,
+            completed_at: Some(now),
+            last_tool: None,
+            last_turn: None,
+            tasks: Vec::new(),
+        });
+        store.store_task(DelegateTask {
+            task_id: "delegate_3".into(),
+            agent_name: Some("patch".into()),
+            task_description: "Patch bug".into(),
+            status: DelegateTaskStatus::Failed { error: "child exited".into() },
+            result: None,
+            started_at: now,
+            completed_at: Some(now),
+            last_tool: None,
+            last_turn: None,
+            tasks: Vec::new(),
+        });
+
+        let snapshot = store.progress_snapshot();
+
+        assert!(snapshot.active);
+        assert_eq!(snapshot.running, 1);
+        assert_eq!(snapshot.completed, 1);
+        assert_eq!(snapshot.failed, 1);
+        assert_eq!(snapshot.children.len(), 3);
+        let running = snapshot.children.iter().find(|c| c.task_id == "delegate_1").unwrap();
+        assert_eq!(running.status, "running");
+        assert_eq!(running.last_tool.as_deref(), Some("read"));
+        assert_eq!(running.last_turn, Some(2));
+        assert_eq!(running.tasks_done, 1);
+        let completed = snapshot.children.iter().find(|c| c.task_id == "delegate_2").unwrap();
+        assert_eq!(completed.status, "completed");
+        assert!(completed.result_summary.as_ref().unwrap().starts_with("Validation passed"));
+        assert!(completed.result_summary.as_ref().unwrap().len() < "Validation passed with a long enough result summary to truncate".len());
+        let failed = snapshot.children.iter().find(|c| c.task_id == "delegate_3").unwrap();
+        assert_eq!(failed.status, "failed");
+    }
+
 }

--- a/core/crates/omegon/src/features/delegate.rs
+++ b/core/crates/omegon/src/features/delegate.rs
@@ -400,6 +400,8 @@ pub struct DelegateRunner {
     result_store: Arc<DelegateResultStore>,
     sandbox: bool,
     child_agent_binary: Option<PathBuf>,
+    wall_timeout_secs: u64,
+    idle_timeout_secs: u64,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -645,12 +647,21 @@ impl DelegateRunner {
             result_store,
             sandbox,
             child_agent_binary: None,
+            wall_timeout_secs: 300,
+            idle_timeout_secs: 120,
         }
     }
 
     #[cfg(test)]
     fn with_child_agent_binary(mut self, child_agent_binary: PathBuf) -> Self {
         self.child_agent_binary = Some(child_agent_binary);
+        self
+    }
+
+    #[cfg(test)]
+    fn with_timeouts(mut self, wall_timeout_secs: u64, idle_timeout_secs: u64) -> Self {
+        self.wall_timeout_secs = wall_timeout_secs;
+        self.idle_timeout_secs = idle_timeout_secs;
         self
     }
 
@@ -802,15 +813,15 @@ If blocked, say the blocker plainly.\n",
         let store = self.result_store.clone();
         let tid = task_id.to_string();
 
-        let wall_timeout = tokio::time::Duration::from_secs(300); // 5 min
-        let idle_timeout = tokio::time::Duration::from_secs(120); // 2 min
+        let wall_timeout = tokio::time::Duration::from_secs(self.wall_timeout_secs);
+        let idle_timeout = tokio::time::Duration::from_secs(self.idle_timeout_secs);
         let mut last_activity = std::time::Instant::now();
         let mut last_activity_event = std::time::Instant::now() - std::time::Duration::from_secs(2); // ensure first event fires
 
         let io_result: Result<(), anyhow::Error> = tokio::select! {
             _ = tokio::time::sleep(wall_timeout) => {
                 tracing::warn!(task_id, "delegate wall-clock timeout");
-                Err(anyhow::anyhow!("Delegate wall-clock timeout after 300s"))
+                Err(anyhow::anyhow!("Delegate wall-clock timeout after {}s", self.wall_timeout_secs))
             }
             result = async {
                 loop {
@@ -858,7 +869,7 @@ If blocked, say the blocker plainly.\n",
                         }
                         Err(_) => {
                             tracing::warn!(task_id, idle_secs = last_activity.elapsed().as_secs(), "delegate idle timeout");
-                            return Err(anyhow::anyhow!("Delegate idle timeout — no output for 120s"));
+                            return Err(anyhow::anyhow!("Delegate idle timeout — no output for {}s", self.idle_timeout_secs));
                         }
                     }
                 }
@@ -2466,6 +2477,40 @@ This agent runs in write mode and can modify files.
         assert!(err.contains("exit_code: 7"), "{err}");
         assert!(err.contains("child stderr line"), "{err}");
         assert!(err.contains("test:model"), "{err}");
+    }
+
+
+    #[tokio::test]
+    async fn delegate_runner_times_out_and_kills_silent_child() {
+        let temp_dir = TempDir::new().unwrap();
+        let child = write_fake_child(
+            temp_dir.path(),
+            "fake-child-timeout.sh",
+            "#!/bin/sh\nexec sleep 10\n",
+        );
+        let store = Arc::new(DelegateResultStore::new());
+        let runner = DelegateRunner::new(temp_dir.path().to_path_buf(), store.clone(), false)
+            .with_child_agent_binary(child)
+            .with_timeouts(1, 30);
+
+        let err = runner
+            .run_delegate_child(
+                "delegate_timeout",
+                "Do the thing",
+                &DelegateRuntimeRequest {
+                    scope: None,
+                    model: Some("test:model".into()),
+                    thinking_level: None,
+                    worker_profile: DelegateWorkerProfile::Scout,
+                },
+                None,
+                Some("test:model".into()),
+            )
+            .await
+            .unwrap_err()
+            .to_string();
+
+        assert!(err.contains("Delegate wall-clock timeout after 1s"), "{err}");
     }
 
 }

--- a/core/crates/omegon/src/features/delegate.rs
+++ b/core/crates/omegon/src/features/delegate.rs
@@ -399,6 +399,7 @@ pub struct DelegateRunner {
     cwd: PathBuf,
     result_store: Arc<DelegateResultStore>,
     sandbox: bool,
+    child_agent_binary: Option<PathBuf>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -643,7 +644,14 @@ impl DelegateRunner {
             cwd,
             result_store,
             sandbox,
+            child_agent_binary: None,
         }
+    }
+
+    #[cfg(test)]
+    fn with_child_agent_binary(mut self, child_agent_binary: PathBuf) -> Self {
+        self.child_agent_binary = Some(child_agent_binary);
+        self
     }
 
     fn spawn_sandboxed(
@@ -756,7 +764,11 @@ If blocked, say the blocker plainly.\n",
             }
         };
         let child_config = ChildAgentSpawnConfig {
-            agent_binary: std::env::current_exe()
+            agent_binary: self
+                .child_agent_binary
+                .clone()
+                .map(Ok)
+                .unwrap_or_else(std::env::current_exe)
                 .context("delegate runner could not locate current executable")?,
             model: model.clone(),
             max_turns: runtime.worker_profile.max_turns(),
@@ -2375,6 +2387,85 @@ This agent runs in write mode and can modify files.
         assert!(completed.result_summary.as_ref().unwrap().len() < "Validation passed with a long enough result summary to truncate".len());
         let failed = snapshot.children.iter().find(|c| c.task_id == "delegate_3").unwrap();
         assert_eq!(failed.status, "failed");
+    }
+
+
+    fn write_fake_child(dir: &Path, name: &str, body: &str) -> PathBuf {
+        let path = dir.join(name);
+        std::fs::write(&path, body).unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = std::fs::metadata(&path).unwrap().permissions();
+            perms.set_mode(0o755);
+            std::fs::set_permissions(&path, perms).unwrap();
+        }
+        path
+    }
+
+    #[tokio::test]
+    async fn delegate_runner_executes_injected_child_successfully() {
+        let temp_dir = TempDir::new().unwrap();
+        let child = write_fake_child(
+            temp_dir.path(),
+            "fake-child-success.sh",
+            "#!/bin/sh\necho delegate-child-ok\n",
+        );
+        let store = Arc::new(DelegateResultStore::new());
+        let runner = DelegateRunner::new(temp_dir.path().to_path_buf(), store.clone(), false)
+            .with_child_agent_binary(child);
+
+        let result = runner
+            .run_delegate_child(
+                "delegate_success",
+                "Do the thing",
+                &DelegateRuntimeRequest {
+                    scope: None,
+                    model: Some("test:model".into()),
+                    thinking_level: None,
+                    worker_profile: DelegateWorkerProfile::Scout,
+                },
+                None,
+                Some("test:model".into()),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(result, "delegate-child-ok");
+    }
+
+    #[tokio::test]
+    async fn delegate_runner_surfaces_injected_child_failure_context() {
+        let temp_dir = TempDir::new().unwrap();
+        let child = write_fake_child(
+            temp_dir.path(),
+            "fake-child-fail.sh",
+            "#!/bin/sh\necho child stderr line >&2\nexit 7\n",
+        );
+        let store = Arc::new(DelegateResultStore::new());
+        let runner = DelegateRunner::new(temp_dir.path().to_path_buf(), store.clone(), false)
+            .with_child_agent_binary(child);
+
+        let err = runner
+            .run_delegate_child(
+                "delegate_fail",
+                "Do the thing",
+                &DelegateRuntimeRequest {
+                    scope: None,
+                    model: Some("test:model".into()),
+                    thinking_level: None,
+                    worker_profile: DelegateWorkerProfile::Scout,
+                },
+                None,
+                Some("test:model".into()),
+            )
+            .await
+            .unwrap_err()
+            .to_string();
+
+        assert!(err.contains("exit_code: 7"), "{err}");
+        assert!(err.contains("child stderr line"), "{err}");
+        assert!(err.contains("test:model"), "{err}");
     }
 
 }

--- a/core/crates/omegon/src/features/delegate.rs
+++ b/core/crates/omegon/src/features/delegate.rs
@@ -2492,6 +2492,18 @@ This agent runs in write mode and can modify files.
         let runner = DelegateRunner::new(temp_dir.path().to_path_buf(), store.clone(), false)
             .with_child_agent_binary(child)
             .with_timeouts(1, 30);
+        store.store_task(DelegateTask {
+            task_id: "delegate_timeout".to_string(),
+            task_description: "Do the thing".to_string(),
+            agent_name: Some("timeout-worker".to_string()),
+            status: DelegateTaskStatus::Running,
+            result: None,
+            started_at: SystemTime::now(),
+            completed_at: None,
+            last_tool: None,
+            last_turn: None,
+            tasks: Vec::new(),
+        });
 
         let err = runner
             .run_delegate_child(
@@ -2511,6 +2523,92 @@ This agent runs in write mode and can modify files.
             .to_string();
 
         assert!(err.contains("Delegate wall-clock timeout after 1s"), "{err}");
+        store.update_task_status(
+            "delegate_timeout",
+            DelegateTaskStatus::Failed { error: err.clone() },
+            Some(err),
+        );
+        let progress = store.progress_snapshot();
+        assert!(!progress.active, "timeout should clear active delegate progress");
+        assert_eq!(progress.running, 0);
+        assert_eq!(progress.failed, 1);
+        let child = progress
+            .children
+            .iter()
+            .find(|child| child.task_id == "delegate_timeout")
+            .unwrap();
+        assert_eq!(child.status, "failed");
+        assert!(child.result_summary.as_deref().unwrap_or_default().contains("Delegate wall-clock timeout"));
+    }
+
+
+    #[tokio::test]
+    async fn delegate_runner_idle_timeout_kills_quiet_child_after_initial_activity() {
+        let temp_dir = TempDir::new().unwrap();
+        let child = write_fake_child(
+            temp_dir.path(),
+            "fake-child-idle-timeout.sh",
+            "#!/bin/sh
+echo initial activity >&2
+exec sleep 10
+",
+        );
+        let store = Arc::new(DelegateResultStore::new());
+        let runner = DelegateRunner::new(temp_dir.path().to_path_buf(), store.clone(), false)
+            .with_child_agent_binary(child)
+            .with_timeouts(30, 1);
+        store.store_task(DelegateTask {
+            task_id: "delegate_idle_timeout".to_string(),
+            task_description: "Do the quiet thing".to_string(),
+            agent_name: Some("idle-worker".to_string()),
+            status: DelegateTaskStatus::Running,
+            result: None,
+            started_at: SystemTime::now(),
+            completed_at: None,
+            last_tool: None,
+            last_turn: None,
+            tasks: Vec::new(),
+        });
+
+        let err = runner
+            .run_delegate_child(
+                "delegate_idle_timeout",
+                "Do the quiet thing",
+                &DelegateRuntimeRequest {
+                    scope: None,
+                    model: Some("test:model".into()),
+                    thinking_level: None,
+                    worker_profile: DelegateWorkerProfile::Scout,
+                },
+                None,
+                Some("test:model".into()),
+            )
+            .await
+            .unwrap_err()
+            .to_string();
+
+        assert!(err.contains("Delegate idle timeout"), "{err}");
+        assert!(err.contains("no output for 1s"), "{err}");
+        store.update_task_status(
+            "delegate_idle_timeout",
+            DelegateTaskStatus::Failed { error: err.clone() },
+            Some(err),
+        );
+        let progress = store.progress_snapshot();
+        assert!(!progress.active, "idle timeout should clear active delegate progress");
+        assert_eq!(progress.running, 0);
+        assert_eq!(progress.failed, 1);
+        let child = progress
+            .children
+            .iter()
+            .find(|child| child.task_id == "delegate_idle_timeout")
+            .unwrap();
+        assert_eq!(child.status, "failed");
+        assert!(child
+            .result_summary
+            .as_deref()
+            .unwrap_or_default()
+            .contains("Delegate idle timeout"));
     }
 
 }


### PR DESCRIPTION
## Summary

This PR tightens the cleave/delegate subagent execution lane so it can support the incoming plan/workstream/branching guide changes around code lanes and worktrees.

It adds richer status projections for subagent progress, introduces deterministic execution-eval coverage using injected child binaries, and fixes worktree/merge semantics exposed by those tests.

## What changed

### Cleave/delegate status visibility

- Adds richer cleave progress snapshot coverage:
  - child spawned/running/completed/failed state
  - task/checklist progress
  - last tool and turn activity
  - PID/supervision state
  - token accounting
  - terminal run state
- Adds richer delegate progress snapshot coverage:
  - running/completed/failed delegate state
  - last tool and turn activity
  - checklist/task progress
  - result summaries for terminal children

### Deterministic execution-eval harness

- Adds injectable child binary support for delegate workers.
- Adds real process-spawn tests for delegate:
  - successful injected child
  - failed injected child with stderr/exit code context
  - wall-clock timeout
  - idle timeout
- Adds real process-spawn tests for cleave:
  - successful injected child
  - failed injected child
  - wall-clock timeout
  - cancellation

These tests avoid live LLM/provider dependencies and give us a stable harness for subagent execution behavior.

### Worktree/merge fixes

- Fixes cleave git worktree creation by explicitly creating the child branch before adding the libgit2 worktree.
  - The prior path could fail with `branch not found: cleave/0-alpha`.
  - This aligns cleave’s implementation with the intended `git worktree add -b` behavior.
- Fixes failed-child merge reporting:
  - A failed child with no salvaged changes is now reported as skipped.
  - It is no longer reported as a successful `NoChanges` merge.

## Validation

Ran:

```text
cargo test -p omegon --bin omegon cleave -- --nocapture
cargo test -p omegon --bin omegon delegate -- --nocapture
cargo test -p omegon-git worktree
cargo check -p omegon
git diff --check
```

Latest focused validation:

```text
cleave:   155 passed
delegate: 27 passed
cargo check -p omegon: passed
```

## Risk

Medium-low.

The production behavior changes are small but touch sensitive execution paths:

- `omegon-git` worktree creation now creates the branch explicitly before creating the worktree.
- cleave merge reporting changes failed-child/no-change outcomes from `NoChanges` to `Skipped`.

The rest is primarily tests and status/read-model coverage.

## Review focus

1. Whether explicit branch creation in `omegon_git::worktree::create` is correct for all existing callers.
2. Whether failed-child/no-salvage should be `Skipped`, as this PR implements, or another terminal merge outcome.
3. Whether the status snapshot DTOs expose enough for upcoming plan/workstream/code-lane UI surfaces without leaking implementation details.

## Remaining parallel work after this PR

### Lane A — Code lane / worktree vocabulary alignment

- Audit naming: branch, worktree, workspace, scope, child, lane.
- Decide whether user-facing output should call cleave children “code lanes.”
- Define: one cleave child = one bounded execution lane with scope, model, worktree, branch, status, and merge outcome.
- Keep internal structs stable unless rename cost is low.

### Lane B — Execution eval expansion

- Add cleave dependency-wave tests.
- Add salvage tests for failed children that produced useful work.
- Add cancellation tests that verify no orphan process remains.
- Add delegate cancellation seam if needed.
- Factor shared fake-child fixtures.

### Lane C — Status surface / ACP-read model integration

- Decide canonical DTO location: feature modules for now vs `surfaces/subagents.rs`.
- Add read-only ACP surfaces later:
  - `_subagents/cleave/status`
  - `_subagents/delegate/status`
- Keep ACP read-only initially.
- Defer mutation/control until cancellation and supervision semantics are stable.

### Lane D — Lifecycle + subagent plan integration

- Map cleave child lanes to plan tasks.
- Include design/OpenSpec references in progress when available.
- Ensure lifecycle read models can show active workstream, active code lanes, pending merges, and blocked lanes.
- Keep lifecycle mutation services separate from execution orchestration.
