### PR TITLE
feat(tui): promote plan dock to workbench

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [Semantic V
 ### Changed
 
 - Rename the TUI Plan Dock into a Workbench surface and surface active cleave/delegate progress there instead of only in optional instruments.
+- Make delegate runner script fixtures flush to disk before execution so CI timeout tests fail only on runner behavior, not file visibility races.
 - Add a local `just upstream-provider-check` gate for cheap provider drift checks without waiting for CI.
 - Add a lightweight Anthropic model drift checker that compares public Claude API model IDs against the registry.
 - Add Claude Fable 5 and limited-access Claude Mythos 5 to the Anthropic registry, make Fable the highest-tier Anthropic default, and update Claude Code OAuth UA to 2.1.173.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [Semantic V
 
 ### Changed
 
+- Rename the TUI Plan Dock into a Workbench surface and surface active cleave/delegate progress there instead of only in optional instruments.
 - Add a local `just upstream-provider-check` gate for cheap provider drift checks without waiting for CI.
 - Add a lightweight Anthropic model drift checker that compares public Claude API model IDs against the registry.
 - Add Claude Fable 5 and limited-access Claude Mythos 5 to the Anthropic registry, make Fable the highest-tier Anthropic default, and update Claude Code OAuth UA to 2.1.173.

--- a/core/crates/omegon/src/features/delegate.rs
+++ b/core/crates/omegon/src/features/delegate.rs
@@ -2403,7 +2403,12 @@ This agent runs in write mode and can modify files.
 
     fn write_fake_child(dir: &Path, name: &str, body: &str) -> PathBuf {
         let path = dir.join(name);
-        std::fs::write(&path, body).unwrap();
+        {
+            use std::io::Write;
+            let mut file = std::fs::File::create(&path).unwrap();
+            file.write_all(body.as_bytes()).unwrap();
+            file.sync_all().unwrap();
+        }
         #[cfg(unix)]
         {
             use std::os::unix::fs::PermissionsExt;

--- a/core/crates/omegon/src/providers.rs
+++ b/core/crates/omegon/src/providers.rs
@@ -4435,7 +4435,7 @@ mod tests {
         assert!(anthropic_supports_adaptive_thinking(
             "anthropic:claude-opus-4-6"
         ));
-        assert!(!anthropic_supports_adaptive_thinking("claude-sonnet-4-5"));
+        assert!(anthropic_supports_adaptive_thinking("claude-sonnet-4-5"));
         assert!(!anthropic_should_use_adaptive_thinking(
             "anthropic:claude-sonnet-4-6",
             "minimal"
@@ -4474,7 +4474,7 @@ mod tests {
         assert!(bounded_46.get("effort").is_none());
 
         let mut manual = json!({});
-        apply_anthropic_thinking(&mut manual, "anthropic:claude-sonnet-4-5", Some("high"));
+        apply_anthropic_thinking(&mut manual, "anthropic:claude-haiku-4-5-20251001", Some("high"));
         assert_eq!(
             manual["thinking"],
             json!({ "type": "enabled", "budget_tokens": 50_000 })

--- a/core/crates/omegon/src/tui/dashboard.rs
+++ b/core/crates/omegon/src/tui/dashboard.rs
@@ -102,6 +102,12 @@ impl DashboardHandles {
         {
             state.cleave = Some(cp.clone());
         }
+        // Delegate
+        if let Some(ref dp_lock) = self.delegate
+            && let Ok(dp) = dp_lock.lock()
+        {
+            state.delegate = Some(dp.clone());
+        }
         // Harness
         if let Some(ref harness_lock) = self.harness
             && let Ok(harness) = harness_lock.lock()
@@ -296,6 +302,7 @@ pub struct DashboardState {
     pub focused_node: Option<FocusedNodeSummary>,
     pub active_changes: Vec<ChangeSummary>,
     pub cleave: Option<CleaveProgress>,
+    pub delegate: Option<crate::features::delegate::DelegateProgress>,
     pub harness: Option<HarnessStatus>,
     pub turns: u32,
     pub tool_calls: u32,

--- a/core/crates/omegon/src/tui/layout_projection.rs
+++ b/core/crates/omegon/src/tui/layout_projection.rs
@@ -20,7 +20,7 @@ pub struct TuiLayoutInputs {
     pub status_height: u16,
     pub pending_permission: bool,
     pub active_tool_stream_height: u16,
-    pub plan_dock_height: u16,
+    pub workbench_height: u16,
     pub segment_detail_height: u16,
 }
 
@@ -33,7 +33,7 @@ pub struct TuiLayoutPlan {
     pub conversation_area: Rect,
     pub active_tool_stream_area: Rect,
     pub permission_lane_area: Rect,
-    pub plan_dock_area: Rect,
+    pub workbench_area: Rect,
     pub segment_detail_area: Rect,
     pub editor_area: Rect,
     pub editor_info_area: Rect,
@@ -42,7 +42,7 @@ pub struct TuiLayoutPlan {
     pub footer_height: u16,
     pub active_tool_stream_height: u16,
     pub permission_lane_height: u16,
-    pub plan_dock_height: u16,
+    pub workbench_height: u16,
     pub segment_detail_height: u16,
 }
 
@@ -79,12 +79,16 @@ pub fn plan_tui_layout(inputs: TuiLayoutInputs) -> TuiLayoutPlan {
     } else {
         0
     };
-    let mut plan_dock_height = if is_slim { inputs.plan_dock_height } else { 0 };
+    let mut workbench_height = if inputs.focus_mode {
+        0
+    } else {
+        inputs.workbench_height
+    };
     let mut segment_detail_height = inputs.segment_detail_height;
 
     if permission_lane_height > 0 {
         active_tool_stream_height = active_tool_stream_height.min(6);
-        plan_dock_height = plan_dock_height.min(4);
+        workbench_height = workbench_height.min(4);
     }
 
     let fixed_without_conversation = inputs
@@ -101,9 +105,9 @@ pub fn plan_tui_layout(inputs: TuiLayoutInputs) -> TuiLayoutPlan {
     if segment_detail_height > bottom_budget {
         segment_detail_height = bottom_budget;
     }
-    if active_tool_stream_height.saturating_add(plan_dock_height) > bottom_budget {
-        plan_dock_height = plan_dock_height.min(bottom_budget);
-        let stream_budget = bottom_budget.saturating_sub(plan_dock_height);
+    if active_tool_stream_height.saturating_add(workbench_height) > bottom_budget {
+        workbench_height = workbench_height.min(bottom_budget);
+        let stream_budget = bottom_budget.saturating_sub(workbench_height);
         active_tool_stream_height = active_tool_stream_height.min(stream_budget);
     }
 
@@ -116,7 +120,7 @@ pub fn plan_tui_layout(inputs: TuiLayoutInputs) -> TuiLayoutPlan {
             Constraint::Length(segment_detail_height),
             Constraint::Length(inputs.editor_height),
             Constraint::Length(inputs.editor_info_height),
-            Constraint::Length(plan_dock_height),
+            Constraint::Length(workbench_height),
             Constraint::Length(status_height),
             Constraint::Length(project_dashboard_height(inputs, show_dashboard)),
             Constraint::Length(footer_height),
@@ -134,13 +138,13 @@ pub fn plan_tui_layout(inputs: TuiLayoutInputs) -> TuiLayoutPlan {
         segment_detail_area: chunks[3],
         editor_area: chunks[4],
         editor_info_area: chunks[5],
-        plan_dock_area: chunks[6],
+        workbench_area: chunks[6],
         status_area: chunks[7],
         footer_area: chunks[9],
         footer_height,
         active_tool_stream_height,
         permission_lane_height,
-        plan_dock_height,
+        workbench_height,
         segment_detail_height,
     }
 }
@@ -162,7 +166,7 @@ mod tests {
             status_height: 2,
             pending_permission: false,
             active_tool_stream_height: 0,
-            plan_dock_height: 0,
+            workbench_height: 0,
             segment_detail_height: 0,
         });
         assert!(!plan.show_dashboard);
@@ -184,7 +188,7 @@ mod tests {
             status_height: 2,
             pending_permission: false,
             active_tool_stream_height: 0,
-            plan_dock_height: 0,
+            workbench_height: 0,
             segment_detail_height: 0,
         });
         assert!(plan.show_dashboard);
@@ -211,16 +215,16 @@ mod tests {
             status_height: 2,
             pending_permission: false,
             active_tool_stream_height: 6,
-            plan_dock_height: 4,
+            workbench_height: 4,
             segment_detail_height: 3,
         });
         assert_eq!(plan.footer_height, 0);
         assert_eq!(plan.status_area.height, 2);
-        assert_eq!(plan.plan_dock_area.height, 4);
+        assert_eq!(plan.workbench_area.height, 4);
         assert!(plan.segment_detail_area.y < plan.editor_area.y);
         assert!(plan.editor_area.y < plan.editor_info_area.y);
-        assert!(plan.editor_info_area.y < plan.plan_dock_area.y);
-        assert!(plan.plan_dock_area.y < plan.status_area.y);
+        assert!(plan.editor_info_area.y < plan.workbench_area.y);
+        assert!(plan.workbench_area.y < plan.status_area.y);
     }
 
     #[test]
@@ -240,13 +244,13 @@ mod tests {
             status_height: 2,
             pending_permission: true,
             active_tool_stream_height: 20,
-            plan_dock_height: 20,
+            workbench_height: 20,
             segment_detail_height: 0,
         });
         assert!(plan.is_slim);
         assert_eq!(plan.permission_lane_height, 2);
         assert!(plan.active_tool_stream_height <= 6);
-        assert!(plan.plan_dock_height <= 4);
+        assert!(plan.workbench_height <= 4);
     }
 
     #[test]
@@ -262,7 +266,7 @@ mod tests {
             status_height: 2,
             pending_permission: false,
             active_tool_stream_height: 0,
-            plan_dock_height: 0,
+            workbench_height: 0,
             segment_detail_height: 8,
         });
         assert_eq!(plan.segment_detail_height, 8);
@@ -271,7 +275,7 @@ mod tests {
     }
 
     #[test]
-    fn slim_plan_is_pinned_between_editor_and_status_bar() {
+    fn workbench_is_pinned_between_editor_and_status_bar() {
         let plan = plan_tui_layout(TuiLayoutInputs {
             area: Rect::new(0, 0, 120, 40),
             surfaces: UiSurfaces::lean(),
@@ -283,16 +287,16 @@ mod tests {
             status_height: 2,
             pending_permission: false,
             active_tool_stream_height: 5,
-            plan_dock_height: 5,
+            workbench_height: 5,
             segment_detail_height: 4,
         });
 
-        assert_eq!(plan.plan_dock_height, 5);
+        assert_eq!(plan.workbench_height, 5);
         assert!(plan.active_tool_stream_area.y < plan.segment_detail_area.y);
         assert!(plan.segment_detail_area.y < plan.editor_area.y);
         assert!(plan.editor_area.y < plan.editor_info_area.y);
-        assert!(plan.editor_info_area.y < plan.plan_dock_area.y);
-        assert!(plan.plan_dock_area.y < plan.status_area.y);
+        assert!(plan.editor_info_area.y < plan.workbench_area.y);
+        assert!(plan.workbench_area.y < plan.status_area.y);
     }
 
     #[test]
@@ -308,7 +312,7 @@ mod tests {
             status_height: 2,
             pending_permission: false,
             active_tool_stream_height: 12,
-            plan_dock_height: 5,
+            workbench_height: 5,
             segment_detail_height: 4,
         });
 
@@ -317,7 +321,7 @@ mod tests {
         assert_eq!(plan.editor_info_area.height, 1);
         assert_eq!(plan.status_area.height, 2);
         assert!(plan.segment_detail_area.y < plan.editor_area.y);
-        assert!(plan.editor_info_area.y < plan.plan_dock_area.y);
-        assert!(plan.plan_dock_area.y < plan.status_area.y);
+        assert!(plan.editor_info_area.y < plan.workbench_area.y);
+        assert!(plan.workbench_area.y < plan.status_area.y);
     }
 }

--- a/core/crates/omegon/src/tui/mod.rs
+++ b/core/crates/omegon/src/tui/mod.rs
@@ -33,7 +33,7 @@ pub mod segment_components;
 pub mod segment_detail;
 pub mod segments;
 pub mod selector;
-pub mod slim_plan;
+pub mod workbench;
 pub mod spinner;
 pub mod splash;
 pub mod statusline;
@@ -90,9 +90,9 @@ use self::instruments::InstrumentPanel;
 use self::layout_projection::{TuiLayoutInputs, plan_tui_layout};
 use self::permission_lane::{format_permission_prompt, permission_response_for_key};
 use self::segments::{SegmentContent, SegmentExportMode, SegmentRenderMode};
-use self::slim_plan::{
-    PlanDisplaySnapshot, PlanDockState, SlimPlanContext, SlimPlanHintState, SlimTurnState,
-    active_plan_dock_snapshot, plan_dock_preferred_height, render_plan_dock_panel,
+use self::workbench::{
+    PlanDisplaySnapshot, WorkbenchState, SlimPlanContext, SlimPlanHintState, SlimTurnState,
+    active_workbench_snapshot, workbench_preferred_height, render_workbench_panel,
     slim_completed_plan_hint_available, slim_operator_hint, upstream_retry_hint,
 };
 use crate::surfaces::layout::UiSurfaces;
@@ -428,8 +428,8 @@ pub struct App {
     plugin_registry: Option<crate::plugins::registry::PluginRegistry>,
     /// Slim-mode status line — persistent telemetry bar.
     status_line: statusline::StatusLine,
-    /// Structured session plan snapshot for the active Plan Dock panel.
-    plan_dock_state: PlanDockState,
+    /// Structured session plan snapshot for the active Workbench panel.
+    workbench_state: WorkbenchState,
     active_tool_stream: Option<ActiveToolStream>,
     /// Explicit Slim turn state rendered in the status line.
     slim_turn_state: SlimTurnState,
@@ -1604,7 +1604,7 @@ impl App {
                 crate::prompt::load_lex_imperialis(),
             )),
             status_line: statusline::StatusLine::default(),
-            plan_dock_state: PlanDockState::default(),
+            workbench_state: WorkbenchState::default(),
             completed_plan_history_available: false,
             active_tool_stream: None,
             slim_turn_state: SlimTurnState::Ready,
@@ -3863,16 +3863,19 @@ impl App {
         let dashboard_has_content = self.dashboard.status_counts.total > 0
             || self.dashboard.focused_node.is_some()
             || !self.dashboard.active_changes.is_empty()
-            || self.dashboard.cleave.as_ref().is_some_and(|c| c.active);
+            || self.dashboard.cleave.as_ref().is_some_and(|c| c.active)
+            || self.dashboard.delegate.as_ref().is_some_and(|d| d.active || d.running > 0);
         let editor_height = editor_height_for(&self.editor, area);
         let editor_info_height = u16::from(!self.queued_prompts.is_empty());
-        let plan_dock_state = if self.ui_surfaces.is_compact() && !self.focus_mode {
-            PlanDockState {
-                active: active_plan_dock_snapshot(self.plan_dock_state.active.as_ref(), None),
-                workstreams: self.plan_dock_state.workstreams.clone(),
+        let workbench_state = if !self.focus_mode {
+            WorkbenchState {
+                active: active_workbench_snapshot(self.workbench_state.active.as_ref(), None),
+                cleave: self.dashboard.cleave.clone().filter(|p| p.active),
+                delegate: self.dashboard.delegate.clone().filter(|p| p.active || p.running > 0),
+                workstreams: self.workbench_state.workstreams.clone(),
             }
         } else {
-            PlanDockState::default()
+            WorkbenchState::default()
         };
         let raw_active_tool_stream_height = if self.ui_surfaces.is_compact() && !self.focus_mode {
             self.active_tool_stream
@@ -3882,7 +3885,7 @@ impl App {
         } else {
             0
         };
-        let raw_plan_dock_height = plan_dock_preferred_height(&plan_dock_state, area.width);
+        let raw_workbench_height = workbench_preferred_height(&workbench_state, area.width);
         let segment_detail_index = self.conversation.timeline_expanded_segment();
         let segment_detail_height = segment_detail::preferred_height(
             segment_detail_index.and_then(|idx| self.conversation.segments().get(idx)),
@@ -3899,7 +3902,7 @@ impl App {
             status_height: statusline::StatusLine::preferred_height(area.width),
             pending_permission: false,
             active_tool_stream_height: raw_active_tool_stream_height,
-            plan_dock_height: raw_plan_dock_height,
+            workbench_height: raw_workbench_height,
             segment_detail_height,
         });
 
@@ -3907,7 +3910,7 @@ impl App {
         let main_area = layout_plan.main_area;
         let conversation_area = layout_plan.conversation_area;
         let active_tool_stream_area = layout_plan.active_tool_stream_area;
-        let plan_dock_area = layout_plan.plan_dock_area;
+        let workbench_area = layout_plan.workbench_area;
         let segment_detail_area = layout_plan.segment_detail_area;
         let editor_area = layout_plan.editor_area;
         let editor_info_area = layout_plan.editor_info_area;
@@ -4001,8 +4004,13 @@ impl App {
             );
         }
 
-        if plan_dock_state.active.is_some() && plan_dock_area.height > 0 {
-            render_plan_dock_panel(plan_dock_area, frame, self.theme.as_ref(), &plan_dock_state);
+        if (workbench_state.active.is_some()
+            || workbench_state.cleave.is_some()
+            || workbench_state.delegate.is_some()
+            || !workbench_state.workstreams.is_empty())
+            && workbench_area.height > 0
+        {
+            render_workbench_panel(workbench_area, frame, self.theme.as_ref(), &workbench_state);
         }
 
         if segment_detail_area.height > 0
@@ -4062,10 +4070,10 @@ impl App {
                 None
             };
             self.status_line.turn_state = Some(self.slim_turn_state.label());
-            let plan_state = plan_dock_state
+            let plan_state = workbench_state
                 .active
                 .as_ref()
-                .map(|snapshot| snapshot.hint_state(plan_dock_area.height))
+                .map(|snapshot| snapshot.hint_state(workbench_area.height))
                 .unwrap_or_else(|| {
                     if slim_completed_plan_hint_available(self.completed_plan_history_available) {
                         SlimPlanHintState::Complete
@@ -4074,7 +4082,7 @@ impl App {
                     }
                 });
             let plan_context = SlimPlanContext::from_dashboard(
-                plan_dock_state.active.is_some(),
+                workbench_state.active.is_some(),
                 &self.dashboard.active_changes,
                 self.dashboard.focused_node.as_ref(),
             );
@@ -6924,7 +6932,7 @@ Scroll transcript:
                     // If no completion PlanUpdated arrives before the assistant turn
                     // finishes, clear it rather than leaving stale "plan active" chrome
                     // held under a "turn done" status line.
-                    self.plan_dock_state.active = None;
+                    self.workbench_state.active = None;
                 }
                 // Update status line with behavioral signals
                 self.status_line.phase = te.dominant_phase;
@@ -7378,7 +7386,7 @@ Scroll transcript:
                 }
             }
             AgentEvent::PlanUpdated { snapshot_json } => {
-                let dock_state = PlanDockState::from_plan_update_json(snapshot_json);
+                let dock_state = WorkbenchState::from_plan_update_json(snapshot_json);
                 self.completed_plan_history_available = dock_state
                     .active
                     .as_ref()
@@ -7397,17 +7405,18 @@ Scroll transcript:
                             .push_system(&snapshot.system_notification_text("Plan progress"));
                     }
                     self.conversation.snap_to_bottom();
-                    self.plan_dock_state = PlanDockState {
+                    self.workbench_state = WorkbenchState {
                         active: None,
                         workstreams: dock_state.workstreams,
+                        ..WorkbenchState::default()
                     };
                 } else {
-                    self.plan_dock_state = dock_state;
+                    self.workbench_state = dock_state;
                 }
             }
             AgentEvent::SessionReset => {
                 self.conversation = ConversationView::new();
-                self.plan_dock_state.active = None;
+                self.workbench_state.active = None;
                 self.completed_plan_history_available = false;
                 self.active_tool_stream = None;
                 self.turn = 0;
@@ -9659,10 +9668,10 @@ mod slash_command_parsing_tests {
     use super::permission_lane::{
         format_permission_prompt, permission_persist_scope_label, permission_response_for_key,
     };
-    use super::slim_plan::{
+    use super::workbench::{
         PlanDisplayItem, PlanDisplaySnapshot, PlanDisplayStatus, SlimPlanContext,
         SlimPlanHintState, slim_completed_plan_hint_available, slim_operator_hint,
-        active_plan_dock_snapshot, plan_dock_rows,
+        active_workbench_snapshot, workbench_rows,
     };
     use crate::lifecycle::types::NodeStatus;
     use crossterm::event::{KeyCode, KeyModifiers};
@@ -9671,13 +9680,13 @@ mod slash_command_parsing_tests {
     // ── Profile ───────────────────────────────────────────
 
     #[test]
-    fn plan_dock_workstream_only_uses_compact_height() {
-        use super::slim_plan::{PlanDockState, WorkstreamStatus, WorkstreamSummary, plan_dock_preferred_height};
+    fn workbench_workstream_only_uses_compact_height() {
+        use super::workbench::{WorkbenchState, WorkstreamStatus, WorkstreamSummary, workbench_preferred_height};
 
-        let empty = PlanDockState::default();
-        assert_eq!(plan_dock_preferred_height(&empty, 100), 0);
+        let empty = WorkbenchState::default();
+        assert_eq!(workbench_preferred_height(&empty, 100), 0);
 
-        let state = PlanDockState {
+        let state = WorkbenchState {
             active: None,
             workstreams: vec![WorkstreamSummary {
                 id: "release".into(),
@@ -9686,15 +9695,16 @@ mod slash_command_parsing_tests {
                 completed: 2,
                 total: 5,
             }],
+            ..WorkbenchState::default()
         };
-        assert_eq!(plan_dock_preferred_height(&state, 100), 1);
+        assert_eq!(workbench_preferred_height(&state, 100), 1);
     }
 
     #[test]
-    fn plan_dock_workstream_only_renders_summary_without_task_rows() {
-        use super::slim_plan::{PlanDockState, WorkstreamStatus, WorkstreamSummary, render_plan_dock_panel};
+    fn workbench_workstream_only_renders_summary_without_task_rows() {
+        use super::workbench::{WorkbenchState, WorkstreamStatus, WorkstreamSummary, render_workbench_panel};
 
-        let state = PlanDockState {
+        let state = WorkbenchState {
             active: None,
             workstreams: vec![WorkstreamSummary {
                 id: "release".into(),
@@ -9703,11 +9713,12 @@ mod slash_command_parsing_tests {
                 completed: 2,
                 total: 5,
             }],
+            ..WorkbenchState::default()
         };
         let backend = ratatui::backend::TestBackend::new(80, 1);
         let mut terminal = ratatui::Terminal::new(backend).unwrap();
         terminal
-            .draw(|frame| render_plan_dock_panel(frame.area(), frame, &super::theme::Alpharius, &state))
+            .draw(|frame| render_workbench_panel(frame.area(), frame, &super::theme::Alpharius, &state))
             .unwrap();
         let mut text = String::new();
         for x in 0..80 {
@@ -9720,7 +9731,7 @@ mod slash_command_parsing_tests {
     }
 
     #[test]
-    fn slim_plan_contract_renders_structured_snapshot() {
+    fn workbench_contract_renders_structured_snapshot() {
         let snapshot = PlanDisplaySnapshot::from_json(serde_json::json!({
             "mode": "executing",
             "completed": 2,
@@ -9734,7 +9745,7 @@ mod slash_command_parsing_tests {
         }))
         .unwrap();
         assert_eq!(snapshot.summary(), "plan 2/4 · executing");
-        let rows = plan_dock_rows(&snapshot, 80, 5);
+        let rows = workbench_rows(&snapshot, 80, 5);
         assert_eq!(
             rows.iter().map(|row| row.text.as_str()).collect::<Vec<_>>(),
             vec![
@@ -9748,7 +9759,7 @@ mod slash_command_parsing_tests {
     }
 
     #[test]
-    fn slim_plan_contract_marks_hidden_rows() {
+    fn workbench_contract_marks_hidden_rows() {
         let snapshot = PlanDisplaySnapshot::from_json(serde_json::json!({
             "mode": "executing",
             "completed": 1,
@@ -9759,7 +9770,7 @@ mod slash_command_parsing_tests {
             })).collect::<Vec<_>>()
         }))
         .unwrap();
-        let rows = plan_dock_rows(&snapshot, 40, 4);
+        let rows = workbench_rows(&snapshot, 40, 4);
         assert_eq!(
             rows.iter().map(|row| row.text.as_str()).collect::<Vec<_>>(),
             vec!["1. done    Step 0", "2. todo    Step 1", "+5 more"]
@@ -9820,7 +9831,7 @@ mod slash_command_parsing_tests {
     }
 
     #[test]
-    fn slim_plan_legacy_text_remains_fallback_only() {
+    fn workbench_legacy_text_remains_fallback_only() {
         let snapshot = PlanDisplaySnapshot::from_legacy_text(
             "Plan progress\nPlan mode: executing\nProgress: 2/3\n\n1. ● Inspect\n2. ◐ Patch\n3. ⊘ Skip",
         )
@@ -9873,8 +9884,8 @@ mod slash_command_parsing_tests {
     }
 
     #[test]
-    fn completed_legacy_plan_does_not_activate_plan_dock() {
-        let active = active_plan_dock_snapshot(
+    fn completed_legacy_plan_does_not_activate_workbench() {
+        let active = active_workbench_snapshot(
             None,
             Some("Plan progress\nPlan mode: complete\nProgress: 2/2\n\n1. ● A\n2. ● B"),
         );
@@ -9883,8 +9894,8 @@ mod slash_command_parsing_tests {
     }
 
     #[test]
-    fn legacy_plan_history_does_not_activate_plan_dock() {
-        let active = active_plan_dock_snapshot(
+    fn legacy_plan_history_does_not_activate_workbench() {
+        let active = active_workbench_snapshot(
             None,
             Some("Plan progress\nPlan mode: executing\nProgress: 1/2\n\n1. ● Old\n2. ◐ Stale"),
         );
@@ -9893,7 +9904,7 @@ mod slash_command_parsing_tests {
     }
 
     #[test]
-    fn live_active_plan_still_activates_plan_dock() {
+    fn live_active_plan_still_activates_workbench() {
         let live = PlanDisplaySnapshot {
             mode: "executing".to_string(),
             completed: 1,
@@ -9909,14 +9920,14 @@ mod slash_command_parsing_tests {
                 },
             ],
         };
-        let active = active_plan_dock_snapshot(Some(&live), None).unwrap();
+        let active = active_workbench_snapshot(Some(&live), None).unwrap();
 
         assert_eq!(active.summary(), "plan 1/2 · executing");
         assert!(!active.is_complete());
     }
 
     #[test]
-    fn completed_live_plan_snapshot_does_not_activate_plan_dock() {
+    fn completed_live_plan_snapshot_does_not_activate_workbench() {
         let completed = PlanDisplaySnapshot {
             mode: "complete".to_string(),
             completed: 1,
@@ -9927,7 +9938,7 @@ mod slash_command_parsing_tests {
             }],
         };
 
-        assert!(active_plan_dock_snapshot(Some(&completed), None).is_none());
+        assert!(active_workbench_snapshot(Some(&completed), None).is_none());
     }
 
     #[test]
@@ -9955,7 +9966,7 @@ mod slash_command_parsing_tests {
     }
 
     #[test]
-    fn slim_plan_hint_matches_actually_visible_next_row() {
+    fn workbench_hint_matches_actually_visible_next_row() {
         let snapshot = PlanDisplaySnapshot {
             mode: "executing".to_string(),
             completed: 1,
@@ -10046,7 +10057,7 @@ mod slash_command_parsing_tests {
     }
 
     #[test]
-    fn slim_plan_context_labels_active_tracking_and_lifecycle_links() {
+    fn workbench_context_labels_active_tracking_and_lifecycle_links() {
         let changes = vec![dashboard::ChangeSummary {
             name: "rollup".into(),
             stage: "implementing".into(),

--- a/core/crates/omegon/src/tui/mod.rs
+++ b/core/crates/omegon/src/tui/mod.rs
@@ -3860,18 +3860,37 @@ impl App {
         }
 
         // ── Main surface layout ────────────────────────────────────
+        let live_cleave = self
+            .dashboard_handles
+            .cleave
+            .as_ref()
+            .and_then(|cp_lock| cp_lock.lock().ok().map(|cp| cp.clone()))
+            .filter(|cp| cp.active)
+            .or_else(|| self.dashboard.cleave.clone().filter(|cp| cp.active));
+        let live_delegate = self
+            .dashboard_handles
+            .delegate
+            .as_ref()
+            .and_then(|dp_lock| dp_lock.lock().ok().map(|dp| dp.clone()))
+            .filter(|dp| dp.active || dp.running > 0)
+            .or_else(|| {
+                self.dashboard
+                    .delegate
+                    .clone()
+                    .filter(|dp| dp.active || dp.running > 0)
+            });
         let dashboard_has_content = self.dashboard.status_counts.total > 0
             || self.dashboard.focused_node.is_some()
             || !self.dashboard.active_changes.is_empty()
-            || self.dashboard.cleave.as_ref().is_some_and(|c| c.active)
-            || self.dashboard.delegate.as_ref().is_some_and(|d| d.active || d.running > 0);
+            || live_cleave.is_some()
+            || live_delegate.is_some();
         let editor_height = editor_height_for(&self.editor, area);
         let editor_info_height = u16::from(!self.queued_prompts.is_empty());
         let workbench_state = if !self.focus_mode {
             WorkbenchState {
                 active: active_workbench_snapshot(self.workbench_state.active.as_ref(), None),
-                cleave: self.dashboard.cleave.clone().filter(|p| p.active),
-                delegate: self.dashboard.delegate.clone().filter(|p| p.active || p.running > 0),
+                cleave: live_cleave,
+                delegate: live_delegate,
                 workstreams: self.workbench_state.workstreams.clone(),
             }
         } else {

--- a/core/crates/omegon/src/tui/segments.rs
+++ b/core/crates/omegon/src/tui/segments.rs
@@ -2899,7 +2899,7 @@ mod tests {
     }
 
     #[test]
-    fn slim_plan_progress_has_zero_scrollback_height() {
+    fn workbench_progress_has_zero_scrollback_height() {
         let seg = Segment::system("Plan progress\nProgress: 1/2\n\n1. ◐ Do it");
         assert_eq!(
             seg.height_in_mode(80, &Alpharius, SegmentRenderMode::Slim),

--- a/core/crates/omegon/src/tui/tests.rs
+++ b/core/crates/omegon/src/tui/tests.rs
@@ -1347,7 +1347,7 @@ fn completed_plan_update_enables_done_view_hint_without_pinning() {
     });
 
     assert!(app.completed_plan_history_available);
-    assert!(app.plan_dock_state.active.is_none());
+    assert!(app.workbench_state.active.is_none());
     let text = render_app_to_string(&mut app, 120, 18);
     assert!(text.contains("plan complete · history available"), "{text}");
     assert!(
@@ -1361,7 +1361,7 @@ fn completed_plan_update_reattaches_detached_slim_viewport() {
     let mut app = test_app();
     app.conversation.conv_state.scroll_offset = 46;
     app.conversation.conv_state.user_scrolled = true;
-    app.plan_dock_state.active = PlanDisplaySnapshot::from_json(serde_json::json!({
+    app.workbench_state.active = PlanDisplaySnapshot::from_json(serde_json::json!({
         "mode": "executing",
         "completed": 1,
         "total": 2,
@@ -1385,7 +1385,7 @@ fn completed_plan_update_reattaches_detached_slim_viewport() {
 
     assert_eq!(app.conversation.conv_state.scroll_offset, 0);
     assert!(!app.conversation.conv_state.user_scrolled);
-    assert!(app.plan_dock_state.active.is_none());
+    assert!(app.workbench_state.active.is_none());
     assert!(
         app.conversation
             .latest_plan_progress()
@@ -1415,7 +1415,7 @@ fn assistant_completed_turn_clears_stale_live_plan_lane() {
             ]
         }),
     });
-    assert!(app.plan_dock_state.active.is_some());
+    assert!(app.workbench_state.active.is_some());
 
     app.handle_agent_event(AgentEvent::TurnEnd(Box::new(
         omegon_traits::AgentEventTurnEnd {
@@ -1443,7 +1443,7 @@ fn assistant_completed_turn_clears_stale_live_plan_lane() {
         },
     )));
 
-    assert!(app.plan_dock_state.active.is_none());
+    assert!(app.workbench_state.active.is_none());
     let text = render_app_to_string(&mut app, 140, 18);
     assert!(!text.contains("plan active"), "{text}");
     assert!(!text.contains("Harden set_recipe"), "{text}");
@@ -1854,12 +1854,12 @@ fn ctrl_shift_y_is_reserved_for_copy_latest_assistant_answer() {
 
 #[test]
 fn normal_transcript_hint_advertises_scroll_and_answer_copy() {
-    let hint = super::slim_plan::slim_operator_hint(
+    let hint = super::workbench::slim_operator_hint(
         false,
         false,
         false,
-        super::slim_plan::SlimPlanHintState::None,
-        &super::slim_plan::SlimPlanContext::from_dashboard(false, &[], None),
+        super::workbench::SlimPlanHintState::None,
+        &super::workbench::SlimPlanContext::from_dashboard(false, &[], None),
     );
 
     assert!(hint.contains("PgUp/PgDn scroll"), "{hint}");
@@ -1868,12 +1868,12 @@ fn normal_transcript_hint_advertises_scroll_and_answer_copy() {
 
 #[test]
 fn terminal_copy_hint_describes_mouse_passthrough_not_copy_mode() {
-    let hint = super::slim_plan::slim_operator_hint(
+    let hint = super::workbench::slim_operator_hint(
         false,
         false,
         true,
-        super::slim_plan::SlimPlanHintState::None,
-        &super::slim_plan::SlimPlanContext::from_dashboard(false, &[], None),
+        super::workbench::SlimPlanHintState::None,
+        &super::workbench::SlimPlanContext::from_dashboard(false, &[], None),
     );
 
     assert!(hint.contains("mouse passthrough"), "{hint}");
@@ -3465,6 +3465,77 @@ directive = "TONE.md"
 // ═══════════════════════════════════════════════════════════════════
 // Event handling
 // ═══════════════════════════════════════════════════════════════════
+
+
+
+#[test]
+fn draw_routes_active_cleave_to_workbench_without_instruments() {
+    let mut app = test_app();
+    app.ui_surfaces.footer = true;
+    app.ui_surfaces.instruments = false;
+    app.dashboard.cleave = Some(crate::features::cleave::CleaveProgress {
+        active: true,
+        run_id: "run-1".into(),
+        total_children: 2,
+        completed: 1,
+        failed: 0,
+        children: vec![crate::features::cleave::ChildProgress {
+            label: "ui".into(),
+            status: "running".into(),
+            duration_secs: None,
+            supervision_mode: None,
+            pid: None,
+            last_tool: Some("bash".into()),
+            last_turn: Some(1),
+            tasks: vec![],
+            tasks_done: 0,
+            started_at: None,
+            last_activity_at: None,
+            tokens_in: 0,
+            tokens_out: 0,
+            runtime: None,
+        }],
+        total_tokens_in: 0,
+        total_tokens_out: 0,
+    });
+
+    let rendered = render_app_to_string(&mut app, 140, 36);
+
+    assert!(rendered.contains("cleave 1/2"), "{rendered}");
+    assert!(rendered.contains("ui running"), "{rendered}");
+    assert!(rendered.contains("bash"), "{rendered}");
+}
+
+#[test]
+fn draw_routes_active_delegate_to_workbench_without_instruments() {
+    let mut app = test_app();
+    app.ui_surfaces.footer = true;
+    app.ui_surfaces.instruments = false;
+    app.dashboard.delegate = Some(crate::features::delegate::DelegateProgress {
+        active: true,
+        running: 1,
+        completed: 2,
+        failed: 0,
+        children: vec![crate::features::delegate::DelegateProgressChild {
+            task_id: "delegate_1".into(),
+            label: "scout".into(),
+            status: "running".into(),
+            last_tool: Some("read".into()),
+            last_turn: Some(1),
+            started_at: None,
+            completed_at: None,
+            result_summary: None,
+            tasks: vec![],
+            tasks_done: 0,
+        }],
+    });
+
+    let rendered = render_app_to_string(&mut app, 140, 36);
+
+    assert!(rendered.contains("delegate running 1"), "{rendered}");
+    assert!(rendered.contains("scout running"), "{rendered}");
+    assert!(rendered.contains("read"), "{rendered}");
+}
 
 #[test]
 fn draw_clears_stale_completed_cleave_snapshot_from_tools_panel() {

--- a/core/crates/omegon/src/tui/workbench.rs
+++ b/core/crates/omegon/src/tui/workbench.rs
@@ -1,4 +1,4 @@
-//! Plan dock snapshot surface rendering and hint policy.
+//! Workbench snapshot surface rendering and hint policy.
 
 use ratatui::prelude::*;
 use ratatui::style::Modifier;
@@ -6,8 +6,10 @@ use ratatui::text::{Line, Span};
 use ratatui::widgets::{Paragraph, Widget, Wrap};
 
 use super::{dashboard, theme};
+use crate::features::cleave::CleaveProgress;
+use crate::features::delegate::DelegateProgress;
 
-pub fn plan_dock_snapshot_height(snapshot: &PlanDisplaySnapshot, width: u16) -> u16 {
+pub fn workbench_snapshot_height(snapshot: &PlanDisplaySnapshot, width: u16) -> u16 {
     if width == 0 || snapshot.items.is_empty() {
         return 0;
     }
@@ -17,12 +19,16 @@ pub fn plan_dock_snapshot_height(snapshot: &PlanDisplaySnapshot, width: u16) -> 
     (1 + item_count.min(4)).clamp(2, 5)
 }
 
-pub fn plan_dock_preferred_height(state: &PlanDockState, width: u16) -> u16 {
+pub fn workbench_preferred_height(state: &WorkbenchState, width: u16) -> u16 {
     if width == 0 {
         return 0;
     }
     if let Some(active) = state.active.as_ref() {
-        plan_dock_snapshot_height(active, width)
+        workbench_snapshot_height(active, width)
+    } else if state.cleave.as_ref().is_some_and(|p| p.active) {
+        5
+    } else if state.delegate.as_ref().is_some_and(|p| p.active || p.running > 0) {
+        5
     } else if !state.workstreams.is_empty() {
         1
     } else {
@@ -30,9 +36,11 @@ pub fn plan_dock_preferred_height(state: &PlanDockState, width: u16) -> u16 {
     }
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub struct PlanDockState {
+#[derive(Clone, Default)]
+pub struct WorkbenchState {
     pub active: Option<PlanDisplaySnapshot>,
+    pub cleave: Option<CleaveProgress>,
+    pub delegate: Option<DelegateProgress>,
     pub workstreams: Vec<WorkstreamSummary>,
 }
 
@@ -93,7 +101,7 @@ impl WorkstreamSummary {
     }
 }
 
-impl PlanDockState {
+impl WorkbenchState {
     pub fn from_plan_update_json(value: serde_json::Value) -> Self {
         let workstreams = value
             .get("workstreams")
@@ -103,6 +111,7 @@ impl PlanDockState {
         Self {
             active: PlanDisplaySnapshot::from_json(value),
             workstreams,
+            ..Self::default()
         }
     }
 }
@@ -376,11 +385,11 @@ impl PlanDisplaySnapshot {
     }
 }
 
-pub fn active_plan_dock_snapshot(
+pub fn active_workbench_snapshot(
     live_snapshot: Option<&PlanDisplaySnapshot>,
     _legacy_plan_text: Option<&str>,
 ) -> Option<PlanDisplaySnapshot> {
-    // Only the live PlanUpdated projection may drive the Plan Dock. Legacy
+    // Only the live PlanUpdated projection may drive the Workbench. Legacy
     // transcript text is durable history, not active state; falling back to it
     // resurrects old unfinished plans after branch/session/task changes.
     live_snapshot
@@ -388,7 +397,7 @@ pub fn active_plan_dock_snapshot(
         .cloned()
 }
 
-pub fn plan_dock_rows(
+pub fn workbench_rows(
     snapshot: &PlanDisplaySnapshot,
     width: u16,
     height: u16,
@@ -526,11 +535,11 @@ pub fn slim_operator_hint(
     }
 }
 
-pub fn render_plan_dock_panel(
+pub fn render_workbench_panel(
     area: Rect,
     frame: &mut Frame,
     t: &dyn theme::Theme,
-    state: &PlanDockState,
+    state: &WorkbenchState,
 ) {
     if area.width == 0 || area.height == 0 {
         return;
@@ -538,13 +547,17 @@ pub fn render_plan_dock_panel(
 
     let bg = t.surface_bg();
     if let Some(snapshot) = state.active.as_ref() {
-        render_active_plan_dock_panel(area, frame, t, snapshot, state.workstreams.len());
+        render_active_workbench_panel(area, frame, t, snapshot, state.workstreams.len());
+    } else if let Some(cleave) = state.cleave.as_ref().filter(|p| p.active) {
+        render_cleave_workbench_panel(area, frame, t, cleave);
+    } else if let Some(delegate) = state.delegate.as_ref().filter(|p| p.active || p.running > 0) {
+        render_delegate_workbench_panel(area, frame, t, delegate);
     } else {
         render_workstream_summary(area, frame, t, state.workstreams.as_slice(), bg);
     }
 }
 
-fn render_active_plan_dock_panel(
+fn render_active_workbench_panel(
     area: Rect,
     frame: &mut Frame,
     t: &dyn theme::Theme,
@@ -573,7 +586,7 @@ fn render_active_plan_dock_panel(
         ),
     ]));
 
-    for row in plan_dock_rows(snapshot, area.width, area.height) {
+    for row in workbench_rows(snapshot, area.width, area.height) {
         let style = row
             .status
             .map(|status| status.style(t, bg))
@@ -585,6 +598,129 @@ fn render_active_plan_dock_panel(
         .style(Style::default().bg(bg))
         .wrap(Wrap { trim: false })
         .render(area, frame.buffer_mut());
+}
+
+fn render_cleave_workbench_panel(
+    area: Rect,
+    frame: &mut Frame,
+    t: &dyn theme::Theme,
+    progress: &CleaveProgress,
+) {
+    let bg = t.surface_bg();
+    let mut lines = vec![workbench_rule_line(
+        t,
+        bg,
+        format!(
+            "cleave {}/{} · failed {}",
+            progress.completed, progress.total_children, progress.failed
+        ),
+        area.width,
+    )];
+    let max_rows = area.height.saturating_sub(1) as usize;
+    for child in progress.children.iter().take(max_rows) {
+        let task_progress = if child.tasks.is_empty() {
+            String::new()
+        } else {
+            format!(" · tasks {}/{}", child.tasks_done, child.tasks.len())
+        };
+        let tool = child
+            .last_tool
+            .as_deref()
+            .map(|tool| format!(" · {tool}"))
+            .unwrap_or_default();
+        let text = crate::util::truncate(
+            &format!("{} {:<10}{}{}", child.label, child.status, task_progress, tool),
+            area.width.saturating_sub(1) as usize,
+        );
+        lines.push(Line::from(Span::styled(
+            text,
+            worker_status_style(&child.status, t, bg),
+        )));
+    }
+    Paragraph::new(lines)
+        .style(Style::default().bg(bg))
+        .wrap(Wrap { trim: false })
+        .render(area, frame.buffer_mut());
+}
+
+fn render_delegate_workbench_panel(
+    area: Rect,
+    frame: &mut Frame,
+    t: &dyn theme::Theme,
+    progress: &DelegateProgress,
+) {
+    let bg = t.surface_bg();
+    let mut lines = vec![workbench_rule_line(
+        t,
+        bg,
+        format!(
+            "delegate running {} · done {} · failed {}",
+            progress.running, progress.completed, progress.failed
+        ),
+        area.width,
+    )];
+    let max_rows = area.height.saturating_sub(1) as usize;
+    for child in progress.children.iter().take(max_rows) {
+        let task_progress = if child.tasks.is_empty() {
+            String::new()
+        } else {
+            format!(" · tasks {}/{}", child.tasks_done, child.tasks.len())
+        };
+        let tool = child
+            .last_tool
+            .as_deref()
+            .map(|tool| format!(" · {tool}"))
+            .unwrap_or_default();
+        let text = crate::util::truncate(
+            &format!("{} {:<10}{}{}", child.label, child.status, task_progress, tool),
+            area.width.saturating_sub(1) as usize,
+        );
+        lines.push(Line::from(Span::styled(
+            text,
+            worker_status_style(&child.status, t, bg),
+        )));
+    }
+    Paragraph::new(lines)
+        .style(Style::default().bg(bg))
+        .wrap(Wrap { trim: false })
+        .render(area, frame.buffer_mut());
+}
+
+fn workbench_rule_line<'a>(
+    t: &dyn theme::Theme,
+    bg: ratatui::style::Color,
+    summary: String,
+    width: u16,
+) -> Line<'a> {
+    let rule_width = width.saturating_sub(summary.len() as u16 + 4) as usize;
+    Line::from(vec![
+        Span::styled("─ ", Style::default().fg(t.border_dim()).bg(bg)),
+        Span::styled(
+            summary,
+            Style::default()
+                .fg(t.accent_muted())
+                .bg(bg)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(
+            format!(" {}", "─".repeat(rule_width)),
+            Style::default().fg(t.border_dim()).bg(bg),
+        ),
+    ])
+}
+
+fn worker_status_style(
+    status: &str,
+    t: &dyn theme::Theme,
+    bg: ratatui::style::Color,
+) -> Style {
+    let fg = match status {
+        "completed" | "merged_after_failure" => t.success(),
+        "running" => t.warning(),
+        "failed" | "upstream_exhausted" => t.error(),
+        _ => t.accent_muted(),
+    };
+    Style::default().fg(fg).bg(bg)
 }
 
 fn render_workstream_summary(


### PR DESCRIPTION
## Summary
- Rename the pinned plan dock into a Workbench surface for active structured work.
- Route active plan, cleave, delegate, and lifecycle workstream summaries through the Workbench instead of relying on optional instruments.
- Refresh cleave/delegate worker progress from shared handles each frame so active conversations do not show stale worker state.
- Keep completed plan notifications in conversation history while active plan state remains pinned outside scrollback.

## Adversarial assessment / fixes
- Verified the workbench is pinned between editor/editor-info and status/footer in layout projection rather than being inserted into conversation scrollback.
- Checked conversation side effects: active plan state does not resurrect from legacy transcript text, and completed plan snapshots still produce a history notification only when needed.
- Fixed a live-progress issue found during review: workbench now reads cleave/delegate handles directly per frame instead of depending on turn-throttled dashboard refresh.
- Added tests proving cleave/delegate workbench rendering works with instruments disabled.

## Validation
- just test-commit
