### PR TITLE
fix(hygiene): separate source cleanliness from agent state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [Semantic V
 
 - Add `just source-clean` and source-vs-agent-state dirty classification so live `.omegon/` telemetry no longer blocks source-plane cleanliness checks.
 
+### Fixed
+
+- Reject staged agent-state telemetry in source-clean checks so live audit logs cannot accidentally leak into source commits.
+
 ## [0.27.0] - 2026-06-11
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [Semantic V
 
 ## [Unreleased]
 
+### Added
+
+- Add `just source-clean` and source-vs-agent-state dirty classification so live `.omegon/` telemetry no longer blocks source-plane cleanliness checks.
+
 ## [0.27.0] - 2026-06-11
 
 ### Added

--- a/Justfile
+++ b/Justfile
@@ -23,6 +23,10 @@ bootstrap *args:
 dirty-report:
     python3 scripts/dirty_report.py
 
+# Gate on source-plane cleanliness while allowing live agent telemetry/state.
+source-clean:
+    python3 scripts/dirty_report.py --source-clean
+
 # ─── Rust ────────────────────────────────────────────
 
 # Run all Rust tests
@@ -47,7 +51,7 @@ test-profile *args:
 
 # Run Python unit tests for developer tooling scripts.
 test-dev-scripts:
-    python3 -m unittest scripts/test_affected_crates.py scripts/test_test_profile.py
+    python3 -m unittest scripts/test_affected_crates.py scripts/test_test_profile.py scripts/test_dirty_report.py
 
 # Check provider-published model context docs against the local registry.
 provider-context-truth *args:

--- a/Justfile
+++ b/Justfile
@@ -51,7 +51,7 @@ test-profile *args:
 
 # Run Python unit tests for developer tooling scripts.
 test-dev-scripts:
-    python3 -m unittest scripts/test_affected_crates.py scripts/test_test_profile.py scripts/test_dirty_report.py
+    python3 -m unittest scripts/test_affected_crates.py scripts/test_test_profile.py scripts/test_dirty_report.py scripts/test_dirty_report_git.py
 
 # Check provider-published model context docs against the local registry.
 provider-context-truth *args:

--- a/core/crates/omegon/src/cleave/context.rs
+++ b/core/crates/omegon/src/cleave/context.rs
@@ -451,16 +451,16 @@ fn build_finalization_section(submodules: &[String]) -> String {
 
     section.push_str("You MUST complete these steps before finishing:\n\n");
     section.push_str("1. Run all guardrail checks listed above and fix failures\n");
-    section.push_str("2. Commit your in-scope work with a clean git state when you are done\n");
+    section.push_str("2. Commit your in-scope work with a clean source-plane state when you are done\n");
 
     if !submodules.is_empty() {
         section.push_str("3. **Submodule note**: if your scope crosses a submodule boundary, commit your edits normally. The orchestrator will handle submodule pointer updates during harvest/merge.\n");
-        section.push_str("4. Verify clean state for the files you changed: `git status` should show nothing left to commit in your worktree\n");
+        section.push_str("4. Verify source-plane clean state for the files you changed: `just source-clean` should pass. Live `.omegon/` agent telemetry may still be dirty while agents are active.\n");
     } else {
         section.push_str(
             "3. Commit with a clear message: `git commit -m \"feat(<label>): <summary>\"`\n",
         );
-        section.push_str("4. Verify clean state: `git status` should show nothing to commit\n");
+        section.push_str("4. Verify source-plane clean state: `just source-clean` should pass. Live `.omegon/` agent telemetry may still be dirty while agents are active.\n");
     }
 
     section.push_str("\nDo NOT edit `.cleave-prompt.md` or any task/result metadata files. Those are orchestrator-owned and may be ignored by git.\n");

--- a/scripts/dirty_report.py
+++ b/scripts/dirty_report.py
@@ -1,12 +1,40 @@
 #!/usr/bin/env python3
-"""Classify git working-tree dirt for safer scoped commits."""
+"""Classify git working-tree dirt for safer scoped commits.
+
+Omegon-operated worktrees have two dirty planes:
+
+* source plane: code, docs, specs, release memory, configs, tooling
+* agent-state plane: live `.omegon/` coordination and telemetry
+
+Raw `git status` is still useful, but it is the wrong release/PR gate once
+multiple agents append and consolidate audit logs. Use `--source-clean` when a
+workflow needs to know whether source-plane files are dirty while live agent
+state may legitimately be changing.
+"""
 
 from __future__ import annotations
 
+import argparse
+import json
 import subprocess
 import sys
 from collections import defaultdict
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
+
+SOURCE_CATEGORIES = {
+    "cargo",
+    "design",
+    "lifecycle",
+    "lifecycle-state",
+    "other",
+    "release-memory",
+    "rust-source",
+    "site",
+    "skills",
+    "spec",
+    "tooling",
+}
+AGENT_STATE_CATEGORIES = {"agent-state"}
 
 
 @dataclass(frozen=True)
@@ -14,6 +42,7 @@ class Entry:
     status: str
     path: str
     category: str
+    plane: str
     note: str
 
 
@@ -28,33 +57,71 @@ def run_git(args: list[str]) -> str:
     return result.stdout
 
 
-def classify(path: str) -> tuple[str, str]:
+def is_agent_state_path(path: str) -> bool:
+    """Return true for live Omegon coordination/telemetry paths.
+
+    Keep this repo-local and explicit. Arbitrary JSONL elsewhere is source dirt.
+    """
+    if path == ".omegon/audit-log.jsonl":
+        return True
+    if path == ".omegon/ipc.sock":
+        return True
+    if path.startswith(".omegon/runtime/"):
+        return True
+    if path.startswith(".omegon/leases/"):
+        return True
+    if path.startswith(".omegon/workspace/"):
+        return True
+    if path.startswith(".omegon/tmp/"):
+        return True
+    if path.startswith(".omegon/") and (
+        path.endswith(".db")
+        or path.endswith(".db-wal")
+        or path.endswith(".db-shm")
+        or path.endswith(".sock")
+    ):
+        return True
+    return False
+
+
+def classify(path: str) -> tuple[str, str, str]:
+    if is_agent_state_path(path):
+        return (
+            "agent-state",
+            "agent-state",
+            "live Omegon coordination/telemetry; may change while agents are active",
+        )
     if path == "ai/lifecycle/state.json":
         return (
             "lifecycle-state",
+            "source",
             "tracked lifecycle/runtime state; commit separately only when intentional",
         )
     if path.startswith("ai/lifecycle/"):
-        return "lifecycle", "lifecycle artifact; avoid mixing with source commits"
+        return "lifecycle", "source", "lifecycle artifact; avoid mixing with source commits"
     if path.startswith("openspec/"):
-        return "spec", "OpenSpec artifact; should usually pair with planned implementation"
+        return "spec", "source", "OpenSpec artifact; should usually pair with planned implementation"
     if path.startswith("docs/design/") or path.startswith("ai/design/"):
-        return "design", "design artifact; avoid accidental runtime churn"
+        return "design", "source", "design artifact; avoid accidental runtime churn"
     if path == "CHANGELOG.md":
-        return "release-memory", "required for behavior/operator-workflow changes"
+        return "release-memory", "source", "required for behavior/operator-workflow changes"
     if path.endswith(".rs") and path.startswith("core/crates/"):
-        return "rust-source", "Rust source; check for unrelated rustfmt drift"
+        return "rust-source", "source", "Rust source; check for unrelated rustfmt drift"
     if path == "Cargo.lock" or path.endswith("Cargo.toml"):
-        return "cargo", "Cargo manifest/lockfile"
+        return "cargo", "source", "Cargo manifest/lockfile"
     if path.startswith("scripts/") or path in {"Justfile", "justfile"}:
-        return "tooling", "developer/release tooling"
+        return "tooling", "source", "developer/release tooling"
     if path.startswith("skills/"):
-        return "skills", "operator skill content"
+        return "skills", "source", "operator skill content"
     if path.startswith("site/"):
-        return "site", "generated or authored site content"
+        return "site", "source", "generated or authored site content"
     if path.startswith(".omegon/"):
-        return "omegon-local", "repo-local agent state; normally should be ignored or separate"
-    return "other", "inspect manually"
+        return (
+            "omegon-local",
+            "source",
+            "repo-local Omegon artifact not classified as live agent state; inspect before committing",
+        )
+    return "other", "source", "inspect manually"
 
 
 def parse_status() -> list[Entry]:
@@ -77,8 +144,8 @@ def parse_status() -> list[Entry]:
                 source = parts[i]
                 i += 1
                 path = f"{source} -> {path}"
-        category, note = classify(path.split(" -> ")[-1])
-        entries.append(Entry(status=status, path=path, category=category, note=note))
+        category, plane, note = classify(path.split(" -> ")[-1])
+        entries.append(Entry(status=status, path=path, category=category, plane=plane, note=note))
     return entries
 
 
@@ -86,27 +153,48 @@ def staged_categories(entries: list[Entry]) -> set[str]:
     return {entry.category for entry in entries if entry.status[0] != " " and entry.status[0] != "?"}
 
 
-def main() -> int:
-    try:
-        entries = parse_status()
-    except subprocess.CalledProcessError as exc:
-        sys.stderr.write(exc.stderr)
-        return exc.returncode
+def source_entries(entries: list[Entry]) -> list[Entry]:
+    return [entry for entry in entries if entry.plane == "source"]
 
+
+def agent_state_entries(entries: list[Entry]) -> list[Entry]:
+    return [entry for entry in entries if entry.plane == "agent-state"]
+
+
+def build_report(entries: list[Entry]) -> dict[str, object]:
+    sources = source_entries(entries)
+    agent_state = agent_state_entries(entries)
+    return {
+        "clean": not entries,
+        "source_clean": not sources,
+        "agent_state_dirty": bool(agent_state),
+        "source_count": len(sources),
+        "agent_state_count": len(agent_state),
+        "entries": [asdict(entry) for entry in entries],
+    }
+
+
+def print_human_report(entries: list[Entry]) -> None:
     if not entries:
         print("Working tree clean.")
-        return 0
+        return
+
+    sources = source_entries(entries)
+    agent_state = agent_state_entries(entries)
+    if not sources and agent_state:
+        print("Source tree clean; agent state dirty:\n")
+    else:
+        print("Dirty tree classification:\n")
 
     grouped: dict[str, list[Entry]] = defaultdict(list)
     for entry in entries:
         grouped[entry.category].append(entry)
 
-    print("Dirty tree classification:\n")
     for category in sorted(grouped):
         print(f"{category}:")
         for entry in grouped[category]:
             print(f"  {entry.status} {entry.path}")
-            print(f"     {entry.note}")
+            print(f"     plane={entry.plane}; {entry.note}")
         print()
 
     cats = {entry.category for entry in entries}
@@ -124,6 +212,8 @@ def main() -> int:
         warnings.append("for Rust source dirt, check whether unrelated files are rustfmt-only drift.")
     if "release-memory" not in cats and ({"rust-source", "tooling", "cargo"} & cats):
         warnings.append("behavior/tooling changes may require CHANGELOG.md under [Unreleased].")
+    if agent_state and sources:
+        warnings.append("agent-state is dirty alongside source; use explicit-path commits.")
 
     if warnings:
         print("Warnings:")
@@ -133,8 +223,43 @@ def main() -> int:
 
     print("Suggested hygiene:")
     print("  - Start/end implementation slices with `just dirty-report`.")
+    print("  - Use `just source-clean` for PR/release gates while agents are active.")
     print("  - Use explicit-path commits; avoid `git add .` for mixed worktrees.")
     print("  - Keep lifecycle-state changes in separate commits unless the task is lifecycle metadata.")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--json", action="store_true", help="emit machine-readable classification")
+    parser.add_argument(
+        "--source-clean",
+        action="store_true",
+        help="exit non-zero only when source-plane files are dirty",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        entries = parse_status()
+    except subprocess.CalledProcessError as exc:
+        sys.stderr.write(exc.stderr)
+        return exc.returncode
+
+    report = build_report(entries)
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    elif args.source_clean:
+        if report["source_clean"]:
+            if report["agent_state_dirty"]:
+                print("Source tree clean; agent state dirty.")
+            else:
+                print("Source tree clean.")
+        else:
+            print_human_report(entries)
+    else:
+        print_human_report(entries)
+
+    if args.source_clean and not report["source_clean"]:
+        return 1
     return 0
 
 

--- a/scripts/dirty_report.py
+++ b/scripts/dirty_report.py
@@ -45,6 +45,10 @@ class Entry:
     plane: str
     note: str
 
+    @property
+    def staged(self) -> bool:
+        return self.status[0] not in {" ", "?"}
+
 
 def run_git(args: list[str]) -> str:
     result = subprocess.run(
@@ -168,6 +172,7 @@ def build_report(entries: list[Entry]) -> dict[str, object]:
         "clean": not entries,
         "source_clean": not sources,
         "agent_state_dirty": bool(agent_state),
+        "staged_agent_state_count": sum(1 for entry in agent_state if entry.staged),
         "source_count": len(sources),
         "agent_state_count": len(agent_state),
         "entries": [asdict(entry) for entry in entries],
@@ -212,6 +217,12 @@ def print_human_report(entries: list[Entry]) -> None:
         warnings.append("for Rust source dirt, check whether unrelated files are rustfmt-only drift.")
     if "release-memory" not in cats and ({"rust-source", "tooling", "cargo"} & cats):
         warnings.append("behavior/tooling changes may require CHANGELOG.md under [Unreleased].")
+    staged_agent_state = [entry for entry in agent_state if entry.staged]
+    if staged_agent_state:
+        warnings.append(
+            "agent-state is staged; unstage it before source commits: "
+            + ", ".join(entry.path for entry in staged_agent_state)
+        )
     if agent_state and sources:
         warnings.append("agent-state is dirty alongside source; use explicit-path commits.")
 
@@ -248,7 +259,7 @@ def main(argv: list[str] | None = None) -> int:
     if args.json:
         print(json.dumps(report, indent=2, sort_keys=True))
     elif args.source_clean:
-        if report["source_clean"]:
+        if report["source_clean"] and report["staged_agent_state_count"] == 0:
             if report["agent_state_dirty"]:
                 print("Source tree clean; agent state dirty.")
             else:
@@ -258,7 +269,7 @@ def main(argv: list[str] | None = None) -> int:
     else:
         print_human_report(entries)
 
-    if args.source_clean and not report["source_clean"]:
+    if args.source_clean and (not report["source_clean"] or report["staged_agent_state_count"]):
         return 1
     return 0
 

--- a/scripts/test_dirty_report.py
+++ b/scripts/test_dirty_report.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Unit tests for dirty_report.py."""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from scripts import dirty_report as dr  # noqa: E402
+
+
+class DirtyReportTests(unittest.TestCase):
+    def test_audit_log_is_agent_state_not_source(self) -> None:
+        category, plane, _ = dr.classify(".omegon/audit-log.jsonl")
+        self.assertEqual(category, "agent-state")
+        self.assertEqual(plane, "agent-state")
+
+    def test_runtime_sqlite_files_are_agent_state(self) -> None:
+        for path in [
+            ".omegon/codescan.db",
+            ".omegon/codescan.db-wal",
+            ".omegon/codescan.db-shm",
+            ".omegon/ipc.sock",
+            ".omegon/runtime/session.json",
+        ]:
+            with self.subTest(path=path):
+                category, plane, _ = dr.classify(path)
+                self.assertEqual(category, "agent-state")
+                self.assertEqual(plane, "agent-state")
+
+    def test_unclassified_omegon_jsonl_is_source_until_decided(self) -> None:
+        category, plane, _ = dr.classify(".omegon/evidence/records.jsonl")
+        self.assertEqual(category, "omegon-local")
+        self.assertEqual(plane, "source")
+
+    def test_arbitrary_jsonl_is_not_agent_state(self) -> None:
+        category, plane, _ = dr.classify("notes/foo.jsonl")
+        self.assertEqual(category, "other")
+        self.assertEqual(plane, "source")
+
+    def test_source_clean_ignores_only_agent_state_entries(self) -> None:
+        entries = [
+            dr.Entry(
+                status=" M",
+                path=".omegon/audit-log.jsonl",
+                category="agent-state",
+                plane="agent-state",
+                note="live",
+            )
+        ]
+        report = dr.build_report(entries)
+        self.assertTrue(report["source_clean"])
+        self.assertTrue(report["agent_state_dirty"])
+
+    def test_source_clean_fails_for_source_entries(self) -> None:
+        entries = [
+            dr.Entry(
+                status=" M",
+                path="core/crates/omegon/src/lib.rs",
+                category="rust-source",
+                plane="source",
+                note="source",
+            ),
+            dr.Entry(
+                status=" M",
+                path=".omegon/audit-log.jsonl",
+                category="agent-state",
+                plane="agent-state",
+                note="live",
+            ),
+        ]
+        report = dr.build_report(entries)
+        self.assertFalse(report["source_clean"])
+        self.assertTrue(report["agent_state_dirty"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_dirty_report.py
+++ b/scripts/test_dirty_report.py
@@ -76,6 +76,20 @@ class DirtyReportTests(unittest.TestCase):
         self.assertFalse(report["source_clean"])
         self.assertTrue(report["agent_state_dirty"])
 
+    def test_source_clean_fails_for_staged_agent_state(self) -> None:
+        entries = [
+            dr.Entry(
+                status="M ",
+                path=".omegon/audit-log.jsonl",
+                category="agent-state",
+                plane="agent-state",
+                note="live",
+            )
+        ]
+        report = dr.build_report(entries)
+        self.assertTrue(report["source_clean"])
+        self.assertEqual(report["staged_agent_state_count"], 1)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/test_dirty_report_git.py
+++ b/scripts/test_dirty_report_git.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Black-box tests for dirty_report.py git porcelain behavior."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "dirty_report.py"
+
+
+def run(cwd: Path, args: list[str], *, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(args, cwd=cwd, check=check, text=True, capture_output=True)
+
+
+class DirtyReportGitTests(unittest.TestCase):
+    def init_repo(self) -> Path:
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        repo = Path(tmp.name)
+        run(repo, ["git", "init"])
+        run(repo, ["git", "config", "user.email", "test@example.invalid"])
+        run(repo, ["git", "config", "user.name", "Dirty Report Test"])
+        (repo / ".gitignore").write_text("*.pyc\n")
+        run(repo, ["git", "add", ".gitignore"])
+        run(repo, ["git", "commit", "-m", "init"])
+        return repo
+
+    def source_clean(self, repo: Path) -> subprocess.CompletedProcess[str]:
+        return run(repo, [sys.executable, str(SCRIPT), "--source-clean"], check=False)
+
+    def test_unstaged_tracked_audit_log_passes_source_clean(self) -> None:
+        repo = self.init_repo()
+        audit = repo / ".omegon" / "audit-log.jsonl"
+        audit.parent.mkdir()
+        audit.write_text('{"event":"initial"}\n')
+        run(repo, ["git", "add", str(audit.relative_to(repo))])
+        run(repo, ["git", "commit", "-m", "track audit"])
+
+        audit.write_text('{"event":"initial"}\n{"event":"live"}\n')
+        result = self.source_clean(repo)
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("Source tree clean; agent state dirty", result.stdout)
+
+    def test_staged_tracked_audit_log_fails_source_clean(self) -> None:
+        repo = self.init_repo()
+        audit = repo / ".omegon" / "audit-log.jsonl"
+        audit.parent.mkdir()
+        audit.write_text('{"event":"initial"}\n')
+        run(repo, ["git", "add", str(audit.relative_to(repo))])
+        run(repo, ["git", "commit", "-m", "track audit"])
+
+        audit.write_text('{"event":"initial"}\n{"event":"live"}\n')
+        run(repo, ["git", "add", str(audit.relative_to(repo))])
+        result = self.source_clean(repo)
+
+        self.assertNotEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("agent-state is staged", result.stdout)
+
+    def test_dirty_source_file_fails_source_clean(self) -> None:
+        repo = self.init_repo()
+        src = repo / "core" / "crates" / "omegon" / "src" / "lib.rs"
+        src.parent.mkdir(parents=True)
+        src.write_text("pub fn demo() {}\n")
+        run(repo, ["git", "add", str(src.relative_to(repo))])
+        run(repo, ["git", "commit", "-m", "track source"])
+
+        src.write_text("pub fn demo() -> u8 { 1 }\n")
+        result = self.source_clean(repo)
+
+        self.assertNotEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("rust-source", result.stdout)
+
+    def test_untracked_ignored_audit_log_does_not_block(self) -> None:
+        repo = self.init_repo()
+        (repo / ".gitignore").write_text("*.pyc\n.omegon/audit-log.jsonl\n")
+        run(repo, ["git", "add", ".gitignore"])
+        run(repo, ["git", "commit", "-m", "ignore audit"])
+        audit = repo / ".omegon" / "audit-log.jsonl"
+        audit.parent.mkdir()
+        audit.write_text('{"event":"live"}\n')
+
+        result = self.source_clean(repo)
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("Source tree clean", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add `just source-clean` as the source-plane cleanliness gate
- classify live `.omegon/` telemetry/runtime files as agent-state instead of source dirt
- reject staged agent-state so audit logs cannot leak into source commits
- update cleave finalization guidance to use source-plane cleanliness instead of raw `git status`

## Validation

- `just test-dev-scripts`
- `cargo test -p omegon cleave::context -- --nocapture`
- `just source-clean`
