### PR TITLE
feat(providers): track Anthropic model drift and OAuth stall recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [Semantic V
 
 ## [Unreleased]
 
+### Changed
+
+- Add a local `just upstream-provider-check` gate for cheap provider drift checks without waiting for CI.
+- Add a lightweight Anthropic model drift checker that compares public Claude API model IDs against the registry.
+- Add Claude Fable 5 and limited-access Claude Mythos 5 to the Anthropic registry, make Fable the highest-tier Anthropic default, and update Claude Code OAuth UA to 2.1.173.
+- Derive Anthropic adaptive-thinking support from model registry metadata with a family fallback for unreleased Fable/Mythos/Sonnet/Opus model IDs.
+- Recommend Anthropic OAuth relogin on repeated stalled-stream exhaustion when the active credential source is OAuth-only.
+
 ## [0.27.0] - 2026-06-11
 
 ### Added

--- a/Justfile
+++ b/Justfile
@@ -53,6 +53,12 @@ test-dev-scripts:
 provider-context-truth *args:
     python3 scripts/provider_context_truth.py {{args}}
 
+# Check local provider drift and cheap upstream sources (no credentials required).
+upstream-provider-check:
+    python3 scripts/check_model_registry.py
+    python3 scripts/check_upstream_versions.py
+    python3 scripts/check_anthropic_models.py
+
 # Run tests only for Rust crates affected by changed paths.
 test-changed *args:
     #!/usr/bin/env bash

--- a/core/crates/omegon/src/features/model_budget.rs
+++ b/core/crates/omegon/src/features/model_budget.rs
@@ -330,10 +330,9 @@ mod tests {
 
     #[test]
     fn tier_resolve_anthropic() {
-        assert!(
-            ModelTier::Gloriana
-                .resolve_model("anthropic", "")
-                .contains("opus")
+        assert_eq!(
+            ModelTier::Gloriana.resolve_model("anthropic", ""),
+            "claude-fable-5"
         );
         assert!(
             ModelTier::Victory
@@ -375,9 +374,10 @@ mod tests {
         let budget = ModelBudget::new(settings.clone());
         let msg = budget.switch_tier(ModelTier::Gloriana, "test");
         assert!(msg.contains("gloriana"), "should mention tier: {msg}");
-        assert!(
-            settings.lock().unwrap().model.contains("opus"),
-            "should switch to opus"
+        assert_eq!(
+            settings.lock().unwrap().model,
+            "anthropic:claude-fable-5",
+            "should switch to highest-tier Anthropic model"
         );
     }
 
@@ -399,9 +399,9 @@ mod tests {
         let model = ModelTier::Victory.resolve_model("anthropic", "claude-sonnet-4-6");
         assert_eq!(model, "claude-sonnet-4-6", "should preserve exact version");
 
-        // If on a different tier, should switch to default
+        // If on a different tier, should switch to highest-tier default.
         let model = ModelTier::Gloriana.resolve_model("anthropic", "claude-sonnet-4-6");
-        assert!(model.contains("opus"), "should switch to opus: {model}");
+        assert_eq!(model, "claude-fable-5");
     }
 
     #[test]

--- a/core/crates/omegon/src/loop.rs
+++ b/core/crates/omegon/src/loop.rs
@@ -1956,7 +1956,12 @@ async fn stream_with_retry(
                 kind = kind_label,
                 "{reason}: {err_msg}"
             );
-            let advice = exhaustion_advice(transient_kind, rate_limit_exhausted, stall_exhausted);
+            let advice = exhaustion_advice(
+                &provider,
+                transient_kind,
+                rate_limit_exhausted,
+                stall_exhausted,
+            );
             let _ = events.send(AgentEvent::ProviderFailure {
                 provider: provider.clone(),
                 model: model.clone(),
@@ -2032,11 +2037,18 @@ async fn stream_with_retry(
 }
 
 fn exhaustion_advice(
+    provider: &str,
     transient_kind: Option<TransientFailureKind>,
     rate_limit_exhausted: bool,
     stall_exhausted: bool,
 ) -> &'static str {
     if stall_exhausted {
+        if provider == "anthropic"
+            && crate::providers::anthropic_credential_mode()
+                == crate::providers::AnthropicCredentialMode::OAuthOnly
+        {
+            return "Anthropic OAuth streams are repeatedly stalling. Retry /auth login anthropic to refresh the Claude session, or switch provider with /model.";
+        }
         return "The provider's stream is unresponsive. Retry later or switch provider with /model.";
     }
     if rate_limit_exhausted || matches!(transient_kind, Some(TransientFailureKind::RateLimited)) {
@@ -6514,28 +6526,53 @@ This is the right first slice."#;
     #[test]
     fn exhaustion_advice_distinguishes_provider_outage_from_rate_limit() {
         assert!(
-            exhaustion_advice(Some(TransientFailureKind::Upstream5xx), false, false)
-                .contains("provider-side outage or capacity problem")
+            exhaustion_advice(
+                "openai",
+                Some(TransientFailureKind::Upstream5xx),
+                false,
+                false
+            )
+            .contains("provider-side outage or capacity problem")
         );
         assert!(
-            exhaustion_advice(Some(TransientFailureKind::ProviderOverloaded), false, false)
-                .contains("provider-side outage or capacity problem")
+            exhaustion_advice(
+                "openai",
+                Some(TransientFailureKind::ProviderOverloaded),
+                false,
+                false
+            )
+            .contains("provider-side outage or capacity problem")
         );
         assert!(
-            exhaustion_advice(Some(TransientFailureKind::RateLimited), true, false)
-                .contains("rate-limiting the session")
+            exhaustion_advice(
+                "openai",
+                Some(TransientFailureKind::RateLimited),
+                true,
+                false
+            )
+            .contains("rate-limiting the session")
         );
     }
 
     #[test]
     fn exhaustion_advice_distinguishes_unstable_network_and_stalled_stream() {
         assert!(
-            exhaustion_advice(Some(TransientFailureKind::NetworkReset), false, false)
-                .contains("provider or network path is unstable")
+            exhaustion_advice(
+                "openai",
+                Some(TransientFailureKind::NetworkReset),
+                false,
+                false
+            )
+            .contains("provider or network path is unstable")
         );
         assert!(
-            exhaustion_advice(Some(TransientFailureKind::StalledStream), false, true)
-                .contains("stream is unresponsive")
+            exhaustion_advice(
+                "openai",
+                Some(TransientFailureKind::StalledStream),
+                false,
+                true
+            )
+            .contains("stream is unresponsive")
         );
     }
 

--- a/core/crates/omegon/src/model_registry.rs
+++ b/core/crates/omegon/src/model_registry.rs
@@ -303,7 +303,7 @@ mod tests {
         let reg = ModelRegistry::global();
         assert_eq!(reg.default_model("openai"), Some("gpt-5.5"));
         assert_eq!(reg.default_model("openai-codex"), Some("gpt-5.5"));
-        assert_eq!(reg.default_model("anthropic"), Some("claude-sonnet-4-6"));
+        assert_eq!(reg.default_model("anthropic"), Some("claude-fable-5"));
         assert_eq!(reg.default_model("nonexistent"), None);
     }
 
@@ -313,7 +313,7 @@ mod tests {
         assert_eq!(reg.tier_model("gloriana", "openai"), Some("gpt-5.5"));
         assert_eq!(
             reg.tier_model("gloriana", "anthropic"),
-            Some("claude-opus-4-6")
+            Some("claude-fable-5")
         );
         assert_eq!(
             reg.tier_model("retribution", "anthropic"),

--- a/core/crates/omegon/src/providers.rs
+++ b/core/crates/omegon/src/providers.rs
@@ -18,7 +18,7 @@ use crate::bridge::{LlmBridge, LlmEvent, LlmMessage, StreamOptions};
 /// Claude Code CLI version for OAuth user-agent header.
 /// Must match what Anthropic expects for subscription recognition.
 /// Update when upstream Claude Code advances.
-const CLAUDE_CODE_UA: &str = "claude-cli/2.1.154";
+const CLAUDE_CODE_UA: &str = "claude-cli/2.1.173";
 use omegon_traits::ToolDefinition;
 
 /// Anthropic credential mode — records what credential source is active.
@@ -70,7 +70,7 @@ pub fn anthropic_credential_mode() -> AnthropicCredentialMode {
 pub fn automation_safe_model() -> Option<String> {
     // 1. Anthropic (OAuth or API key)
     if resolve_api_key_sync("anthropic").is_some() {
-        return Some("anthropic:claude-sonnet-4-6".to_string());
+        return default_model_for_provider("anthropic");
     }
     // 2. OpenAI Codex (OAuth)
     if resolve_api_key_sync("openai-codex").is_some() {
@@ -2548,16 +2548,18 @@ fn anthropic_manual_budget_tokens(reasoning: Option<&str>) -> Option<u32> {
 }
 
 fn anthropic_supports_adaptive_thinking(model: &str) -> bool {
-    let model = model.to_ascii_lowercase();
-    // Sonnet 4.6+ and Opus 4.6+ support adaptive thinking
-    model.contains("claude-sonnet-4-6")
-        || model.contains("claude-sonnet-4-7")
-        || model.contains("claude-sonnet-4-8")
-        || model.contains("claude-sonnet-4-9")
-        || model.contains("claude-opus-4-6")
-        || model.contains("claude-opus-4-7")
-        || model.contains("claude-opus-4-8")
-        || model.contains("claude-opus-4-9")
+    let model_id = model_id_from_spec(model);
+    let qualified_id = format!("anthropic:{model_id}");
+    if let Some(info) = crate::model_registry::ModelRegistry::global().model_info(&qualified_id) {
+        return info.supports_reasoning;
+    }
+
+    let model = model_id.to_ascii_lowercase();
+    // Fallback for prerelease Anthropic families before the registry is updated.
+    model.contains("claude-sonnet-4-")
+        || model.contains("claude-opus-4-")
+        || model.contains("claude-fable-")
+        || model.contains("claude-mythos-")
 }
 
 fn anthropic_should_use_adaptive_thinking(model: &str, reasoning: &str) -> bool {
@@ -3368,6 +3370,23 @@ impl LlmBridge for AntigravityClient {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn anthropic_adaptive_thinking_uses_registry_metadata_and_family_fallback() {
+        assert!(anthropic_supports_adaptive_thinking(
+            "anthropic:claude-fable-5"
+        ));
+        assert!(anthropic_supports_adaptive_thinking("claude-mythos-5"));
+        assert!(anthropic_supports_adaptive_thinking(
+            "anthropic:claude-sonnet-4-6"
+        ));
+        assert!(anthropic_supports_adaptive_thinking("claude-opus-4-8"));
+        assert!(anthropic_supports_adaptive_thinking("claude-fable-6"));
+        assert!(anthropic_supports_adaptive_thinking("claude-sonnet-4-99"));
+        assert!(!anthropic_supports_adaptive_thinking(
+            "claude-haiku-4-5-20251001"
+        ));
+    }
 
     #[test]
     fn parse_rate_limit_snapshot_extracts_anthropic_utilization_headers() {

--- a/data/model-registry.json
+++ b/data/model-registry.json
@@ -1,6 +1,6 @@
 {
   "version": 2,
-  "lastReviewed": "2026-05-28",
+  "lastReviewed": "2026-06-11",
   "_comment_inference": [
     "Inference defaults for dynamically discovered models (Ollama Cloud, local Ollama).",
     "When a model is not in the 'models' array, these heuristics are used.",
@@ -51,12 +51,12 @@
     }
   },
   "defaults": {
-    "anthropic": "claude-sonnet-4-6",
+    "anthropic": "claude-fable-5",
     "openai": "gpt-5.5",
     "openai-codex": "gpt-5.5",
     "groq": "llama-3.3-70b-versatile",
-    "xai": "grok-3-mini-fast",
-    "mistral": "devstral-small-2505",
+    "xai": "grok-3",
+    "mistral": "mistral-small-latest",
     "cerebras": "llama-3.3-70b",
     "google": "gemini-2.5-flash",
     "google-antigravity": "gemini-2.5-flash",
@@ -69,7 +69,7 @@
   },
   "tiers": {
     "gloriana": {
-      "anthropic": "claude-opus-4-6",
+      "anthropic": "claude-fable-5",
       "openai": "gpt-5.5",
       "openai-codex": "gpt-5.5",
       "google": "gemini-3.1-pro-preview",
@@ -94,8 +94,8 @@
       "google-antigravity": "gemini-2.0-flash-lite",
       "openrouter": "anthropic/claude-haiku-4-5-20251001",
       "groq": "llama-3.3-70b-versatile",
-      "xai": "grok-3-mini-fast",
-      "mistral": "devstral-small-2505",
+      "xai": "grok-3",
+      "mistral": "mistral-small-latest",
       "cerebras": "llama-3.3-70b",
       "huggingface": "Qwen/Qwen3-32B",
       "ollama": "qwen3:32b",
@@ -104,6 +104,18 @@
     }
   },
   "routes": [
+    {
+      "provider": "anthropic",
+      "modelIdPattern": "claude-fable-*",
+      "contextCeiling": 1000000,
+      "tier": "gloriana"
+    },
+    {
+      "provider": "anthropic",
+      "modelIdPattern": "claude-mythos-*",
+      "contextCeiling": 1000000,
+      "tier": "gloriana"
+    },
     {
       "provider": "anthropic",
       "modelIdPattern": "claude-opus-*",
@@ -281,6 +293,45 @@
   ],
   "models": [
     {
+      "id": "claude-fable-5",
+      "provider": "anthropic",
+      "name": "Claude Fable 5",
+      "contextInput": 1000000,
+      "contextOutput": 131072,
+      "costTier": "premium",
+      "pricing": {
+        "input": 10.0,
+        "output": 50.0
+      },
+      "capabilities": [
+        "reasoning",
+        "coding",
+        "vision"
+      ],
+      "description": "Generally available Mythos-class model for highest-capability reasoning, coding, and long-horizon agentic work",
+      "supportsReasoning": true
+    },
+    {
+      "id": "claude-mythos-5",
+      "provider": "anthropic",
+      "name": "Claude Mythos 5",
+      "contextInput": 1000000,
+      "contextOutput": 131072,
+      "costTier": "premium",
+      "pricing": {
+        "input": 10.0,
+        "output": 50.0
+      },
+      "capabilities": [
+        "reasoning",
+        "coding",
+        "vision"
+      ],
+      "recommended": false,
+      "description": "Limited-release Mythos-class model; exposed for explicit operator selection when account access is available",
+      "supportsReasoning": true
+    },
+    {
       "id": "claude-opus-4-8",
       "provider": "anthropic",
       "name": "Claude Opus 4.8",
@@ -296,7 +347,8 @@
         "coding",
         "vision"
       ],
-      "description": "Latest frontier reasoning, coding, and vision"
+      "description": "Latest frontier reasoning, coding, and vision",
+      "supportsReasoning": true
     },
     {
       "id": "claude-opus-4-7",
@@ -315,7 +367,8 @@
         "vision"
       ],
       "recommended": false,
-      "description": "Previous Opus release retained for compatibility; not recommended for new sessions now that Opus 4.8 is available"
+      "description": "Previous Opus release retained for compatibility; not recommended for new sessions now that Opus 4.8 is available",
+      "supportsReasoning": true
     },
     {
       "id": "claude-sonnet-4-7",
@@ -333,7 +386,8 @@
         "coding",
         "vision"
       ],
-      "description": "Latest balanced performance and cost"
+      "description": "Latest balanced performance and cost",
+      "supportsReasoning": true
     },
     {
       "id": "claude-opus-4-6",
@@ -351,7 +405,8 @@
         "coding",
         "vision"
       ],
-      "description": "Frontier reasoning, coding, and vision"
+      "description": "Frontier reasoning, coding, and vision",
+      "supportsReasoning": true
     },
     {
       "id": "claude-sonnet-4-6",
@@ -369,7 +424,8 @@
         "coding",
         "vision"
       ],
-      "description": "Balanced performance and cost"
+      "description": "Balanced performance and cost",
+      "supportsReasoning": true
     },
     {
       "id": "claude-haiku-4-5-20251001",

--- a/scripts/check_anthropic_models.py
+++ b/scripts/check_anthropic_models.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Cheap Anthropic model drift check.
+
+Scrapes Anthropic's public models overview page for Claude API IDs and compares
+those IDs with data/model-registry.json. This is intentionally lightweight: it
+uses stdlib only, does not require credentials, and reports drift without trying
+to infer all pricing/capability metadata.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+import urllib.request
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+REGISTRY = REPO_ROOT / "data" / "model-registry.json"
+OVERVIEW_URL = "https://platform.claude.com/docs/en/about-claude/models/overview"
+
+MODEL_RE = re.compile(r"claude-(?:fable|mythos|opus|sonnet|haiku)-[a-z0-9-]+")
+CURRENT_SECTION_START = "Claude Fable 5 and Claude Mythos 5"
+CURRENT_SECTION_END = "Legacy models"
+
+
+def fetch_text(url: str) -> str:
+    req = urllib.request.Request(url, headers={"User-Agent": "omegon-upstream-check/1"})
+    with urllib.request.urlopen(req, timeout=30) as resp:  # noqa: S310 - fixed HTTPS URL
+        return resp.read().decode("utf-8", errors="replace")
+
+
+def registry_anthropic_ids() -> set[str]:
+    data = json.loads(REGISTRY.read_text())
+    return {m["id"] for m in data["models"] if m.get("provider") == "anthropic"}
+
+
+def current_models_section(text: str) -> str:
+    start = text.find(CURRENT_SECTION_START)
+    end = text.find(CURRENT_SECTION_END, start if start >= 0 else 0)
+    if start >= 0 and end > start:
+        return text[start:end]
+    return text
+
+
+def upstream_model_ids(text: str) -> set[str]:
+    ids = set(MODEL_RE.findall(current_models_section(text)))
+    # Drop Bedrock/Vertex decorated IDs and page slugs; keep Claude API IDs and aliases.
+    return {
+        mid
+        for mid in ids
+        if "-v1" not in mid
+        and "-and-" not in mid
+        and mid != "claude-haiku-4-5"  # documented alias; registry stores pinned ID
+        and mid != "claude-mythos-preview"  # invitation-only preview, not a GA catalog target
+        and not mid.endswith("-on")
+        and not mid.endswith("-models")
+    }
+
+
+def main() -> int:
+    try:
+        text = fetch_text(OVERVIEW_URL)
+    except Exception as exc:  # pragma: no cover - network dependent
+        print(json.dumps({"error": f"failed to fetch {OVERVIEW_URL}: {exc}"}, indent=2))
+        return 2
+
+    upstream = upstream_model_ids(text)
+    registry = registry_anthropic_ids()
+    missing = sorted(upstream - registry)
+    stale = sorted(registry - upstream)
+    output = {
+        "source": OVERVIEW_URL,
+        "upstream_count": len(upstream),
+        "registry_count": len(registry),
+        "missing_from_registry": missing,
+        "registry_only": stale,
+    }
+    print(json.dumps(output, indent=2))
+    return 1 if missing else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_model_registry.py
+++ b/scripts/check_model_registry.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Local consistency checks for data/model-registry.json.
+
+This is intentionally offline and stdlib-only. Use it after quick model catalog edits
+so drift is caught before CI or upstream probes run.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+REGISTRY_PATH = ROOT / "data" / "model-registry.json"
+PROVIDER_RS = ROOT / "core" / "crates" / "omegon" / "src" / "providers.rs"
+# Some defaults intentionally target dynamic/local/compat providers whose models
+# are not exhaustively enumerated in the static registry.
+DYNAMIC_PROVIDERS = {
+    "cerebras",
+    "google-antigravity",
+    "huggingface",
+    "ollama",
+    "openrouter",
+    "anthropic",
+    "ollama-cloud",
+    "openai",
+    "openai-codex",
+}
+
+
+def load_registry() -> dict:
+    try:
+        return json.loads(REGISTRY_PATH.read_text())
+    except Exception as exc:  # noqa: BLE001 - script prints actionable error
+        raise SystemExit(f"failed to parse {REGISTRY_PATH}: {exc}") from exc
+
+
+def provider_names_from_rust() -> set[str]:
+    text = PROVIDER_RS.read_text()
+    names = set(re.findall(r'provider_id\s*=>\s*"([a-z0-9-]+)"', text))
+    names.update(re.findall(r'"([a-z0-9-]+)"\s*=>\s*Some\(', text))
+    return names
+
+
+def main() -> int:
+    data = load_registry()
+    errors: list[str] = []
+    warnings: list[str] = []
+
+    models = data.get("models", [])
+    if not isinstance(models, list):
+        errors.append("models must be a list")
+        models = []
+
+    model_keys: set[tuple[str, str]] = set()
+    model_ids_by_provider: dict[str, set[str]] = {}
+    for idx, model in enumerate(models):
+        if not isinstance(model, dict):
+            errors.append(f"models[{idx}] must be an object")
+            continue
+        provider = model.get("provider")
+        model_id = model.get("id")
+        if not isinstance(provider, str) or not provider:
+            errors.append(f"models[{idx}] missing provider")
+            continue
+        if not isinstance(model_id, str) or not model_id:
+            errors.append(f"models[{idx}] missing id")
+            continue
+        key = (provider, model_id)
+        if key in model_keys:
+            errors.append(f"duplicate model entry: {provider}:{model_id}")
+        model_keys.add(key)
+        model_ids_by_provider.setdefault(provider, set()).add(model_id)
+
+        for field in ["contextInput", "contextOutput"]:
+            value = model.get(field)
+            if not isinstance(value, int) or value <= 0:
+                errors.append(f"{provider}:{model_id} has invalid {field}: {value!r}")
+        if model.get("supportsReasoning") and "reasoning" not in model.get("capabilities", []):
+            errors.append(
+                f"{provider}:{model_id} supportsReasoning=true but lacks reasoning capability"
+            )
+
+    defaults = data.get("defaults", {})
+    if not isinstance(defaults, dict):
+        errors.append("defaults must be an object")
+        defaults = {}
+    for provider, model_id in sorted(defaults.items()):
+        if provider not in DYNAMIC_PROVIDERS and (provider, model_id) not in model_keys:
+            errors.append(f"defaults.{provider} references unknown model {model_id}")
+
+    tiers = data.get("tiers", {})
+    if not isinstance(tiers, dict):
+        errors.append("tiers must be an object")
+        tiers = {}
+    for tier, providers in sorted(tiers.items()):
+        if not isinstance(providers, dict):
+            errors.append(f"tiers.{tier} must be an object")
+            continue
+        for provider, model_id in sorted(providers.items()):
+            if provider not in DYNAMIC_PROVIDERS and (provider, model_id) not in model_keys:
+                errors.append(f"tiers.{tier}.{provider} references unknown model {model_id}")
+
+    routes = data.get("routes", [])
+    if not isinstance(routes, list):
+        errors.append("routes must be a list")
+        routes = []
+    for idx, route in enumerate(routes):
+        if not isinstance(route, dict):
+            errors.append(f"routes[{idx}] must be an object")
+            continue
+        provider = route.get("provider")
+        pattern = route.get("modelIdPattern")
+        ceiling = route.get("contextCeiling")
+        tier = route.get("tier")
+        if not isinstance(provider, str) or not provider:
+            errors.append(f"routes[{idx}] missing provider")
+        if not isinstance(pattern, str) or not pattern:
+            errors.append(f"routes[{idx}] missing modelIdPattern")
+        if not isinstance(ceiling, int) or ceiling <= 0:
+            errors.append(f"routes[{idx}] invalid contextCeiling: {ceiling!r}")
+        if tier not in tiers:
+            errors.append(f"routes[{idx}] references unknown tier {tier!r}")
+
+    rust_providers = provider_names_from_rust() | DYNAMIC_PROVIDERS
+    registry_providers = set(model_ids_by_provider)
+    for provider in sorted(defaults):
+        if provider not in DYNAMIC_PROVIDERS and provider not in registry_providers:
+            errors.append(f"defaults.{provider} has no model entries")
+    for provider in sorted(registry_providers - rust_providers):
+        warnings.append(f"registry provider {provider!r} was not recognized in providers.rs scan")
+
+    result = {
+        "registry": str(REGISTRY_PATH.relative_to(ROOT)),
+        "models": len(model_keys),
+        "providers": sorted(registry_providers),
+        "errors": errors,
+        "warnings": warnings,
+    }
+    print(json.dumps(result, indent=2))
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- Add a cheap provider drift gate via `just upstream-provider-check`.
- Add offline registry consistency validation with `scripts/check_model_registry.py`.
- Add public Anthropic model-name drift detection with `scripts/check_anthropic_models.py`.
- Update Anthropic registry defaults for Claude Fable 5 and limited-access Mythos 5.
- Update Claude Code OAuth UA to `2.1.173`.
- Derive Anthropic adaptive-thinking support from registry metadata with future-family fallback.
- Recommend `/auth login anthropic` when Anthropic OAuth streams repeatedly stall.

## Details

### Provider drift checks

`just upstream-provider-check` now runs:

```bash
python3 scripts/check_model_registry.py
python3 scripts/check_upstream_versions.py
python3 scripts/check_anthropic_models.py
```

The local registry checker is offline/stdlib-only and catches broken manual edits before CI:

- duplicate provider/model entries,
- broken defaults and tiers,
- malformed routes,
- invalid context windows,
- inconsistent reasoning capability metadata.

The Anthropic checker fetches public docs and compares current Claude API model IDs against `data/model-registry.json`.

### Anthropic model registry

Adds/updates:

- `claude-fable-5` as the highest-tier/default Anthropic model.
- `claude-mythos-5` as limited-access and not recommended by default.
- Fable/Mythos route patterns.
- reasoning metadata for Sonnet/Opus/Fable/Mythos families.

### OAuth stall recovery

Repeated Anthropic OAuth stream stalls now produce targeted advice:

```text
/auth login anthropic
```

instead of only generic retry/switch-provider guidance.

## Validation

```text
cargo test -p omegon
2900 passed, 0 failed, 1 ignored

just upstream-provider-check
✓ check_model_registry.py: errors=[], warnings=[]
✓ check_upstream_versions.py: updates=[]
✓ check_anthropic_models.py: missing_from_registry=[]

cargo test -p omegon anthropic_adaptive_thinking_uses_registry_metadata_and_family_fallback -- --nocapture
✓

cargo test -p omegon model_registry -- --nocapture
✓

cargo test -p omegon tier_resolve_anthropic -- --nocapture
✓

cargo test -p omegon exhaustion_advice -- --nocapture
✓
```

## Notes

`check_anthropic_models.py` currently reports these registry-only entries:

```text
claude-opus-4-7
claude-sonnet-4-7
```

Those are retained compatibility entries, not failures.
