### PR TITLE
feat(commands): add registry safety metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [Semantic V
 
 ### Changed
 
+- Add explicit command registry availability/safety metadata, including CLI/ACP confirmation gates with `--dangerously-bypass-permissions` bypass support.
+- Preserve queued prompt dispatch mode at queue time so delayed prompts keep their original queue semantics.
+
 - Rename the TUI Plan Dock into a Workbench surface and surface active cleave/delegate progress there instead of only in optional instruments.
 - Make delegate runner script fixtures flush to disk before execution so CI timeout tests fail only on runner behavior, not file visibility races.
 - Add a local `just upstream-provider-check` gate for cheap provider drift checks without waiting for CI.

--- a/ai/lifecycle/state.json
+++ b/ai/lifecycle/state.json
@@ -1172,6 +1172,21 @@
       "bound_change": null,
       "created_at": "2026-06-09T14:33:42Z",
       "updated_at": "2026-06-09T16:22:35Z"
+    },
+    {
+      "id": "prompt-library-loop-system",
+      "title": "Prompt library and loop execution system",
+      "state": "exploring",
+      "parent": null,
+      "tags": [],
+      "priority": null,
+      "issue_type": null,
+      "open_questions": [],
+      "decisions": [],
+      "overview": "",
+      "bound_change": null,
+      "created_at": "2026-06-12T02:19:51Z",
+      "updated_at": "2026-06-12T02:19:51Z"
     }
   ],
   "changes": [
@@ -3046,6 +3061,24 @@
       "to_state": "decided",
       "reason": null,
       "forced": false
+    },
+    {
+      "timestamp": "2026-06-12T02:19:51Z",
+      "entity_type": "node",
+      "entity_id": "prompt-library-loop-system",
+      "from_state": "(new)",
+      "to_state": "seed",
+      "reason": null,
+      "forced": false
+    },
+    {
+      "timestamp": "2026-06-12T02:19:51Z",
+      "entity_type": "node",
+      "entity_id": "prompt-library-loop-system",
+      "from_state": "seed",
+      "to_state": "exploring",
+      "reason": "initial status on create",
+      "forced": true
     }
   ]
 }

--- a/core/crates/omegon-traits/src/lib.rs
+++ b/core/crates/omegon-traits/src/lib.rs
@@ -1561,6 +1561,93 @@ pub enum LifecyclePhase {
 // Slash commands
 // ═══════════════════════════════════════════════════════════════════════════
 
+/// Surfaces where a slash command may be discovered and invoked.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CommandAvailability {
+    /// Show/execute in the local terminal UI.
+    pub tui: bool,
+    /// Show/execute through CLI or remote slash-command entrypoints.
+    pub cli: bool,
+    /// Show/execute through ACP-hosted clients.
+    pub acp: bool,
+}
+
+impl CommandAvailability {
+    pub const ALL: Self = Self {
+        tui: true,
+        cli: true,
+        acp: true,
+    };
+    pub const TUI_ONLY: Self = Self {
+        tui: true,
+        cli: false,
+        acp: false,
+    };
+}
+
+/// Coarse command side-effect class for remote-surface policy decisions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CommandSafetyClass {
+    /// Command is only meaningful in a local interactive UI.
+    LocalOnly,
+    /// Command only reads state and returns information.
+    ReadOnly,
+    /// Command mutates the prompt queue or pending local work but does not touch external state.
+    QueueMutation,
+    /// Command mutates local/project state.
+    StateChanging,
+    /// Command may touch external services or host integrations.
+    ExternalSideEffect,
+    /// Command is destructive or irreversible without stronger confirmation.
+    Destructive,
+}
+
+/// Safety metadata used by CLI/ACP/TUI command surfaces.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CommandSafety {
+    pub class: CommandSafetyClass,
+    pub requires_confirmation: bool,
+    pub prompt_injection_sensitive: bool,
+}
+
+impl CommandSafety {
+    pub const READ_ONLY: Self = Self {
+        class: CommandSafetyClass::ReadOnly,
+        requires_confirmation: false,
+        prompt_injection_sensitive: false,
+    };
+
+    pub const LOCAL_ONLY: Self = Self {
+        class: CommandSafetyClass::LocalOnly,
+        requires_confirmation: false,
+        prompt_injection_sensitive: false,
+    };
+
+    pub const QUEUE_MUTATION: Self = Self {
+        class: CommandSafetyClass::QueueMutation,
+        requires_confirmation: false,
+        prompt_injection_sensitive: true,
+    };
+
+    pub const STATE_CHANGING: Self = Self {
+        class: CommandSafetyClass::StateChanging,
+        requires_confirmation: false,
+        prompt_injection_sensitive: false,
+    };
+
+    pub const EXTERNAL_SIDE_EFFECT: Self = Self {
+        class: CommandSafetyClass::ExternalSideEffect,
+        requires_confirmation: true,
+        prompt_injection_sensitive: false,
+    };
+
+    pub const DESTRUCTIVE: Self = Self {
+        class: CommandSafetyClass::Destructive,
+        requires_confirmation: true,
+        prompt_injection_sensitive: false,
+    };
+}
+
 /// Definition of a slash command that a feature registers.
 #[derive(Debug, Clone)]
 pub struct CommandDefinition {
@@ -1570,6 +1657,10 @@ pub struct CommandDefinition {
     pub description: String,
     /// Subcommand completions (e.g. ["200k", "1m"] for /context).
     pub subcommands: Vec<String>,
+    /// Surfaces where this command may be exposed.
+    pub availability: CommandAvailability,
+    /// Side-effect and prompt-injection safety metadata for remote surfaces.
+    pub safety: CommandSafety,
 }
 
 /// Result of handling a slash command.

--- a/core/crates/omegon/src/acp.rs
+++ b/core/crates/omegon/src/acp.rs
@@ -513,6 +513,7 @@ pub struct OmegonAcpAgent {
         Rc<RefCell<std::collections::BTreeMap<String, crate::extensions::ExtensionPollingHandle>>>,
     session_task_bindings: RefCell<Vec<crate::conversation::SessionTaskBinding>>,
     surface_updates_enabled: RefCell<bool>,
+    dangerously_bypass_permissions: bool,
 }
 
 impl OmegonAcpAgent {
@@ -520,9 +521,25 @@ impl OmegonAcpAgent {
         Self::new_with_extension_metadata(model, Default::default())
     }
 
+    pub fn new_with_safety(model: &str, dangerously_bypass_permissions: bool) -> Self {
+        Self::new_with_extension_metadata_and_safety(
+            model,
+            Default::default(),
+            dangerously_bypass_permissions,
+        )
+    }
+
     pub fn new_with_extension_metadata(
         model: &str,
         extension_metadata: std::collections::BTreeMap<String, serde_json::Value>,
+    ) -> Self {
+        Self::new_with_extension_metadata_and_safety(model, extension_metadata, false)
+    }
+
+    pub fn new_with_extension_metadata_and_safety(
+        model: &str,
+        extension_metadata: std::collections::BTreeMap<String, serde_json::Value>,
+        dangerously_bypass_permissions: bool,
     ) -> Self {
         Self {
             model: model.to_string(),
@@ -536,6 +553,7 @@ impl OmegonAcpAgent {
             extension_rpc_handles: Rc::new(RefCell::new(Default::default())),
             session_task_bindings: RefCell::new(Vec::new()),
             surface_updates_enabled: RefCell::new(false),
+            dangerously_bypass_permissions,
         }
     }
 
@@ -722,8 +740,12 @@ impl OmegonAcpAgent {
                 None
             };
 
-            let mut handle =
-                acp_worker::spawn_worker(self.model.clone(), cwd.to_path_buf(), host_ctx);
+            let mut handle = acp_worker::spawn_worker(
+                self.model.clone(),
+                cwd.to_path_buf(),
+                host_ctx,
+                self.dangerously_bypass_permissions,
+            );
             // Drain the secrets channel asynchronously — the worker sends it
             // after AgentSetup completes. Store in self.secrets for redaction.
             let secrets_cell = self.secrets.clone();
@@ -4697,7 +4719,12 @@ auto_disabled = true
     }
 }
 
-pub async fn run(model: &str, agent_id: Option<&str>, cwd: &std::path::Path) -> anyhow::Result<()> {
+pub async fn run(
+    model: &str,
+    agent_id: Option<&str>,
+    cwd: &std::path::Path,
+    dangerously_bypass_permissions: bool,
+) -> anyhow::Result<()> {
     use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
 
     let extension_metadata = if let Some(id) = agent_id {
@@ -4710,9 +4737,10 @@ pub async fn run(model: &str, agent_id: Option<&str>, cwd: &std::path::Path) -> 
         Default::default()
     };
 
-    let agent = Rc::new(OmegonAcpAgent::new_with_extension_metadata(
+    let agent = Rc::new(OmegonAcpAgent::new_with_extension_metadata_and_safety(
         model,
         extension_metadata,
+        dangerously_bypass_permissions,
     ));
 
     let stdout = tokio::io::stdout().compat_write();
@@ -4739,6 +4767,7 @@ pub async fn run_server(
     agent_id: Option<&str>,
     cwd: &std::path::Path,
     tls: Option<crate::control_tls::ControlTlsConfig>,
+    dangerously_bypass_permissions: bool,
 ) -> anyhow::Result<()> {
     use std::sync::Arc;
     use tokio_util::sync::CancellationToken;
@@ -4758,6 +4787,7 @@ pub async fn run_server(
         model: model.to_string(),
         cwd: std::fs::canonicalize(cwd).unwrap_or_else(|_| cwd.to_path_buf()),
         agent_id: agent_id.map(String::from),
+        dangerously_bypass_permissions,
         active_connections: Arc::new(std::sync::atomic::AtomicU64::new(0)),
         shutdown: shutdown.clone(),
     };

--- a/core/crates/omegon/src/acp_worker.rs
+++ b/core/crates/omegon/src/acp_worker.rs
@@ -152,6 +152,7 @@ pub fn spawn_worker(
     model: String,
     cwd: PathBuf,
     host_ctx: Option<crate::host_context::HostContext>,
+    dangerously_bypass_permissions: bool,
 ) -> WorkerHandle {
     let (request_tx, request_rx) = mpsc::channel::<WorkerRequest>(16);
     let (event_tx, event_rx) = tokio::sync::broadcast::channel::<WorkerEvent>(256);
@@ -179,6 +180,7 @@ pub fn spawn_worker(
                     event_tx,
                     secrets_tx,
                     host_ctx,
+                    dangerously_bypass_permissions,
                 ),
             );
         })
@@ -201,6 +203,7 @@ async fn worker_loop(
     event_tx: tokio::sync::broadcast::Sender<WorkerEvent>,
     secrets_tx: tokio::sync::oneshot::Sender<std::sync::Arc<omegon_secrets::SecretsManager>>,
     host_ctx: Option<crate::host_context::HostContext>,
+    dangerously_bypass_permissions: bool,
 ) {
     // Set the canonical project root env var so extensions can locate the workspace
     // without depending on embedder-specific names (FLYNT_VAULT, CODEX_VAULT).
@@ -561,6 +564,7 @@ async fn worker_loop(
                     &secrets,
                     workspace_ctx(&cwd, &session_id, &instance_id),
                     &mut bus,
+                    dangerously_bypass_permissions,
                 )
                 .await;
                 // Persona switch needs async bus.execute_tool — handle the marker
@@ -649,6 +653,7 @@ async fn handle_control_request(
     secrets: &std::sync::Arc<omegon_secrets::SecretsManager>,
     workspace_ctx: crate::workspace::control::WorkspaceControlContext<'_>,
     bus: &mut crate::bus::EventBus,
+    dangerously_bypass_permissions: bool,
 ) -> String {
     let cwd = workspace_ctx.cwd;
     let parts: Vec<&str> = command.splitn(2, char::is_whitespace).collect();
@@ -1096,7 +1101,142 @@ async fn handle_control_request(
             "Auth status requires interactive terminal. Use `omegon auth status` in a shell.".into()
         }
 
-        _ => format!("Unknown control request: {command}"),
+        _ => handle_registered_acp_command(bus, cmd, args, dangerously_bypass_permissions)
+            .unwrap_or_else(|| format!("Unknown control request: {command}")),
+    }
+}
+
+pub(crate) fn handle_registered_acp_command(
+    bus: &mut crate::bus::EventBus,
+    name: &str,
+    args: &str,
+    dangerously_bypass_permissions: bool,
+) -> Option<String> {
+    let definition = bus
+        .command_definitions()
+        .iter()
+        .map(|(_, definition)| definition)
+        .find(|definition| definition.name == name)?;
+
+    if !definition.availability.acp {
+        return Some(format!("Command /{name} is not available over ACP."));
+    }
+    if definition.safety.requires_confirmation && !dangerously_bypass_permissions {
+        return Some(format!(
+            "Command /{name} requires interactive confirmation and is unavailable over ACP."
+        ));
+    }
+
+    match bus.dispatch_command(name, args) {
+        omegon_traits::CommandResult::Display(text) => Some(text),
+        omegon_traits::CommandResult::Handled => Some(format!("/{name} handled.")),
+        omegon_traits::CommandResult::NotHandled => Some(format!(
+            "Command /{name} was registered but did not handle the request."
+        )),
+    }
+}
+
+#[cfg(test)]
+mod command_safety_tests {
+    use super::*;
+    use omegon_traits::{
+        CommandAvailability, CommandDefinition, CommandResult, CommandSafety, CommandSafetyClass,
+        Feature,
+    };
+    use std::sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    };
+
+    struct TestCommandFeature {
+        definition: CommandDefinition,
+        handled: Arc<AtomicBool>,
+    }
+
+    impl Feature for TestCommandFeature {
+        fn name(&self) -> &str {
+            "test-command"
+        }
+
+        fn commands(&self) -> Vec<CommandDefinition> {
+            vec![self.definition.clone()]
+        }
+
+        fn handle_command(&mut self, name: &str, args: &str) -> CommandResult {
+            if name == self.definition.name {
+                self.handled.store(true, Ordering::SeqCst);
+                CommandResult::Display(format!("handled {args}"))
+            } else {
+                CommandResult::NotHandled
+            }
+        }
+    }
+
+    fn bus_with_command(
+        availability: CommandAvailability,
+        requires_confirmation: bool,
+    ) -> (crate::bus::EventBus, Arc<AtomicBool>) {
+        let handled = Arc::new(AtomicBool::new(false));
+        let mut bus = crate::bus::EventBus::new();
+        bus.register(Box::new(TestCommandFeature {
+            definition: CommandDefinition {
+                name: "unsafe_test".into(),
+                description: "test command".into(),
+                subcommands: vec![],
+                availability,
+                safety: CommandSafety {
+                    class: CommandSafetyClass::StateChanging,
+                    requires_confirmation,
+                    prompt_injection_sensitive: false,
+                },
+            },
+            handled: handled.clone(),
+        }));
+        bus.finalize();
+        (bus, handled)
+    }
+
+    #[test]
+    fn acp_registered_command_requires_confirmation_without_bypass() {
+        let (mut bus, handled) = bus_with_command(CommandAvailability::ALL, true);
+
+        let response = handle_registered_acp_command(&mut bus, "unsafe_test", "args", false)
+            .expect("registered command response");
+
+        assert!(
+            response.contains("requires interactive confirmation"),
+            "{response}"
+        );
+        assert!(!handled.load(Ordering::SeqCst));
+    }
+
+    #[test]
+    fn acp_registered_command_bypass_allows_confirmation_required_command() {
+        let (mut bus, handled) = bus_with_command(CommandAvailability::ALL, true);
+
+        let response = handle_registered_acp_command(&mut bus, "unsafe_test", "args", true)
+            .expect("registered command response");
+
+        assert_eq!(response, "handled args");
+        assert!(handled.load(Ordering::SeqCst));
+    }
+
+    #[test]
+    fn acp_registered_command_availability_is_not_bypassed() {
+        let (mut bus, handled) = bus_with_command(
+            CommandAvailability {
+                tui: true,
+                cli: true,
+                acp: false,
+            },
+            true,
+        );
+
+        let response = handle_registered_acp_command(&mut bus, "unsafe_test", "args", true)
+            .expect("registered command response");
+
+        assert!(response.contains("not available over ACP"), "{response}");
+        assert!(!handled.load(Ordering::SeqCst));
     }
 }
 

--- a/core/crates/omegon/src/bus.rs
+++ b/core/crates/omegon/src/bus.rs
@@ -723,6 +723,8 @@ mod tests {
                 name: "notify".into(),
                 description: "Send a test notification".into(),
                 subcommands: vec![],
+                availability: omegon_traits::CommandAvailability::ALL,
+                safety: omegon_traits::CommandSafety::READ_ONLY,
             }]
         }
 

--- a/core/crates/omegon/src/cleave/context.rs
+++ b/core/crates/omegon/src/cleave/context.rs
@@ -451,7 +451,9 @@ fn build_finalization_section(submodules: &[String]) -> String {
 
     section.push_str("You MUST complete these steps before finishing:\n\n");
     section.push_str("1. Run all guardrail checks listed above and fix failures\n");
-    section.push_str("2. Commit your in-scope work with a clean source-plane state when you are done\n");
+    section.push_str(
+        "2. Commit your in-scope work with a clean source-plane state when you are done\n",
+    );
 
     if !submodules.is_empty() {
         section.push_str("3. **Submodule note**: if your scope crosses a submodule boundary, commit your edits normally. The orchestrator will handle submodule pointer updates during harvest/merge.\n");

--- a/core/crates/omegon/src/cleave/orchestrator.rs
+++ b/core/crates/omegon/src/cleave/orchestrator.rs
@@ -1669,290 +1669,318 @@ fn nanoid(len: usize) -> String {
 }
 
 fn write_fake_child(dir: &Path, name: &str, body: &str) -> PathBuf {
-        let path = dir.join(name);
-        std::fs::write(&path, body).unwrap();
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            let mut perms = std::fs::metadata(&path).unwrap().permissions();
-            perms.set_mode(0o755);
-            std::fs::set_permissions(&path, perms).unwrap();
-        }
-        path
+    let path = dir.join(name);
+    std::fs::write(&path, body).unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = std::fs::metadata(&path).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&path, perms).unwrap();
     }
+    path
+}
 
-    fn init_git_repo(dir: &Path) {
-        std::process::Command::new("git")
-            .args(["init"])
-            .current_dir(dir)
-            .output()
-            .expect("git init should run");
-        std::fs::write(dir.join("README.md"), "# cleave execution eval\n").unwrap();
-        let add = std::process::Command::new("git")
-            .args(["add", "README.md"])
-            .current_dir(dir)
-            .output()
-            .expect("git add should run");
-        assert!(add.status.success(), "git add failed: {}", String::from_utf8_lossy(&add.stderr));
-        let commit = std::process::Command::new("git")
-            .args([
-                "-c",
-                "user.name=Omegon Test",
-                "-c",
-                "user.email=omegon-test@example.invalid",
-                "commit",
-                "-m",
-                "initial",
-            ])
-            .current_dir(dir)
-            .output()
-            .expect("git commit should run");
-        assert!(
-            commit.status.success(),
-            "git commit failed: {}",
-            String::from_utf8_lossy(&commit.stderr)
-        );
+fn init_git_repo(dir: &Path) {
+    std::process::Command::new("git")
+        .args(["init"])
+        .current_dir(dir)
+        .output()
+        .expect("git init should run");
+    std::fs::write(dir.join("README.md"), "# cleave execution eval\n").unwrap();
+    let add = std::process::Command::new("git")
+        .args(["add", "README.md"])
+        .current_dir(dir)
+        .output()
+        .expect("git add should run");
+    assert!(
+        add.status.success(),
+        "git add failed: {}",
+        String::from_utf8_lossy(&add.stderr)
+    );
+    let commit = std::process::Command::new("git")
+        .args([
+            "-c",
+            "user.name=Omegon Test",
+            "-c",
+            "user.email=omegon-test@example.invalid",
+            "commit",
+            "-m",
+            "initial",
+        ])
+        .current_dir(dir)
+        .output()
+        .expect("git commit should run");
+    assert!(
+        commit.status.success(),
+        "git commit failed: {}",
+        String::from_utf8_lossy(&commit.stderr)
+    );
+}
+
+fn one_child_plan() -> crate::cleave::plan::CleavePlan {
+    crate::cleave::plan::CleavePlan {
+        children: vec![crate::cleave::plan::ChildPlan {
+            label: "alpha".into(),
+            description: "Run fake child".into(),
+            scope: vec!["README.md".into()],
+            depends_on: vec![],
+            model: Some("test:model".into()),
+            runtime: None,
+        }],
+        rationale: "execution eval".into(),
+        default_model: Some("test:model".into()),
     }
+}
 
-    fn one_child_plan() -> crate::cleave::plan::CleavePlan {
-        crate::cleave::plan::CleavePlan {
-            children: vec![crate::cleave::plan::ChildPlan {
-                label: "alpha".into(),
-                description: "Run fake child".into(),
-                scope: vec!["README.md".into()],
-                depends_on: vec![],
-                model: Some("test:model".into()),
-                runtime: None,
-            }],
-            rationale: "execution eval".into(),
-            default_model: Some("test:model".into()),
-        }
+fn test_config(
+    fake_child: PathBuf,
+    events: std::sync::Arc<std::sync::Mutex<Vec<crate::cleave::progress::ProgressEvent>>>,
+) -> CleaveConfig {
+    CleaveConfig {
+        agent_binary: fake_child,
+        bridge_path: PathBuf::new(),
+        node: String::new(),
+        model: "test:model".into(),
+        max_parallel: 1,
+        timeout_secs: 30,
+        idle_timeout_secs: 10,
+        max_turns: 3,
+        inventory: None,
+        inherited_env: vec![],
+        injected_env: vec![],
+        child_runtime: crate::cleave::CleaveChildRuntimeProfile::default(),
+        progress_sink: crate::cleave::progress::callback_progress_sink(move |event| {
+            events.lock().unwrap().push(event.clone());
+        }),
+        workflow: None,
+        sandbox: false,
     }
+}
 
-    fn test_config(
-        fake_child: PathBuf,
-        events: std::sync::Arc<std::sync::Mutex<Vec<crate::cleave::progress::ProgressEvent>>>,
-    ) -> CleaveConfig {
-        CleaveConfig {
-            agent_binary: fake_child,
-            bridge_path: PathBuf::new(),
-            node: String::new(),
-            model: "test:model".into(),
-            max_parallel: 1,
-            timeout_secs: 30,
-            idle_timeout_secs: 10,
-            max_turns: 3,
-            inventory: None,
-            inherited_env: vec![],
-            injected_env: vec![],
-            child_runtime: crate::cleave::CleaveChildRuntimeProfile::default(),
-            progress_sink: crate::cleave::progress::callback_progress_sink(move |event| {
-                events.lock().unwrap().push(event.clone());
-            }),
-            workflow: None,
-            sandbox: false,
-        }
+fn progress_from_events(
+    events: &[crate::cleave::progress::ProgressEvent],
+) -> crate::features::cleave::CleaveProgress {
+    let shared = std::sync::Arc::new(std::sync::Mutex::new(
+        crate::features::cleave::CleaveProgress::default(),
+    ));
+    for event in events {
+        crate::features::cleave::apply_progress_event(&shared, event);
     }
+    shared.lock().unwrap().clone()
+}
 
+#[tokio::test]
+async fn run_cleave_executes_injected_child_successfully() {
+    let repo = tempfile::tempdir().unwrap();
+    init_git_repo(repo.path());
+    let workspace = tempfile::tempdir().unwrap();
+    let fake_child = write_fake_child(
+        repo.path(),
+        "fake-cleave-success.sh",
+        "#!/bin/sh\necho cleave-child-ok\n",
+    );
+    let events = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+    let config = test_config(fake_child, std::sync::Arc::clone(&events));
 
+    let result = run_cleave(
+        &one_child_plan(),
+        "prove cleave child execution",
+        repo.path(),
+        workspace.path(),
+        &config,
+        CancellationToken::new(),
+        None,
+    )
+    .await
+    .unwrap();
 
-    fn progress_from_events(
-        events: &[crate::cleave::progress::ProgressEvent],
-    ) -> crate::features::cleave::CleaveProgress {
-        let shared = std::sync::Arc::new(std::sync::Mutex::new(
-            crate::features::cleave::CleaveProgress::default(),
-        ));
-        for event in events {
-            crate::features::cleave::apply_progress_event(&shared, event);
-        }
-        shared.lock().unwrap().clone()
-    }
+    assert_eq!(result.state.children.len(), 1);
+    let child = &result.state.children[0];
+    assert_eq!(
+        child.status,
+        crate::cleave::state::ChildStatus::Completed,
+        "child failed unexpectedly: {:?}",
+        child.error
+    );
+    assert!(
+        child
+            .stdout
+            .as_deref()
+            .unwrap_or_default()
+            .contains("cleave-child-ok")
+    );
+    assert!(workspace.path().join("state.json").exists());
+    assert!(workspace.path().join("0-task.md").exists());
+    let events = events.lock().unwrap();
+    assert!(events.iter().any(|event| matches!(event, crate::cleave::progress::ProgressEvent::ChildSpawned { child, .. } if child == "alpha")));
+    assert!(events.iter().any(|event| matches!(event, crate::cleave::progress::ProgressEvent::ChildStatus { child, status: crate::cleave::progress::ChildProgressStatus::Completed, .. } if child == "alpha")));
+    assert!(result.merge_results.iter().any(|(label, outcome)| {
+        label == "alpha" && matches!(outcome, MergeOutcome::NoChanges | MergeOutcome::Success)
+    }));
+}
 
-    #[tokio::test]
-    async fn run_cleave_executes_injected_child_successfully() {
-        let repo = tempfile::tempdir().unwrap();
-        init_git_repo(repo.path());
-        let workspace = tempfile::tempdir().unwrap();
-        let fake_child = write_fake_child(
-            repo.path(),
-            "fake-cleave-success.sh",
-            "#!/bin/sh\necho cleave-child-ok\n",
-        );
-        let events = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
-        let config = test_config(fake_child, std::sync::Arc::clone(&events));
+#[tokio::test]
+async fn run_cleave_times_out_and_kills_silent_child() {
+    let repo = tempfile::tempdir().unwrap();
+    init_git_repo(repo.path());
+    let workspace = tempfile::tempdir().unwrap();
+    let fake_child = write_fake_child(
+        repo.path(),
+        "fake-cleave-silent-timeout.sh",
+        "#!/bin/sh\nexec sleep 10\n",
+    );
+    let events = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+    let mut config = test_config(fake_child, std::sync::Arc::clone(&events));
+    config.timeout_secs = 1;
+    config.idle_timeout_secs = 30;
 
-        let result = run_cleave(
-            &one_child_plan(),
-            "prove cleave child execution",
-            repo.path(),
-            workspace.path(),
-            &config,
-            CancellationToken::new(),
-            None,
-        )
-        .await
+    let result = run_cleave(
+        &one_child_plan(),
+        "prove cleave child wall timeout",
+        repo.path(),
+        workspace.path(),
+        &config,
+        CancellationToken::new(),
+        None,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(result.state.children.len(), 1);
+    let child = &result.state.children[0];
+    assert_eq!(child.status, crate::cleave::state::ChildStatus::Failed);
+    assert!(
+        child
+            .error
+            .as_deref()
+            .unwrap_or_default()
+            .contains("Wall-clock timeout"),
+        "unexpected child error: {:?}",
+        child.error
+    );
+    let events = events.lock().unwrap();
+    assert!(events.iter().any(|event| matches!(event, crate::cleave::progress::ProgressEvent::ChildStatus { child, status: crate::cleave::progress::ChildProgressStatus::Failed, error: Some(error), .. } if child == "alpha" && error.contains("Wall-clock timeout"))));
+    let progress = progress_from_events(&events);
+    assert!(!progress.active, "timeout should clear active progress");
+    assert_eq!(progress.failed, 1);
+    let child_progress = progress
+        .children
+        .iter()
+        .find(|c| c.label == "alpha")
         .unwrap();
+    assert_eq!(child_progress.status, "failed");
+    assert_eq!(child_progress.pid, None);
+    assert_eq!(child_progress.supervision_mode, None);
+}
 
-        assert_eq!(result.state.children.len(), 1);
-        let child = &result.state.children[0];
-        assert_eq!(
-            child.status,
-            crate::cleave::state::ChildStatus::Completed,
-            "child failed unexpectedly: {:?}",
-            child.error
-        );
-        assert!(child.stdout.as_deref().unwrap_or_default().contains("cleave-child-ok"));
-        assert!(workspace.path().join("state.json").exists());
-        assert!(workspace.path().join("0-task.md").exists());
-        let events = events.lock().unwrap();
-        assert!(events.iter().any(|event| matches!(event, crate::cleave::progress::ProgressEvent::ChildSpawned { child, .. } if child == "alpha")));
-        assert!(events.iter().any(|event| matches!(event, crate::cleave::progress::ProgressEvent::ChildStatus { child, status: crate::cleave::progress::ChildProgressStatus::Completed, .. } if child == "alpha")));
-        assert!(result.merge_results.iter().any(|(label, outcome)| {
-            label == "alpha" && matches!(outcome, MergeOutcome::NoChanges | MergeOutcome::Success)
-        }));
-    }
+#[tokio::test]
+async fn run_cleave_cancellation_kills_running_child() {
+    let repo = tempfile::tempdir().unwrap();
+    init_git_repo(repo.path());
+    let workspace = tempfile::tempdir().unwrap();
+    let fake_child = write_fake_child(
+        repo.path(),
+        "fake-cleave-cancel.sh",
+        "#!/bin/sh\nexec sleep 10\n",
+    );
+    let events = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+    let config = test_config(fake_child, std::sync::Arc::clone(&events));
+    let cancel = CancellationToken::new();
+    let cancel_clone = cancel.clone();
+    tokio::spawn(async move {
+        tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
+        cancel_clone.cancel();
+    });
 
+    let result = run_cleave(
+        &one_child_plan(),
+        "prove cleave child cancellation",
+        repo.path(),
+        workspace.path(),
+        &config,
+        cancel,
+        None,
+    )
+    .await
+    .unwrap();
 
-
-    #[tokio::test]
-    async fn run_cleave_times_out_and_kills_silent_child() {
-        let repo = tempfile::tempdir().unwrap();
-        init_git_repo(repo.path());
-        let workspace = tempfile::tempdir().unwrap();
-        let fake_child = write_fake_child(
-            repo.path(),
-            "fake-cleave-silent-timeout.sh",
-            "#!/bin/sh\nexec sleep 10\n",
-        );
-        let events = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
-        let mut config = test_config(fake_child, std::sync::Arc::clone(&events));
-        config.timeout_secs = 1;
-        config.idle_timeout_secs = 30;
-
-        let result = run_cleave(
-            &one_child_plan(),
-            "prove cleave child wall timeout",
-            repo.path(),
-            workspace.path(),
-            &config,
-            CancellationToken::new(),
-            None,
-        )
-        .await
+    assert_eq!(result.state.children.len(), 1);
+    let child = &result.state.children[0];
+    assert_eq!(child.status, crate::cleave::state::ChildStatus::Failed);
+    assert!(
+        child
+            .error
+            .as_deref()
+            .unwrap_or_default()
+            .contains("Cancelled"),
+        "unexpected child error: {:?}",
+        child.error
+    );
+    let events = events.lock().unwrap();
+    assert!(events.iter().any(|event| matches!(event, crate::cleave::progress::ProgressEvent::ChildStatus { child, status: crate::cleave::progress::ChildProgressStatus::Failed, error: Some(error), .. } if child == "alpha" && error.contains("Cancelled"))));
+    let progress = progress_from_events(&events);
+    assert!(
+        !progress.active,
+        "cancellation should clear active progress"
+    );
+    assert_eq!(progress.failed, 1);
+    let child_progress = progress
+        .children
+        .iter()
+        .find(|c| c.label == "alpha")
         .unwrap();
+    assert_eq!(child_progress.status, "failed");
+    assert_eq!(child_progress.pid, None);
+    assert_eq!(child_progress.supervision_mode, None);
+}
 
-        assert_eq!(result.state.children.len(), 1);
-        let child = &result.state.children[0];
-        assert_eq!(child.status, crate::cleave::state::ChildStatus::Failed);
-        assert!(
-            child
-                .error
-                .as_deref()
-                .unwrap_or_default()
-                .contains("Wall-clock timeout"),
-            "unexpected child error: {:?}",
-            child.error
-        );
-        let events = events.lock().unwrap();
-        assert!(events.iter().any(|event| matches!(event, crate::cleave::progress::ProgressEvent::ChildStatus { child, status: crate::cleave::progress::ChildProgressStatus::Failed, error: Some(error), .. } if child == "alpha" && error.contains("Wall-clock timeout"))));
-        let progress = progress_from_events(&events);
-        assert!(!progress.active, "timeout should clear active progress");
-        assert_eq!(progress.failed, 1);
-        let child_progress = progress.children.iter().find(|c| c.label == "alpha").unwrap();
-        assert_eq!(child_progress.status, "failed");
-        assert_eq!(child_progress.pid, None);
-        assert_eq!(child_progress.supervision_mode, None);
-    }
+#[tokio::test]
+async fn run_cleave_records_injected_child_failure() {
+    let repo = tempfile::tempdir().unwrap();
+    init_git_repo(repo.path());
+    let workspace = tempfile::tempdir().unwrap();
+    let fake_child = write_fake_child(
+        repo.path(),
+        "fake-cleave-fail.sh",
+        "#!/bin/sh\necho cleave child failed >&2\nexit 9\n",
+    );
+    let events = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+    let config = test_config(fake_child, std::sync::Arc::clone(&events));
 
-    #[tokio::test]
-    async fn run_cleave_cancellation_kills_running_child() {
-        let repo = tempfile::tempdir().unwrap();
-        init_git_repo(repo.path());
-        let workspace = tempfile::tempdir().unwrap();
-        let fake_child = write_fake_child(
-            repo.path(),
-            "fake-cleave-cancel.sh",
-            "#!/bin/sh\nexec sleep 10\n",
-        );
-        let events = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
-        let config = test_config(fake_child, std::sync::Arc::clone(&events));
-        let cancel = CancellationToken::new();
-        let cancel_clone = cancel.clone();
-        tokio::spawn(async move {
-            tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
-            cancel_clone.cancel();
-        });
+    let result = run_cleave(
+        &one_child_plan(),
+        "prove cleave child failure reporting",
+        repo.path(),
+        workspace.path(),
+        &config,
+        CancellationToken::new(),
+        None,
+    )
+    .await
+    .unwrap();
 
-        let result = run_cleave(
-            &one_child_plan(),
-            "prove cleave child cancellation",
-            repo.path(),
-            workspace.path(),
-            &config,
-            cancel,
-            None,
-        )
-        .await
-        .unwrap();
-
-        assert_eq!(result.state.children.len(), 1);
-        let child = &result.state.children[0];
-        assert_eq!(child.status, crate::cleave::state::ChildStatus::Failed);
-        assert!(
-            child.error.as_deref().unwrap_or_default().contains("Cancelled"),
-            "unexpected child error: {:?}",
-            child.error
-        );
-        let events = events.lock().unwrap();
-        assert!(events.iter().any(|event| matches!(event, crate::cleave::progress::ProgressEvent::ChildStatus { child, status: crate::cleave::progress::ChildProgressStatus::Failed, error: Some(error), .. } if child == "alpha" && error.contains("Cancelled"))));
-        let progress = progress_from_events(&events);
-        assert!(!progress.active, "cancellation should clear active progress");
-        assert_eq!(progress.failed, 1);
-        let child_progress = progress.children.iter().find(|c| c.label == "alpha").unwrap();
-        assert_eq!(child_progress.status, "failed");
-        assert_eq!(child_progress.pid, None);
-        assert_eq!(child_progress.supervision_mode, None);
-    }
-
-    #[tokio::test]
-    async fn run_cleave_records_injected_child_failure() {
-        let repo = tempfile::tempdir().unwrap();
-        init_git_repo(repo.path());
-        let workspace = tempfile::tempdir().unwrap();
-        let fake_child = write_fake_child(
-            repo.path(),
-            "fake-cleave-fail.sh",
-            "#!/bin/sh\necho cleave child failed >&2\nexit 9\n",
-        );
-        let events = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
-        let config = test_config(fake_child, std::sync::Arc::clone(&events));
-
-        let result = run_cleave(
-            &one_child_plan(),
-            "prove cleave child failure reporting",
-            repo.path(),
-            workspace.path(),
-            &config,
-            CancellationToken::new(),
-            None,
-        )
-        .await
-        .unwrap();
-
-        assert_eq!(result.state.children.len(), 1);
-        let child = &result.state.children[0];
-        assert_eq!(child.status, crate::cleave::state::ChildStatus::Failed);
-        assert!(child.error.as_deref().unwrap_or_default().contains("cleave child failed"));
-        let events = events.lock().unwrap();
-        assert!(events.iter().any(|event| matches!(event, crate::cleave::progress::ProgressEvent::ChildSpawned { child, .. } if child == "alpha")));
-        assert!(events.iter().any(|event| matches!(event, crate::cleave::progress::ProgressEvent::ChildStatus { child, status: crate::cleave::progress::ChildProgressStatus::Failed, .. } if child == "alpha")));
-        assert!(
-            result.merge_results.is_empty()
-                || result
-                    .merge_results
-                    .iter()
-                    .any(|(label, outcome)| label == "alpha" && matches!(outcome, MergeOutcome::Skipped(_))),
-            "failed children should not be merged: {:?}",
-            result.merge_results
-        );
-    }
+    assert_eq!(result.state.children.len(), 1);
+    let child = &result.state.children[0];
+    assert_eq!(child.status, crate::cleave::state::ChildStatus::Failed);
+    assert!(
+        child
+            .error
+            .as_deref()
+            .unwrap_or_default()
+            .contains("cleave child failed")
+    );
+    let events = events.lock().unwrap();
+    assert!(events.iter().any(|event| matches!(event, crate::cleave::progress::ProgressEvent::ChildSpawned { child, .. } if child == "alpha")));
+    assert!(events.iter().any(|event| matches!(event, crate::cleave::progress::ProgressEvent::ChildStatus { child, status: crate::cleave::progress::ChildProgressStatus::Failed, .. } if child == "alpha")));
+    assert!(
+        result.merge_results.is_empty()
+            || result
+                .merge_results
+                .iter()
+                .any(|(label, outcome)| label == "alpha"
+                    && matches!(outcome, MergeOutcome::Skipped(_))),
+        "failed children should not be merged: {:?}",
+        result.merge_results
+    );
+}

--- a/core/crates/omegon/src/features/cleave.rs
+++ b/core/crates/omegon/src/features/cleave.rs
@@ -729,7 +729,6 @@ impl CleaveFeature {
         self.progress.lock().unwrap().clone()
     }
 
-
     fn render_status(progress: &CleaveProgress) -> String {
         if !progress.active && progress.total_children == 0 {
             return "No active cleave run.".into();
@@ -1314,6 +1313,8 @@ impl Feature for CleaveFeature {
             name: "cleave".into(),
             description: "Show cleave status or trigger decomposition".into(),
             subcommands: vec!["status".into(), "cancel <label>".into()],
+            availability: omegon_traits::CommandAvailability::ALL,
+            safety: omegon_traits::CommandSafety::STATE_CHANGING,
         }]
     }
 
@@ -2472,7 +2473,6 @@ mod assessment_tests {
         assert_eq!(progress.failed, 1);
     }
 
-
     #[test]
     fn cleave_status_render_exposes_child_runtime_activity_and_tasks() {
         let mut progress = CleaveProgress {
@@ -2490,8 +2490,14 @@ mod assessment_tests {
                 last_tool: Some("bash".into()),
                 last_turn: Some(3),
                 tasks: vec![
-                    crate::cleave::progress::ChildTaskItem { description: "Inspect".into(), done: true },
-                    crate::cleave::progress::ChildTaskItem { description: "Patch".into(), done: false },
+                    crate::cleave::progress::ChildTaskItem {
+                        description: "Inspect".into(),
+                        done: true,
+                    },
+                    crate::cleave::progress::ChildTaskItem {
+                        description: "Patch".into(),
+                        done: false,
+                    },
                 ],
                 tasks_done: 1,
                 started_at: None,
@@ -2506,7 +2512,10 @@ mod assessment_tests {
 
         let rendered = CleaveFeature::render_status(&progress);
 
-        assert!(rendered.contains("Cleave active: 0/1 children"), "{rendered}");
+        assert!(
+            rendered.contains("Cleave active: 0/1 children"),
+            "{rendered}"
+        );
         assert!(rendered.contains("alpha [running]"), "{rendered}");
         assert!(rendered.contains("pid=1234"), "{rendered}");
         assert!(rendered.contains("supervision=Attached"), "{rendered}");
@@ -2519,8 +2528,10 @@ mod assessment_tests {
         progress.completed = 1;
         progress.children[0].status = "completed".into();
         let rendered = CleaveFeature::render_status(&progress);
-        assert!(rendered.contains("Last cleave: 1 completed, 0 failed of 1"), "{rendered}");
+        assert!(
+            rendered.contains("Last cleave: 1 completed, 0 failed of 1"),
+            "{rendered}"
+        );
         assert!(rendered.contains("alpha [completed]"), "{rendered}");
     }
-
 }

--- a/core/crates/omegon/src/features/clipboard.rs
+++ b/core/crates/omegon/src/features/clipboard.rs
@@ -52,6 +52,8 @@ impl Feature for ClipboardFeature {
             name: "clipboard".into(),
             description: "Manage clipboard paste retention (subcommands: prune)".into(),
             subcommands: vec!["prune".into()],
+            availability: omegon_traits::CommandAvailability::ALL,
+            safety: omegon_traits::CommandSafety::DESTRUCTIVE,
         }]
     }
 

--- a/core/crates/omegon/src/features/delegate.rs
+++ b/core/crates/omegon/src/features/delegate.rs
@@ -1672,14 +1672,22 @@ impl Feature for DelegateFeature {
                     status_text.push_str(&format!(
                         "| {} | {} | {} | {} | {} | {} | {} |
 ",
-                        child.task_id, agent, status, last_tool, last_turn, task_progress, description
+                        child.task_id,
+                        agent,
+                        status,
+                        last_tool,
+                        last_turn,
+                        task_progress,
+                        description
                     ));
                 }
 
                 if snapshot.children.is_empty() {
-                    status_text.push_str("
+                    status_text.push_str(
+                        "
 No delegate tasks found.
-");
+",
+                    );
                 }
 
                 Ok(ToolResult {
@@ -1713,6 +1721,8 @@ No delegate tasks found.
             name: crate::tool_registry::delegate::DELEGATE.to_string(),
             description: "delegate task management".to_string(),
             subcommands: vec!["status".to_string()],
+            availability: omegon_traits::CommandAvailability::ALL,
+            safety: omegon_traits::CommandSafety::STATE_CHANGING,
         }]
     }
 
@@ -2352,7 +2362,9 @@ This agent runs in write mode and can modify files.
             completed_at: None,
             last_tool: None,
             last_turn: None,
-            tasks: crate::cleave::progress::extract_task_items("- [ ] Inspect files\n- [ ] Report findings"),
+            tasks: crate::cleave::progress::extract_task_items(
+                "- [ ] Inspect files\n- [ ] Report findings",
+            ),
         });
         store.update_task_live_state("delegate_1", Some("read".into()), Some(2));
         store.store_task(DelegateTask {
@@ -2371,7 +2383,9 @@ This agent runs in write mode and can modify files.
             task_id: "delegate_3".into(),
             agent_name: Some("patch".into()),
             task_description: "Patch bug".into(),
-            status: DelegateTaskStatus::Failed { error: "child exited".into() },
+            status: DelegateTaskStatus::Failed {
+                error: "child exited".into(),
+            },
             result: None,
             started_at: now,
             completed_at: Some(now),
@@ -2387,19 +2401,39 @@ This agent runs in write mode and can modify files.
         assert_eq!(snapshot.completed, 1);
         assert_eq!(snapshot.failed, 1);
         assert_eq!(snapshot.children.len(), 3);
-        let running = snapshot.children.iter().find(|c| c.task_id == "delegate_1").unwrap();
+        let running = snapshot
+            .children
+            .iter()
+            .find(|c| c.task_id == "delegate_1")
+            .unwrap();
         assert_eq!(running.status, "running");
         assert_eq!(running.last_tool.as_deref(), Some("read"));
         assert_eq!(running.last_turn, Some(2));
         assert_eq!(running.tasks_done, 1);
-        let completed = snapshot.children.iter().find(|c| c.task_id == "delegate_2").unwrap();
+        let completed = snapshot
+            .children
+            .iter()
+            .find(|c| c.task_id == "delegate_2")
+            .unwrap();
         assert_eq!(completed.status, "completed");
-        assert!(completed.result_summary.as_ref().unwrap().starts_with("Validation passed"));
-        assert!(completed.result_summary.as_ref().unwrap().len() < "Validation passed with a long enough result summary to truncate".len());
-        let failed = snapshot.children.iter().find(|c| c.task_id == "delegate_3").unwrap();
+        assert!(
+            completed
+                .result_summary
+                .as_ref()
+                .unwrap()
+                .starts_with("Validation passed")
+        );
+        assert!(
+            completed.result_summary.as_ref().unwrap().len()
+                < "Validation passed with a long enough result summary to truncate".len()
+        );
+        let failed = snapshot
+            .children
+            .iter()
+            .find(|c| c.task_id == "delegate_3")
+            .unwrap();
         assert_eq!(failed.status, "failed");
     }
-
 
     fn write_fake_child(dir: &Path, name: &str, body: &str) -> PathBuf {
         let path = dir.join(name);
@@ -2484,7 +2518,6 @@ This agent runs in write mode and can modify files.
         assert!(err.contains("test:model"), "{err}");
     }
 
-
     #[tokio::test]
     async fn delegate_runner_times_out_and_kills_silent_child() {
         let temp_dir = TempDir::new().unwrap();
@@ -2527,14 +2560,20 @@ This agent runs in write mode and can modify files.
             .unwrap_err()
             .to_string();
 
-        assert!(err.contains("Delegate wall-clock timeout after 1s"), "{err}");
+        assert!(
+            err.contains("Delegate wall-clock timeout after 1s"),
+            "{err}"
+        );
         store.update_task_status(
             "delegate_timeout",
             DelegateTaskStatus::Failed { error: err.clone() },
             Some(err),
         );
         let progress = store.progress_snapshot();
-        assert!(!progress.active, "timeout should clear active delegate progress");
+        assert!(
+            !progress.active,
+            "timeout should clear active delegate progress"
+        );
         assert_eq!(progress.running, 0);
         assert_eq!(progress.failed, 1);
         let child = progress
@@ -2543,9 +2582,14 @@ This agent runs in write mode and can modify files.
             .find(|child| child.task_id == "delegate_timeout")
             .unwrap();
         assert_eq!(child.status, "failed");
-        assert!(child.result_summary.as_deref().unwrap_or_default().contains("Delegate wall-clock timeout"));
+        assert!(
+            child
+                .result_summary
+                .as_deref()
+                .unwrap_or_default()
+                .contains("Delegate wall-clock timeout")
+        );
     }
-
 
     #[tokio::test]
     async fn delegate_runner_idle_timeout_kills_quiet_child_after_initial_activity() {
@@ -2600,7 +2644,10 @@ exec sleep 10
             Some(err),
         );
         let progress = store.progress_snapshot();
-        assert!(!progress.active, "idle timeout should clear active delegate progress");
+        assert!(
+            !progress.active,
+            "idle timeout should clear active delegate progress"
+        );
         assert_eq!(progress.running, 0);
         assert_eq!(progress.failed, 1);
         let child = progress
@@ -2609,11 +2656,12 @@ exec sleep 10
             .find(|child| child.task_id == "delegate_idle_timeout")
             .unwrap();
         assert_eq!(child.status, "failed");
-        assert!(child
-            .result_summary
-            .as_deref()
-            .unwrap_or_default()
-            .contains("Delegate idle timeout"));
+        assert!(
+            child
+                .result_summary
+                .as_deref()
+                .unwrap_or_default()
+                .contains("Delegate idle timeout")
+        );
     }
-
 }

--- a/core/crates/omegon/src/features/lifecycle.rs
+++ b/core/crates/omegon/src/features/lifecycle.rs
@@ -1241,16 +1241,22 @@ impl Feature for LifecycleFeature {
                 name: "design-focus".into(),
                 description: "Pin a design node (inject its context) — use via agent tool, not operator command".into(),
                 subcommands: self.provider.lock().unwrap().all_nodes().keys().cloned().collect(),
+            availability: omegon_traits::CommandAvailability::ALL,
+            safety: omegon_traits::CommandSafety::STATE_CHANGING,
             },
             CommandDefinition {
                 name: "design-unfocus".into(),
                 description: "Clear design node pin — use via agent tool, not operator command".into(),
                 subcommands: vec![],
+            availability: omegon_traits::CommandAvailability::ALL,
+            safety: omegon_traits::CommandSafety::STATE_CHANGING,
             },
             CommandDefinition {
                 name: "design".into(),
                 description: "Show design tree summary".into(),
                 subcommands: vec!["list".into(), "frontier".into(), "ready".into()],
+            availability: omegon_traits::CommandAvailability::ALL,
+            safety: omegon_traits::CommandSafety::READ_ONLY,
             },
         ]
     }

--- a/core/crates/omegon/src/features/model_budget.rs
+++ b/core/crates/omegon/src/features/model_budget.rs
@@ -269,32 +269,44 @@ impl Feature for ModelBudget {
                 name: "gloriana".into(),
                 description: "Switch to gloriana tier (deep reasoning)".into(),
                 subcommands: vec![],
+                availability: omegon_traits::CommandAvailability::ALL,
+                safety: omegon_traits::CommandSafety::STATE_CHANGING,
             },
             CommandDefinition {
                 name: "victory".into(),
                 description: "Switch to victory tier (capable coding)".into(),
                 subcommands: vec![],
+                availability: omegon_traits::CommandAvailability::ALL,
+                safety: omegon_traits::CommandSafety::STATE_CHANGING,
             },
             CommandDefinition {
                 name: "retribution".into(),
                 description: "Switch to retribution tier (fast/cheap)".into(),
                 subcommands: vec![],
+                availability: omegon_traits::CommandAvailability::ALL,
+                safety: omegon_traits::CommandSafety::STATE_CHANGING,
             },
             // Aliases for familiarity
             CommandDefinition {
                 name: "opus".into(),
                 description: "Switch to gloriana/opus tier".into(),
                 subcommands: vec![],
+                availability: omegon_traits::CommandAvailability::ALL,
+                safety: omegon_traits::CommandSafety::STATE_CHANGING,
             },
             CommandDefinition {
                 name: "sonnet".into(),
                 description: "Switch to victory/sonnet tier".into(),
                 subcommands: vec![],
+                availability: omegon_traits::CommandAvailability::ALL,
+                safety: omegon_traits::CommandSafety::STATE_CHANGING,
             },
             CommandDefinition {
                 name: "haiku".into(),
                 description: "Switch to retribution/haiku tier".into(),
                 subcommands: vec![],
+                availability: omegon_traits::CommandAvailability::ALL,
+                safety: omegon_traits::CommandSafety::STATE_CHANGING,
             },
         ]
     }

--- a/core/crates/omegon/src/features/mutation.rs
+++ b/core/crates/omegon/src/features/mutation.rs
@@ -1739,6 +1739,8 @@ impl Feature for MutationFeature {
             name: "mutation".into(),
             description: "Mutation system — burn metrics, learned skills, diagnostics".into(),
             subcommands: vec!["stats".into(), "review".into(), "config".into()],
+            availability: omegon_traits::CommandAvailability::ALL,
+            safety: omegon_traits::CommandSafety::STATE_CHANGING,
         }]
     }
 

--- a/core/crates/omegon/src/features/session_log.rs
+++ b/core/crates/omegon/src/features/session_log.rs
@@ -829,6 +829,8 @@ impl Feature for SessionLog {
             name: "session-log".into(),
             description: "Read .omegon/agent-journal.md entries and summarize usage".into(),
             subcommands: vec!["read".into(), "usage".into()],
+            availability: omegon_traits::CommandAvailability::ALL,
+            safety: omegon_traits::CommandSafety::READ_ONLY,
         }]
     }
 

--- a/core/crates/omegon/src/features/usage.rs
+++ b/core/crates/omegon/src/features/usage.rs
@@ -99,6 +99,8 @@ impl Feature for UsageFeature {
             name: "usage".into(),
             description: "Show current provider usage telemetry and advisory".into(),
             subcommands: vec![],
+            availability: omegon_traits::CommandAvailability::ALL,
+            safety: omegon_traits::CommandSafety::READ_ONLY,
         }]
     }
 

--- a/core/crates/omegon/src/loop.rs
+++ b/core/crates/omegon/src/loop.rs
@@ -1259,7 +1259,8 @@ pub async fn run(
 
         // Push tool results to conversation and update intent
         let mut results = results;
-        let plan_snapshot_before = work_plan_snapshot_with_lifecycle(&conversation.intent, &config.cwd);
+        let plan_snapshot_before =
+            work_plan_snapshot_with_lifecycle(&conversation.intent, &config.cwd);
         conversation
             .intent
             .update_from_tools(dispatch_calls, &results);
@@ -1267,7 +1268,8 @@ pub async fn run(
         for result in &results {
             conversation.push_tool_result(result.clone());
         }
-        let plan_snapshot_after = work_plan_snapshot_with_lifecycle(&conversation.intent, &config.cwd);
+        let plan_snapshot_after =
+            work_plan_snapshot_with_lifecycle(&conversation.intent, &config.cwd);
 
         if let Some(message) = plan_status_notification(dispatch_calls, &conversation.intent) {
             let _ = events.send(AgentEvent::SystemNotification { message });

--- a/core/crates/omegon/src/main.rs
+++ b/core/crates/omegon/src/main.rs
@@ -1368,6 +1368,7 @@ async fn main() -> anyhow::Result<()> {
                 &cli.model,
                 agent.as_deref(),
                 tls.clone().into_config()?,
+                cli.dangerously_bypass_permissions,
             )
             .await
         }
@@ -1382,6 +1383,7 @@ async fn main() -> anyhow::Result<()> {
                 &cli.model,
                 None,
                 tls.clone().into_config()?,
+                cli.dangerously_bypass_permissions,
             )
             .await
         }
@@ -1460,12 +1462,18 @@ async fn main() -> anyhow::Result<()> {
                     agent.as_deref(),
                     &cli.cwd,
                     tls.clone().into_config()?,
+                    cli.dangerously_bypass_permissions,
                 )
                 .await
             } else {
                 let local = tokio::task::LocalSet::new();
                 local
-                    .run_until(acp::run(&cli.model, agent.as_deref(), &cli.cwd))
+                    .run_until(acp::run(
+                        &cli.model,
+                        agent.as_deref(),
+                        &cli.cwd,
+                        cli.dangerously_bypass_permissions,
+                    ))
                     .await
             }
         }
@@ -2193,6 +2201,7 @@ async fn run_embedded_command(
     model: &str,
     agent_id: Option<&str>,
     tls: Option<control_tls::ControlTlsConfig>,
+    dangerously_bypass_permissions: bool,
 ) -> anyhow::Result<()> {
     let cwd = std::fs::canonicalize(".")?;
 
@@ -2286,6 +2295,7 @@ async fn run_embedded_command(
         model: model.to_string(),
         cwd: cwd.clone(),
         agent_id: agent_id.map(String::from),
+        dangerously_bypass_permissions: dangerously_bypass_permissions,
         active_connections: std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0)),
         shutdown: global_cancel.clone(),
     };
@@ -4122,6 +4132,7 @@ async fn run_interactive_command(cli: &Cli) -> anyhow::Result<()> {
                     cli: &CliRuntimeView {
                         no_session: cli.no_session,
                         model: &cli.model,
+                        dangerously_bypass_permissions: cli.dangerously_bypass_permissions,
                     },
                 };
                 let response = control_runtime::execute_control(&mut ctx, request).await;
@@ -4512,6 +4523,7 @@ async fn run_interactive_command(cli: &Cli) -> anyhow::Result<()> {
                     cli: &CliRuntimeView {
                         no_session: cli.no_session,
                         model: &cli.model,
+                        dangerously_bypass_permissions: cli.dangerously_bypass_permissions,
                     },
                 };
                 let response = control_runtime::execute_control(
@@ -4541,6 +4553,7 @@ async fn run_interactive_command(cli: &Cli) -> anyhow::Result<()> {
                     cli: &CliRuntimeView {
                         no_session: cli.no_session,
                         model: &cli.model,
+                        dangerously_bypass_permissions: cli.dangerously_bypass_permissions,
                     },
                 };
                 let response = control_runtime::execute_control(
@@ -4581,6 +4594,7 @@ async fn run_interactive_command(cli: &Cli) -> anyhow::Result<()> {
                     &CliRuntimeView {
                         no_session: cli.no_session,
                         model: &cli.model,
+                        dangerously_bypass_permissions: cli.dangerously_bypass_permissions,
                     },
                     &events_tx,
                 )
@@ -4615,6 +4629,7 @@ async fn run_interactive_command(cli: &Cli) -> anyhow::Result<()> {
                     &CliRuntimeView {
                         no_session: cli.no_session,
                         model: &cli.model,
+                        dangerously_bypass_permissions: cli.dangerously_bypass_permissions,
                     },
                     &agent.cwd,
                     &provider,
@@ -5601,6 +5616,7 @@ pub(crate) struct InteractiveAgentHost {
 pub(crate) struct CliRuntimeView<'a> {
     pub(crate) no_session: bool,
     pub(crate) model: &'a str,
+    pub(crate) dangerously_bypass_permissions: bool,
 }
 
 fn interactive_resume_mode(cli: &Cli) -> Option<Option<&str>> {
@@ -6857,6 +6873,9 @@ async fn execute_remote_slash_command(
     use omegon_traits::SlashCommandResponse;
 
     let Some(command) = canonical_slash_command(name, args) else {
+        if let Some(response) = execute_registered_remote_command(runtime_state, cli, name, args) {
+            return response;
+        }
         return SlashCommandResponse {
             accepted: false,
             output: Some(format!(
@@ -6876,6 +6895,7 @@ async fn execute_remote_slash_command(
             cli: &CliRuntimeView {
                 no_session: cli.no_session,
                 model: &cli.model,
+                dangerously_bypass_permissions: cli.dangerously_bypass_permissions,
             },
         };
         return control_runtime::execute_control(&mut ctx, control_request).await;
@@ -6903,11 +6923,65 @@ async fn execute_remote_slash_command(
         return execute_plan_slash_command(runtime_state, command);
     }
 
+    if let Some(response) = execute_registered_remote_command(runtime_state, cli, name, args) {
+        return response;
+    }
+
     SlashCommandResponse {
         accepted: false,
         output: Some(format!(
             "Command /{name} is interactive-only or unavailable via remote slash execution."
         )),
+    }
+}
+
+fn execute_registered_remote_command(
+    runtime_state: &mut InteractiveAgentState,
+    cli: &Cli,
+    name: &str,
+    args: &str,
+) -> Option<omegon_traits::SlashCommandResponse> {
+    use omegon_traits::{CommandResult, SlashCommandResponse};
+
+    let definition = runtime_state
+        .bus
+        .command_definitions()
+        .iter()
+        .map(|(_, definition)| definition)
+        .find(|definition| definition.name == name)?;
+
+    if !definition.availability.cli {
+        return Some(SlashCommandResponse {
+            accepted: false,
+            output: Some(format!(
+                "Command /{name} is not available via CLI/remote slash execution."
+            )),
+        });
+    }
+    if definition.safety.requires_confirmation && !cli.dangerously_bypass_permissions {
+        return Some(SlashCommandResponse {
+            accepted: false,
+            output: Some(format!(
+                "Command /{name} requires interactive confirmation and is unavailable via remote slash execution."
+            )),
+        });
+    }
+
+    match runtime_state.bus.dispatch_command(name, args) {
+        CommandResult::Display(text) => Some(SlashCommandResponse {
+            accepted: true,
+            output: Some(text),
+        }),
+        CommandResult::Handled => Some(SlashCommandResponse {
+            accepted: true,
+            output: None,
+        }),
+        CommandResult::NotHandled => Some(SlashCommandResponse {
+            accepted: false,
+            output: Some(format!(
+                "Command /{name} was registered but did not handle the request."
+            )),
+        }),
     }
 }
 
@@ -7025,7 +7099,9 @@ Last completed plan
     }
 }
 
-fn work_plan_snapshot_with_lifecycle(intent: &crate::conversation::IntentDocument) -> serde_json::Value {
+fn work_plan_snapshot_with_lifecycle(
+    intent: &crate::conversation::IntentDocument,
+) -> serde_json::Value {
     let mut registry = intent.plan_registry();
     let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
     let repo_root = setup::find_project_root(&cwd);
@@ -9168,6 +9244,223 @@ mod tests {
         assert!(output.contains("anthropic"), "got: {output}");
         assert!(output.contains("openai-codex"), "got: {output}");
         assert!(!output.contains("ollama,"), "got: {output}");
+    }
+
+    struct TestRemoteCommandFeature {
+        definition: omegon_traits::CommandDefinition,
+        handled: std::sync::Arc<std::sync::atomic::AtomicBool>,
+    }
+
+    impl omegon_traits::Feature for TestRemoteCommandFeature {
+        fn name(&self) -> &str {
+            "test-remote-command"
+        }
+
+        fn commands(&self) -> Vec<omegon_traits::CommandDefinition> {
+            vec![self.definition.clone()]
+        }
+
+        fn handle_command(&mut self, name: &str, args: &str) -> omegon_traits::CommandResult {
+            if name == self.definition.name {
+                self.handled
+                    .store(true, std::sync::atomic::Ordering::SeqCst);
+                omegon_traits::CommandResult::Display(format!("handled {args}"))
+            } else {
+                omegon_traits::CommandResult::NotHandled
+            }
+        }
+    }
+
+    fn remote_command_definition(
+        availability: omegon_traits::CommandAvailability,
+        requires_confirmation: bool,
+    ) -> omegon_traits::CommandDefinition {
+        omegon_traits::CommandDefinition {
+            name: "unsafe_test".into(),
+            description: "test command".into(),
+            subcommands: vec![],
+            availability,
+            safety: omegon_traits::CommandSafety {
+                class: omegon_traits::CommandSafetyClass::StateChanging,
+                requires_confirmation,
+                prompt_injection_sensitive: false,
+            },
+        }
+    }
+
+    fn register_remote_test_command(
+        runtime_state: &mut InteractiveAgentState,
+        availability: omegon_traits::CommandAvailability,
+        requires_confirmation: bool,
+    ) -> std::sync::Arc<std::sync::atomic::AtomicBool> {
+        let handled = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        runtime_state
+            .bus
+            .register(Box::new(TestRemoteCommandFeature {
+                definition: remote_command_definition(availability, requires_confirmation),
+                handled: handled.clone(),
+            }));
+        runtime_state.bus.finalize();
+        handled
+    }
+
+    fn remote_command_test_context(
+        bypass: bool,
+    ) -> (
+        tokio::runtime::Runtime,
+        InteractiveAgentHost,
+        InteractiveAgentState,
+        broadcast::Sender<AgentEvent>,
+        settings::SharedSettings,
+        std::sync::Arc<tokio::sync::RwLock<Box<dyn LlmBridge>>>,
+        std::sync::Arc<tokio::sync::Mutex<Option<oneshot::Sender<String>>>>,
+        Cli,
+    ) {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let agent = test_agent_setup();
+        let (events_tx, _) = broadcast::channel(16);
+        let shared_settings = std::sync::Arc::new(std::sync::Mutex::new(settings::Settings::new(
+            "anthropic:claude-sonnet-4-6",
+        )));
+        let bridge = std::sync::Arc::new(tokio::sync::RwLock::new(Box::new(
+            crate::bridge::NullBridge,
+        ) as Box<dyn LlmBridge>));
+        let login_prompt_tx = std::sync::Arc::new(tokio::sync::Mutex::new(None));
+        let cli = if bypass {
+            Cli::try_parse_from(vec!["omegon", "--dangerously-bypass-permissions"]).unwrap()
+        } else {
+            Cli::try_parse_from(vec!["omegon"]).unwrap()
+        };
+        let (agent, runtime_state) = split_interactive_agent(agent);
+        (
+            rt,
+            agent,
+            runtime_state,
+            events_tx,
+            shared_settings,
+            bridge,
+            login_prompt_tx,
+            cli,
+        )
+    }
+
+    #[test]
+    fn remote_registered_command_requires_confirmation_without_bypass() {
+        let (
+            rt,
+            mut agent,
+            mut runtime_state,
+            events_tx,
+            shared_settings,
+            bridge,
+            login_prompt_tx,
+            cli,
+        ) = remote_command_test_context(false);
+        let handled = register_remote_test_command(
+            &mut runtime_state,
+            omegon_traits::CommandAvailability::ALL,
+            true,
+        );
+
+        let response = rt.block_on(execute_remote_slash_command(
+            &mut runtime_state,
+            &mut agent,
+            &events_tx,
+            &shared_settings,
+            &bridge,
+            &login_prompt_tx,
+            &cli,
+            "unsafe_test",
+            "args",
+        ));
+
+        assert!(!response.accepted);
+        assert!(
+            response
+                .output
+                .unwrap()
+                .contains("requires interactive confirmation")
+        );
+        assert!(!handled.load(std::sync::atomic::Ordering::SeqCst));
+    }
+
+    #[test]
+    fn remote_registered_command_bypass_allows_confirmation_required_command() {
+        let (
+            rt,
+            mut agent,
+            mut runtime_state,
+            events_tx,
+            shared_settings,
+            bridge,
+            login_prompt_tx,
+            cli,
+        ) = remote_command_test_context(true);
+        let handled = register_remote_test_command(
+            &mut runtime_state,
+            omegon_traits::CommandAvailability::ALL,
+            true,
+        );
+
+        let response = rt.block_on(execute_remote_slash_command(
+            &mut runtime_state,
+            &mut agent,
+            &events_tx,
+            &shared_settings,
+            &bridge,
+            &login_prompt_tx,
+            &cli,
+            "unsafe_test",
+            "args",
+        ));
+
+        assert!(response.accepted);
+        assert_eq!(response.output.as_deref(), Some("handled args"));
+        assert!(handled.load(std::sync::atomic::Ordering::SeqCst));
+    }
+
+    #[test]
+    fn remote_registered_command_availability_is_not_bypassed() {
+        let (
+            rt,
+            mut agent,
+            mut runtime_state,
+            events_tx,
+            shared_settings,
+            bridge,
+            login_prompt_tx,
+            cli,
+        ) = remote_command_test_context(true);
+        let handled = register_remote_test_command(
+            &mut runtime_state,
+            omegon_traits::CommandAvailability {
+                tui: true,
+                cli: false,
+                acp: true,
+            },
+            true,
+        );
+
+        let response = rt.block_on(execute_remote_slash_command(
+            &mut runtime_state,
+            &mut agent,
+            &events_tx,
+            &shared_settings,
+            &bridge,
+            &login_prompt_tx,
+            &cli,
+            "unsafe_test",
+            "args",
+        ));
+
+        assert!(!response.accepted);
+        assert!(
+            response
+                .output
+                .unwrap()
+                .contains("not available via CLI/remote slash execution")
+        );
+        assert!(!handled.load(std::sync::atomic::Ordering::SeqCst));
     }
 
     #[test]

--- a/core/crates/omegon/src/plan.rs
+++ b/core/crates/omegon/src/plan.rs
@@ -953,7 +953,10 @@ impl crate::conversation::IntentDocument {
         self.work_plan_snapshot_json_with_registry_entries(self.plan_registry().entries)
     }
 
-    pub fn work_plan_snapshot_json_with_registry_entries<I>(&self, registry_entries: I) -> serde_json::Value
+    pub fn work_plan_snapshot_json_with_registry_entries<I>(
+        &self,
+        registry_entries: I,
+    ) -> serde_json::Value
     where
         I: IntoIterator<Item = PlanRegistryEntry>,
     {

--- a/core/crates/omegon/src/providers.rs
+++ b/core/crates/omegon/src/providers.rs
@@ -4474,7 +4474,11 @@ mod tests {
         assert!(bounded_46.get("effort").is_none());
 
         let mut manual = json!({});
-        apply_anthropic_thinking(&mut manual, "anthropic:claude-haiku-4-5-20251001", Some("high"));
+        apply_anthropic_thinking(
+            &mut manual,
+            "anthropic:claude-haiku-4-5-20251001",
+            Some("high"),
+        );
         assert_eq!(
             manual["thinking"],
             json!({ "type": "enabled", "budget_tokens": 50_000 })

--- a/core/crates/omegon/src/tui/footer.rs
+++ b/core/crates/omegon/src/tui/footer.rs
@@ -1464,7 +1464,11 @@ mod tests {
         let mut terminal = Terminal::new(backend).unwrap();
         terminal
             .draw(|frame| {
-                data.render_engine_fallback_panel(frame.area(), frame, &super::super::theme::Alpharius);
+                data.render_engine_fallback_panel(
+                    frame.area(),
+                    frame,
+                    &super::super::theme::Alpharius,
+                );
             })
             .unwrap();
 
@@ -1656,12 +1660,20 @@ mod tests {
 
         terminal
             .draw(|frame| {
-                verbose.render_engine_fallback_panel(frame.area(), frame, &super::super::theme::Alpharius)
+                verbose.render_engine_fallback_panel(
+                    frame.area(),
+                    frame,
+                    &super::super::theme::Alpharius,
+                )
             })
             .unwrap();
         terminal
             .draw(|frame| {
-                compact.render_engine_fallback_panel(frame.area(), frame, &super::super::theme::Alpharius)
+                compact.render_engine_fallback_panel(
+                    frame.area(),
+                    frame,
+                    &super::super::theme::Alpharius,
+                )
             })
             .unwrap();
 

--- a/core/crates/omegon/src/tui/mod.rs
+++ b/core/crates/omegon/src/tui/mod.rs
@@ -33,7 +33,6 @@ pub mod segment_components;
 pub mod segment_detail;
 pub mod segments;
 pub mod selector;
-pub mod workbench;
 pub mod spinner;
 pub mod splash;
 pub mod statusline;
@@ -42,6 +41,7 @@ pub mod theme;
 pub mod tutorial;
 pub mod widget_renderer;
 pub mod widgets;
+pub mod workbench;
 
 #[cfg(test)]
 mod snapshot_tests;
@@ -91,9 +91,9 @@ use self::layout_projection::{TuiLayoutInputs, plan_tui_layout};
 use self::permission_lane::{format_permission_prompt, permission_response_for_key};
 use self::segments::{SegmentContent, SegmentExportMode, SegmentRenderMode};
 use self::workbench::{
-    PlanDisplaySnapshot, WorkbenchState, SlimPlanContext, SlimPlanHintState, SlimTurnState,
-    active_workbench_snapshot, workbench_preferred_height, render_workbench_panel,
-    slim_completed_plan_hint_available, slim_operator_hint, upstream_retry_hint,
+    PlanDisplaySnapshot, SlimPlanContext, SlimPlanHintState, SlimTurnState, WorkbenchState,
+    active_workbench_snapshot, render_workbench_panel, slim_completed_plan_hint_available,
+    slim_operator_hint, upstream_retry_hint, workbench_preferred_height,
 };
 use crate::surfaces::layout::UiSurfaces;
 use crate::ui_runtime::actions::{
@@ -300,6 +300,7 @@ pub(crate) struct QueuedPrompt {
     text: String,
     attachments: Vec<std::path::PathBuf>,
     metadata: PromptMetadata,
+    queue_mode: PromptQueueMode,
 }
 
 fn segment_meta_from_prompt_metadata(metadata: &PromptMetadata) -> SegmentMeta {
@@ -3303,6 +3304,7 @@ impl App {
             text,
             attachments,
             metadata: PromptMetadata::default(),
+            queue_mode: self.queue_mode,
         });
         tracing::debug!(queued = self.queued_prompts.len(), preview = %preview, "prompt queued");
     }
@@ -3673,6 +3675,47 @@ impl App {
             .await;
     }
 
+    async fn dispatch_next_queued_prompt(&mut self, command_tx: &mpsc::Sender<TuiCommand>) {
+        if self.agent_active || self.should_quit {
+            return;
+        }
+        let Some(queued) = self.queued_prompts.pop_front() else {
+            return;
+        };
+        let text = queued.text;
+        let attachments = queued.attachments;
+        let metadata = queued.metadata;
+        let queue_mode = queued.queue_mode;
+        let meta = segment_meta_from_prompt_metadata(&metadata);
+        if attachments.is_empty() {
+            self.conversation.push_user_with_meta(&text, meta);
+        } else {
+            self.conversation
+                .push_user_with_attachments_and_meta(&text, &attachments, meta);
+        }
+        self.history.push(text.clone());
+        self.history_idx = None;
+        self.agent_active = true;
+        if let Ok(mut ss) = self.dashboard_handles.session.lock() {
+            ss.busy = true;
+        }
+        let image_paths = if attachments.is_empty() {
+            Vec::new()
+        } else {
+            attachments
+        };
+        let _ = command_tx
+            .send(TuiCommand::SubmitPrompt(PromptSubmission {
+                text,
+                image_paths,
+                submitted_by: "local-tui".to_string(),
+                via: "tui",
+                queue_mode,
+                metadata,
+            }))
+            .await;
+    }
+
     fn suppress_editor_input_for(&mut self, duration: Duration) {
         self.suppress_editor_input_until = Some(std::time::Instant::now() + duration);
     }
@@ -3743,7 +3786,8 @@ impl App {
         }
 
         if !self.ui_surfaces.instruments {
-            self.footer_data.render_engine_fallback_panel(area, frame, t);
+            self.footer_data
+                .render_engine_fallback_panel(area, frame, t);
             return area;
         }
 
@@ -5393,6 +5437,7 @@ Scroll transcript:
                         text: builder_prompt,
                         attachments: Vec::new(),
                         metadata: PromptMetadata::default(),
+                        queue_mode: PromptQueueMode::UntilReady,
                     });
                     self.queue_mode = PromptQueueMode::UntilReady;
                     tracing::debug!("skill builder queued");
@@ -5700,6 +5745,7 @@ Scroll transcript:
                         text: builder_prompt,
                         attachments: Vec::new(),
                         metadata: PromptMetadata::default(),
+                        queue_mode: PromptQueueMode::UntilReady,
                     });
                     self.queue_mode = PromptQueueMode::UntilReady;
                     tracing::debug!("persona builder queued");
@@ -8569,6 +8615,11 @@ pub async fn run_tui(
             }
         }
 
+        // Agent events were drained above; if a turn ended and a prompt is queued,
+        // dispatch it before drawing so the visible queue count ticks down on the
+        // same frame that work starts.
+        app.dispatch_next_queued_prompt(&command_tx).await;
+
         // Draw
         terminal.draw(|f| app.draw(f))?;
 
@@ -9479,55 +9530,6 @@ pub async fn run_tui(
             } // match event::read()
         } // if has_terminal_event
 
-        // Agent events already drained before draw (above).
-
-        // Drain queued prompts only after authoritative AgentEnd (but not if quitting)
-        if !app.agent_active && !app.should_quit && !app.queued_prompts.is_empty() {
-            let queued = app.queued_prompts.pop_front().unwrap();
-            let text = queued.text;
-            let attachments = queued.attachments;
-            let metadata = queued.metadata;
-            if attachments.is_empty() {
-                app.conversation
-                    .push_user_with_meta(&text, segment_meta_from_prompt_metadata(&metadata));
-            } else {
-                app.conversation.push_user_with_attachments_and_meta(
-                    &text,
-                    &attachments,
-                    segment_meta_from_prompt_metadata(&metadata),
-                );
-            }
-            app.history.push(text.clone());
-            app.history_idx = None;
-            app.agent_active = true;
-            if let Ok(mut ss) = app.dashboard_handles.session.lock() {
-                ss.busy = true;
-            }
-            if attachments.is_empty() {
-                let _ = command_tx
-                    .send(TuiCommand::SubmitPrompt(PromptSubmission {
-                        text,
-                        image_paths: Vec::new(),
-                        submitted_by: "local-tui".to_string(),
-                        via: "tui",
-                        queue_mode: app.queue_mode,
-                        metadata,
-                    }))
-                    .await;
-            } else {
-                let _ = command_tx
-                    .send(TuiCommand::SubmitPrompt(PromptSubmission {
-                        text,
-                        image_paths: attachments,
-                        submitted_by: "local-tui".to_string(),
-                        via: "tui",
-                        queue_mode: app.queue_mode,
-                        metadata,
-                    }))
-                    .await;
-            }
-        }
-
         if app.should_quit {
             break;
         }
@@ -9689,8 +9691,8 @@ mod slash_command_parsing_tests {
     };
     use super::workbench::{
         PlanDisplayItem, PlanDisplaySnapshot, PlanDisplayStatus, SlimPlanContext,
-        SlimPlanHintState, slim_completed_plan_hint_available, slim_operator_hint,
-        active_workbench_snapshot, workbench_rows,
+        SlimPlanHintState, active_workbench_snapshot, slim_completed_plan_hint_available,
+        slim_operator_hint, workbench_rows,
     };
     use crate::lifecycle::types::NodeStatus;
     use crossterm::event::{KeyCode, KeyModifiers};
@@ -9700,7 +9702,9 @@ mod slash_command_parsing_tests {
 
     #[test]
     fn workbench_workstream_only_uses_compact_height() {
-        use super::workbench::{WorkbenchState, WorkstreamStatus, WorkstreamSummary, workbench_preferred_height};
+        use super::workbench::{
+            WorkbenchState, WorkstreamStatus, WorkstreamSummary, workbench_preferred_height,
+        };
 
         let empty = WorkbenchState::default();
         assert_eq!(workbench_preferred_height(&empty, 100), 0);
@@ -9721,7 +9725,9 @@ mod slash_command_parsing_tests {
 
     #[test]
     fn workbench_workstream_only_renders_summary_without_task_rows() {
-        use super::workbench::{WorkbenchState, WorkstreamStatus, WorkstreamSummary, render_workbench_panel};
+        use super::workbench::{
+            WorkbenchState, WorkstreamStatus, WorkstreamSummary, render_workbench_panel,
+        };
 
         let state = WorkbenchState {
             active: None,
@@ -9737,7 +9743,9 @@ mod slash_command_parsing_tests {
         let backend = ratatui::backend::TestBackend::new(80, 1);
         let mut terminal = ratatui::Terminal::new(backend).unwrap();
         terminal
-            .draw(|frame| render_workbench_panel(frame.area(), frame, &super::theme::Alpharius, &state))
+            .draw(|frame| {
+                render_workbench_panel(frame.area(), frame, &super::theme::Alpharius, &state)
+            })
             .unwrap();
         let mut text = String::new();
         for x in 0..80 {

--- a/core/crates/omegon/src/tui/tests.rs
+++ b/core/crates/omegon/src/tui/tests.rs
@@ -717,6 +717,44 @@ async fn explicit_interrupt_queue_mode_still_requests_cancel() {
     );
 }
 
+#[tokio::test]
+async fn queued_prompt_dispatch_preserves_captured_queue_mode() {
+    let mut app = test_app();
+    let (tx, mut rx) = test_tx_with_rx();
+
+    app.queue_mode = PromptQueueMode::InterruptAfterTurn;
+    app.queue_prompt("queued under interrupt".to_string(), Vec::new());
+    app.queue_mode = PromptQueueMode::UntilReady;
+
+    app.dispatch_next_queued_prompt(&tx).await;
+
+    match rx.recv().await.expect("queued prompt dispatched") {
+        TuiCommand::SubmitPrompt(PromptSubmission {
+            text, queue_mode, ..
+        }) => {
+            assert_eq!(text, "queued under interrupt");
+            assert_eq!(queue_mode, PromptQueueMode::InterruptAfterTurn);
+        }
+        other => panic!("expected prompt submission, got {other:?}"),
+    }
+    assert!(app.queued_prompts.is_empty());
+    assert!(app.agent_active);
+}
+
+#[tokio::test]
+async fn queued_prompt_dispatch_waits_for_idle_agent() {
+    let mut app = test_app();
+    let (tx, mut rx) = test_tx_with_rx();
+
+    app.agent_active = true;
+    app.queue_prompt("wait for current turn".to_string(), Vec::new());
+
+    app.dispatch_next_queued_prompt(&tx).await;
+
+    assert_eq!(app.queued_prompts.len(), 1);
+    assert!(rx.try_recv().is_err());
+}
+
 #[test]
 fn queue_prompt_preserves_fifo_order() {
     let mut app = test_app();
@@ -3466,8 +3504,6 @@ directive = "TONE.md"
 // Event handling
 // ═══════════════════════════════════════════════════════════════════
 
-
-
 #[test]
 fn draw_routes_active_cleave_to_workbench_without_instruments() {
     let mut app = test_app();
@@ -3738,8 +3774,14 @@ fn footer_instrument_layout_renders_only_inference_and_tools_panels() {
         "expected tools panel: {rendered}"
     );
 
-    assert!(rendered.contains("┌ inference"), "missing inference panel: {rendered}");
-    assert!(rendered.contains("┌ tools"), "missing tools panel: {rendered}");
+    assert!(
+        rendered.contains("┌ inference"),
+        "missing inference panel: {rendered}"
+    );
+    assert!(
+        rendered.contains("┌ tools"),
+        "missing tools panel: {rendered}"
+    );
     assert!(
         !rendered.contains("┌ engine"),
         "engine telemetry belongs in the slim status sidecar, not the instrument footer: {rendered}"
@@ -4096,6 +4138,8 @@ fn slash_cleave_run_still_uses_bus_path() {
         name: "cleave".into(),
         description: "parallel work".into(),
         subcommands: vec!["status".into(), "cancel".into()],
+        availability: omegon_traits::CommandAvailability::ALL,
+        safety: omegon_traits::CommandSafety::READ_ONLY,
     });
     let (tx, mut rx) = test_tx_with_rx();
 
@@ -4131,11 +4175,15 @@ fn hidden_model_aliases_do_not_appear_in_palette() {
             name: "sonnet".into(),
             description: "hidden alias".into(),
             subcommands: vec![],
+            availability: omegon_traits::CommandAvailability::ALL,
+            safety: omegon_traits::CommandSafety::READ_ONLY,
         },
         omegon_traits::CommandDefinition {
             name: "victory".into(),
             description: "visible tier".into(),
             subcommands: vec![],
+            availability: omegon_traits::CommandAvailability::ALL,
+            safety: omegon_traits::CommandSafety::READ_ONLY,
         },
     ];
     app.editor.set_text("/");
@@ -4151,6 +4199,8 @@ fn palette_deduplicates_builtin_and_bus_commands() {
         name: "cleave".into(),
         description: "parallel work".into(),
         subcommands: vec!["status".into()],
+        availability: omegon_traits::CommandAvailability::ALL,
+        safety: omegon_traits::CommandSafety::READ_ONLY,
     }];
     app.editor.set_text("/cl");
     let matches = app.matching_commands();
@@ -4190,6 +4240,8 @@ fn slash_cleave_warns_on_anthropic_subscription_but_proceeds() {
         name: "cleave".into(),
         description: "parallel work".into(),
         subcommands: vec![],
+        availability: omegon_traits::CommandAvailability::ALL,
+        safety: omegon_traits::CommandSafety::READ_ONLY,
     });
     let tx = test_tx();
     let result = app.handle_slash_command("/cleave demo", &tx);

--- a/core/crates/omegon/src/tui/workbench.rs
+++ b/core/crates/omegon/src/tui/workbench.rs
@@ -27,7 +27,11 @@ pub fn workbench_preferred_height(state: &WorkbenchState, width: u16) -> u16 {
         workbench_snapshot_height(active, width)
     } else if state.cleave.as_ref().is_some_and(|p| p.active) {
         5
-    } else if state.delegate.as_ref().is_some_and(|p| p.active || p.running > 0) {
+    } else if state
+        .delegate
+        .as_ref()
+        .is_some_and(|p| p.active || p.running > 0)
+    {
         5
     } else if !state.workstreams.is_empty() {
         1
@@ -63,7 +67,6 @@ pub enum WorkstreamStatus {
     Complete,
 }
 
-
 impl WorkstreamStatus {
     pub fn from_label(value: &str) -> Self {
         match value {
@@ -97,7 +100,13 @@ impl WorkstreamSummary {
             .unwrap_or(WorkstreamStatus::Waiting);
         let completed = value.get("completed").and_then(|v| v.as_u64()).unwrap_or(0) as usize;
         let total = value.get("total").and_then(|v| v.as_u64()).unwrap_or(0) as usize;
-        Some(Self { id, title, status, completed, total })
+        Some(Self {
+            id,
+            title,
+            status,
+            completed,
+            total,
+        })
     }
 }
 
@@ -106,7 +115,12 @@ impl WorkbenchState {
         let workstreams = value
             .get("workstreams")
             .and_then(|v| v.as_array())
-            .map(|items| items.iter().filter_map(WorkstreamSummary::from_json).collect())
+            .map(|items| {
+                items
+                    .iter()
+                    .filter_map(WorkstreamSummary::from_json)
+                    .collect()
+            })
             .unwrap_or_default();
         Self {
             active: PlanDisplaySnapshot::from_json(value),
@@ -482,7 +496,14 @@ impl SlimPlanContext {
 
     pub fn labels(&self) -> Vec<String> {
         let mut labels = Vec::new();
-        labels.push(if self.active { "active plan" } else { "no active plan" }.to_string());
+        labels.push(
+            if self.active {
+                "active plan"
+            } else {
+                "no active plan"
+            }
+            .to_string(),
+        );
         if self.tracked {
             labels.push("tracked".to_string());
         }
@@ -550,7 +571,11 @@ pub fn render_workbench_panel(
         render_active_workbench_panel(area, frame, t, snapshot, state.workstreams.len());
     } else if let Some(cleave) = state.cleave.as_ref().filter(|p| p.active) {
         render_cleave_workbench_panel(area, frame, t, cleave);
-    } else if let Some(delegate) = state.delegate.as_ref().filter(|p| p.active || p.running > 0) {
+    } else if let Some(delegate) = state
+        .delegate
+        .as_ref()
+        .filter(|p| p.active || p.running > 0)
+    {
         render_delegate_workbench_panel(area, frame, t, delegate);
     } else {
         render_workstream_summary(area, frame, t, state.workstreams.as_slice(), bg);
@@ -629,7 +654,10 @@ fn render_cleave_workbench_panel(
             .map(|tool| format!(" · {tool}"))
             .unwrap_or_default();
         let text = crate::util::truncate(
-            &format!("{} {:<10}{}{}", child.label, child.status, task_progress, tool),
+            &format!(
+                "{} {:<10}{}{}",
+                child.label, child.status, task_progress, tool
+            ),
             area.width.saturating_sub(1) as usize,
         );
         lines.push(Line::from(Span::styled(
@@ -672,7 +700,10 @@ fn render_delegate_workbench_panel(
             .map(|tool| format!(" · {tool}"))
             .unwrap_or_default();
         let text = crate::util::truncate(
-            &format!("{} {:<10}{}{}", child.label, child.status, task_progress, tool),
+            &format!(
+                "{} {:<10}{}{}",
+                child.label, child.status, task_progress, tool
+            ),
             area.width.saturating_sub(1) as usize,
         );
         lines.push(Line::from(Span::styled(
@@ -709,11 +740,7 @@ fn workbench_rule_line<'a>(
     ])
 }
 
-fn worker_status_style(
-    status: &str,
-    t: &dyn theme::Theme,
-    bg: ratatui::style::Color,
-) -> Style {
+fn worker_status_style(status: &str, t: &dyn theme::Theme, bg: ratatui::style::Color) -> Style {
     let fg = match status {
         "completed" | "merged_after_failure" => t.success(),
         "running" => t.warning(),

--- a/core/crates/omegon/src/web/acp_ws.rs
+++ b/core/crates/omegon/src/web/acp_ws.rs
@@ -30,6 +30,7 @@ pub struct AcpWebState {
     pub model: String,
     pub cwd: PathBuf,
     pub agent_id: Option<String>,
+    pub dangerously_bypass_permissions: bool,
     pub active_connections: Arc<AtomicU64>,
     pub shutdown: CancellationToken,
 }
@@ -158,7 +159,14 @@ async fn handle_acp_socket(socket: WebSocket, state: AcpWebState) {
                 let local = tokio::task::LocalSet::new();
                 local.block_on(
                     &rt,
-                    run_acp_session(model, cwd, agent_id, inbound_rx, outbound_tx),
+                    run_acp_session(
+                        model,
+                        cwd,
+                        agent_id,
+                        state.dangerously_bypass_permissions,
+                        inbound_rx,
+                        outbound_tx,
+                    ),
                 );
             }));
             if let Err(e) = result {
@@ -208,6 +216,7 @@ async fn run_acp_session(
     model: String,
     cwd: PathBuf,
     agent_id: Option<String>,
+    dangerously_bypass_permissions: bool,
     mut inbound_rx: mpsc::UnboundedReceiver<String>,
     outbound_tx: mpsc::UnboundedSender<String>,
 ) {
@@ -221,7 +230,10 @@ async fn run_acp_session(
         }
     }
 
-    let agent = Rc::new(crate::acp::OmegonAcpAgent::new(&model));
+    let agent = Rc::new(crate::acp::OmegonAcpAgent::new_with_safety(
+        &model,
+        dangerously_bypass_permissions,
+    ));
 
     let (read_client, mut read_server) = tokio::io::duplex(DUPLEX_BUFFER_BYTES);
     let (write_client, write_server) = tokio::io::duplex(DUPLEX_BUFFER_BYTES);

--- a/core/crates/omegon/src/web/mod.rs
+++ b/core/crates/omegon/src/web/mod.rs
@@ -322,6 +322,7 @@ pub async fn start_server(
         model: String::new(),
         cwd: std::env::current_dir().unwrap_or_default(),
         agent_id: None,
+        dangerously_bypass_permissions: false,
         active_connections: Arc::new(std::sync::atomic::AtomicU64::new(0)),
         shutdown: tokio_util::sync::CancellationToken::new(),
     };

--- a/docs/prompt-library-loop-system.md
+++ b/docs/prompt-library-loop-system.md
@@ -1,0 +1,90 @@
+---
+id: prompt-library-loop-system
+title: "Prompt library and loop execution system"
+status: exploring
+tags: [tui, prompts, queue, loop, ux]
+open_questions:
+  - "[assumption] Reusable prompts should not automatically register top-level slash commands; /prompt is the routing surface."
+  - "What time system should /loop expose: fixed intervals, cron-like schedules, deadlines, debounce/idle timers, or combinations?"
+  - "What event sources should count as /loop triggers or until conditions: test pass/fail, git changes, file changes, task state changes, tool results, operator idle, wall-clock deadline?"
+  - "How should prompt invocation arguments be templated and validated without turning prompts into a second skill/config language?"
+  - "How should prompt/loop provenance appear in the TUI queue, conversation history, status line, and future workbench?"
+  - "What exact anti-prompt-injection checks must run before prompt templates are listed, previewed, queued, looped, or executed?"
+  - "How should the prompt library distinguish trusted project/user prompt templates from untrusted prompt text produced by model output, downloaded files, copied snippets, or repository content?"
+  - "Should /loop require stronger anti-injection and operator confirmation than /prompt run because it can repeatedly execute injected instructions over time?"
+  - "Should CommandSafety be added to omegon_traits::CommandDefinition as concrete fields now, or introduced as an optional metadata object to preserve compatibility with existing extension command definitions?"
+dependencies: []
+related: []
+---
+
+# Prompt library and loop execution system
+
+## Overview
+
+Design a first-class reusable prompt library and loop execution model. Prompts should remain content/templates rather than individual slash commands; /prompt should manage/run/queue prompt invocations, and /loop should schedule repeated prompt invocations with event/time stop conditions without collapsing prompts into skills or extensions.
+
+## Research
+
+### Upstream UX scan — prompt and loop concepts
+
+Live browser result extraction was unavailable in this environment, so this scan is based on known harness patterns rather than fresh citations. Claude Code exposes custom slash commands from markdown prompt files, with project/user scoping and argument interpolation; useful concepts are filesystem-backed prompt definitions and lightweight templating, but the namespace coupling is a cautionary anti-pattern for Omegon. GitHub Copilot/Copilot Chat supports reusable prompt files in repositories (for example `.github/prompts`) and instruction files; useful concepts are repo-local prompt artifacts and IDE discoverability. Cursor/Windsurf lean heavily on rules/workflows/memories rather than arbitrary command proliferation; useful concepts are separating behavioral policy from one-shot prompts. ChatGPT Tasks and automation products expose time-based schedules, reminders, and recurring execution; useful concepts are explicit recurrence, deadlines, and timezone-aware wall-clock triggers. CI/watch tools (`watch`, file watchers, cron, systemd timers, GitHub Actions schedules) offer mature trigger vocabulary: interval, cron, at/deadline, debounce, on-change, max-runs, backoff, and until-success/failure.
+
+### Registry and remote slash path notes
+
+Current code path indicates command registry data originates from EventBus::command_definitions(), is passed into TUI state for the command palette, and can be dispatched through EventBus::dispatch_command(). Remote slash execution in main.rs currently canonicalizes commands and has special handling/allowlists for control and plan commands before rejecting interactive-only commands. Therefore /prompt and /loop should be implemented as native Feature commands and remote slash execution/ACP should either dispatch explicitly-safe registered bus commands or CommandDefinition should grow an availability/safety field. Hardcoding prompt/loop only would satisfy MVP but preserves the architectural split-brain between registry and remote slash surfaces.
+
+## Decisions
+
+### /prompt and /loop are core registered commands across surfaces
+
+**Status:** proposed
+
+**Rationale:** The operator explicitly requires /prompt and /loop placement in the command registry for TUI, CLI remote slash execution, and ACP. Prompt templates remain data addressed by these commands; individual prompt IDs must not become top-level slash commands.
+
+### Prompt IDs do not register as slash commands
+
+**Status:** proposed
+
+**Rationale:** Reusable prompt templates are content/data resolved by /prompt and /loop. Auto-registering prompt IDs would pollute the slash namespace, collide with extensions/skills, and make CLI/ACP command discovery ambiguous.
+
+### CommandDefinition exposes per-surface availability and safety metadata
+
+**Status:** accepted
+
+**Rationale:** The operator decided CommandDefinition needs explicit availability/safety fields for TUI, CLI remote slash execution, and ACP so remote surfaces can expose registered commands without maintaining hidden hardcoded allowlists. This is required for /prompt and /loop to be registry-native across surfaces.
+
+### Prompt and loop surfaces include an anti-prompt-injection gate
+
+**Status:** proposed
+
+**Rationale:** Reusable prompts and loops can turn stored text into repeated agent instructions. The prompt surface must therefore validate provenance, reject or warn on suspicious instruction-overriding content, and preserve a preview/confirmation boundary before execution, especially for /loop.
+
+### Command availability and safety schema
+
+**Status:** proposed
+
+**Rationale:** CommandDefinition should carry explicit per-surface availability and safety metadata. Proposed shape: CommandAvailability { tui: bool, cli: bool, acp: bool } plus CommandSafety { class: LocalOnly | ReadOnly | QueueMutation | StateChanging | ExternalSideEffect | Destructive, requires_confirmation: bool, prompt_injection_sensitive: bool }. Remote slash execution and ACP expose only commands whose availability allows the surface and whose safety class can be handled by that surface's confirmation/permission model.
+
+### Prompt safety verdict schema
+
+**Status:** proposed
+
+**Rationale:** Prompt loading should produce a PromptSafetyVerdict before execution: Clean, Suspicious { reasons }, Blocked { reasons }, or Trusted { trust_record }. Suspicious prompts may be previewed and require explicit operator confirmation before run/queue. Blocked prompts cannot execute until edited or explicitly trusted by a stronger trust flow. Trusted prompts must be bound to path plus content hash so modifications revoke trust.
+
+### Loop scheduling schema
+
+**Status:** proposed
+
+**Rationale:** LoopSpec should schedule PromptInvocation objects, not slash command strings. Proposed primitives: LoopTrigger::Now | Every(Duration) | At(DateTime) | Cron(String) | OnEvent(EventSelector); LoopStopCondition::MaxRuns(u32) | For(Duration) | Until(DateTime) | UntilEvent(EventSelector) | UntilOutcome(Success|Failure|OperatorStop); LoopConcurrencyPolicy::SkipIfRunning | QueueNext | CancelAndReplace. MVP should implement Now, Every, MaxRuns, For, UntilOutcome(OperatorStop), and SkipIfRunning; cron/file-watch/event selectors can be deferred.
+
+## Open Questions
+
+- [assumption] Reusable prompts should not automatically register top-level slash commands; /prompt is the routing surface.
+- What time system should /loop expose: fixed intervals, cron-like schedules, deadlines, debounce/idle timers, or combinations?
+- What event sources should count as /loop triggers or until conditions: test pass/fail, git changes, file changes, task state changes, tool results, operator idle, wall-clock deadline?
+- How should prompt invocation arguments be templated and validated without turning prompts into a second skill/config language?
+- How should prompt/loop provenance appear in the TUI queue, conversation history, status line, and future workbench?
+- What exact anti-prompt-injection checks must run before prompt templates are listed, previewed, queued, looped, or executed?
+- How should the prompt library distinguish trusted project/user prompt templates from untrusted prompt text produced by model output, downloaded files, copied snippets, or repository content?
+- Should /loop require stronger anti-injection and operator confirmation than /prompt run because it can repeatedly execute injected instructions over time?
+- Should CommandSafety be added to omegon_traits::CommandDefinition as concrete fields now, or introduced as an optional metadata object to preserve compatibility with existing extension command definitions?


### PR DESCRIPTION
## Summary
- Add explicit command availability and safety metadata to registered command definitions.
- Gate registered command execution for CLI remote slash and ACP surfaces using availability and confirmation metadata.
- Thread --dangerously-bypass-permissions through CLI/ACP startup so operator-approved bypass can execute confirmation-gated commands while preserving surface availability checks.
- Preserve queued prompt queue mode at queue time so delayed prompts dispatch with their original semantics.
- Add prompt/loop design notes establishing /prompt and /loop as registry-native commands with prompt-injection-sensitive safety handling.

## Validation
- cargo check -p omegon
- cargo test -p omegon remote_registered_command --no-fail-fast
- cargo test -p omegon acp_registered_command --no-fail-fast
- cargo test -p omegon queued_prompt_dispatch --no-fail-fast
- just test-commit
