### PR TITLE
fix(tui): pin slim plan below composer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [Semantic V
 
 ## [Unreleased]
 
+### Fixed
+
+- Pin the slim plan panel below the composer and above the engine status bar, with a compact height cap so large plans do not crowd typed input.
+
 ## [0.27.0] - 2026-06-11
 
 ### Added

--- a/core/crates/omegon/src/tui/layout_projection.rs
+++ b/core/crates/omegon/src/tui/layout_projection.rs
@@ -101,9 +101,7 @@ pub fn plan_tui_layout(inputs: TuiLayoutInputs) -> TuiLayoutPlan {
         segment_detail_height = bottom_budget;
     }
     if active_tool_stream_height.saturating_add(slim_plan_height) > bottom_budget {
-        let plan_budget =
-            bottom_budget.saturating_sub(active_tool_stream_height.min(bottom_budget));
-        slim_plan_height = slim_plan_height.min(plan_budget);
+        slim_plan_height = slim_plan_height.min(bottom_budget);
         let stream_budget = bottom_budget.saturating_sub(slim_plan_height);
         active_tool_stream_height = active_tool_stream_height.min(stream_budget);
     }
@@ -114,10 +112,10 @@ pub fn plan_tui_layout(inputs: TuiLayoutInputs) -> TuiLayoutPlan {
             Constraint::Min(3),
             Constraint::Length(active_tool_stream_height),
             Constraint::Length(permission_lane_height),
-            Constraint::Length(slim_plan_height),
             Constraint::Length(segment_detail_height),
             Constraint::Length(inputs.editor_height),
             Constraint::Length(inputs.editor_info_height),
+            Constraint::Length(slim_plan_height),
             Constraint::Length(status_height),
             Constraint::Length(project_dashboard_height(inputs, show_dashboard)),
             Constraint::Length(footer_height),
@@ -132,10 +130,10 @@ pub fn plan_tui_layout(inputs: TuiLayoutInputs) -> TuiLayoutPlan {
         conversation_area: chunks[0],
         active_tool_stream_area: chunks[1],
         permission_lane_area: chunks[2],
-        slim_plan_area: chunks[3],
-        segment_detail_area: chunks[4],
-        editor_area: chunks[5],
-        editor_info_area: chunks[6],
+        segment_detail_area: chunks[3],
+        editor_area: chunks[4],
+        editor_info_area: chunks[5],
+        slim_plan_area: chunks[6],
         status_area: chunks[7],
         footer_area: chunks[9],
         footer_height,
@@ -240,5 +238,54 @@ mod tests {
         assert_eq!(plan.segment_detail_height, 8);
         assert_eq!(plan.segment_detail_area.height, 8);
         assert!(plan.conversation_area.height >= 3);
+    }
+
+    #[test]
+    fn slim_plan_is_pinned_between_editor_and_status_bar() {
+        let plan = plan_tui_layout(TuiLayoutInputs {
+            area: Rect::new(0, 0, 120, 40),
+            surfaces: UiSurfaces::lean(),
+            focus_mode: false,
+            dashboard_has_content: false,
+            editor_height: 4,
+            editor_info_height: 1,
+            footer_instruments_height: 4,
+            pending_permission: false,
+            active_tool_stream_height: 5,
+            slim_plan_height: 5,
+            segment_detail_height: 4,
+        });
+
+        assert_eq!(plan.slim_plan_height, 5);
+        assert!(plan.active_tool_stream_area.y < plan.segment_detail_area.y);
+        assert!(plan.segment_detail_area.y < plan.editor_area.y);
+        assert!(plan.editor_area.y < plan.editor_info_area.y);
+        assert!(plan.editor_info_area.y < plan.slim_plan_area.y);
+        assert!(plan.slim_plan_area.y < plan.status_area.y);
+    }
+
+    #[test]
+    fn slim_layout_preserves_editor_and_status_under_auxiliary_pressure() {
+        let plan = plan_tui_layout(TuiLayoutInputs {
+            area: Rect::new(0, 0, 120, 18),
+            surfaces: UiSurfaces::lean(),
+            focus_mode: false,
+            dashboard_has_content: false,
+            editor_height: 4,
+            editor_info_height: 1,
+            footer_instruments_height: 4,
+            pending_permission: false,
+            active_tool_stream_height: 12,
+            slim_plan_height: 5,
+            segment_detail_height: 4,
+        });
+
+        assert!(plan.conversation_area.height >= 3);
+        assert_eq!(plan.editor_area.height, 4);
+        assert_eq!(plan.editor_info_area.height, 1);
+        assert_eq!(plan.status_area.height, 1);
+        assert!(plan.segment_detail_area.y < plan.editor_area.y);
+        assert!(plan.editor_info_area.y < plan.slim_plan_area.y);
+        assert!(plan.slim_plan_area.y < plan.status_area.y);
     }
 }

--- a/core/crates/omegon/src/tui/slim_plan.rs
+++ b/core/crates/omegon/src/tui/slim_plan.rs
@@ -12,8 +12,9 @@ pub fn slim_plan_snapshot_height(snapshot: &PlanDisplaySnapshot, width: u16) -> 
         return 0;
     }
     let item_count = snapshot.items.len() as u16;
-    // Rule/header + compact task rows, capped so the plan never crowds out the transcript.
-    (1 + item_count.min(6)).clamp(2, 8)
+    // Rule/header + compact task rows. Keep the pinned plan compact so it stays
+    // adjacent to the composer without crowding the bottom interaction band.
+    (1 + item_count.min(4)).clamp(2, 5)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]


### PR DESCRIPTION
## Summary

- move the slim plan panel below the composer/editor info and above the engine status bar
- keep the pinned plan compact with a 5-row cap so large plans do not crowd typed input
- prioritize the pinned plan over transient active-tool stream height under tight terminal pressure

## Validation

- `cargo test -p omegon layout_projection -- --nocapture`
- `cargo test -p omegon slim_plan -- --nocapture`
- `git diff --check`
