### PR TITLE
feat(tui): add conversation representation surfaces

### DIFF
--- a/core/crates/omegon/src/acp/surfaces.rs
+++ b/core/crates/omegon/src/acp/surfaces.rs
@@ -80,6 +80,12 @@ pub enum AcpConversationSegmentKind {
         text: String,
         thinking: Option<String>,
     },
+    PeerAgent {
+        label: String,
+        source: String,
+        status: String,
+        text: String,
+    },
     Tool {
         id: String,
         name: String,
@@ -156,6 +162,12 @@ where
                 }
             },
         },
+        ConversationSegmentKind::PeerAgent(peer) => AcpConversationSegmentKind::PeerAgent {
+            label: redact(peer.label.as_ref()),
+            source: peer.source.as_str().to_string(),
+            status: peer.status.as_str().to_string(),
+            text: redact(peer.text.as_ref()),
+        },
         ConversationSegmentKind::Tool(tool) => {
             let include_details = !matches!(policy, SurfaceRedaction::ExternalClient);
             AcpConversationSegmentKind::Tool {
@@ -208,6 +220,7 @@ where
 fn segment_complete<TText, TPath>(kind: &ConversationSegmentKind<TText, TPath>) -> bool {
     match kind {
         ConversationSegmentKind::Assistant(assistant) => assistant.complete,
+        ConversationSegmentKind::PeerAgent(peer) => peer.status.is_terminal(),
         ConversationSegmentKind::Tool(tool) => tool.complete,
         _ => true,
     }
@@ -217,6 +230,7 @@ fn role_name(role: SegmentRole) -> &'static str {
     match role {
         SegmentRole::Operator => "operator",
         SegmentRole::Assistant => "assistant",
+        SegmentRole::PeerAgent => "peer_agent",
         SegmentRole::Tool => "tool",
         SegmentRole::System => "system",
         SegmentRole::Lifecycle => "lifecycle",
@@ -614,7 +628,8 @@ impl AcpConversationSurfaceAdapter {
 mod tests {
     use super::*;
     use crate::surfaces::conversation::{
-        AssistantSegment, ConversationSegmentKind, ImageSegment, ToolSegment,
+        AssistantSegment, ConversationSegmentKind, ImageSegment, PeerAgentSegment, PeerAgentSource,
+        PeerAgentStatus, ToolSegment,
     };
 
     fn redact_secret(text: &str) -> String {
@@ -768,6 +783,36 @@ stack [REDACTED]"
                 assert_eq!(thinking, None);
             }
             other => panic!("expected assistant DTO, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn peer_agent_projection_serializes_role_payload_and_completion() {
+        let projection = ConversationSegmentProjection::new(
+            ConversationSegmentKind::<&str, &Path>::PeerAgent(PeerAgentSegment {
+                label: "scout SECRET",
+                source: PeerAgentSource::Delegate,
+                status: PeerAgentStatus::Running,
+                text: "working SECRET",
+            }),
+        );
+        let dto = AcpConversationSegment::from_projection(
+            AcpConversationIdentity::new("peer-1", 9),
+            &projection,
+            SurfaceRedaction::ExternalClient,
+            redact_secret,
+        );
+
+        assert_eq!(dto.role, "peer_agent");
+        assert!(!dto.complete);
+        match dto.kind {
+            AcpConversationSegmentKind::PeerAgent { label, source, status, text } => {
+                assert_eq!(label, "scout [REDACTED]");
+                assert_eq!(source, "delegate");
+                assert_eq!(status, "running");
+                assert_eq!(text, "working [REDACTED]");
+            }
+            other => panic!("expected peer agent DTO, got {other:?}"),
         }
     }
 

--- a/core/crates/omegon/src/surfaces/conversation.rs
+++ b/core/crates/omegon/src/surfaces/conversation.rs
@@ -15,6 +15,9 @@ use std::path::{Path, PathBuf};
 pub enum SegmentRole {
     Operator,
     Assistant,
+    /// Agent-to-agent conversation participants such as cleave children,
+    /// delegated workers, or remote peer agents.
+    PeerAgent,
     Tool,
     System,
     Lifecycle,
@@ -78,6 +81,7 @@ where
 pub enum ConversationSegmentKind<TText = String, TPath = PathBuf> {
     User(UserSegment<TText>),
     Assistant(AssistantSegment<TText>),
+    PeerAgent(PeerAgentSegment<TText>),
     Tool(ToolSegment<TText>),
     System(SystemSegment<TText>),
     Lifecycle(LifecycleSegment<TText>),
@@ -90,6 +94,7 @@ impl<TText, TPath> ConversationSegmentKind<TText, TPath> {
         match self {
             Self::User(_) => SegmentRole::Operator,
             Self::Assistant(_) => SegmentRole::Assistant,
+            Self::PeerAgent(_) => SegmentRole::PeerAgent,
             Self::Tool(_) => SegmentRole::Tool,
             Self::System(_) => SegmentRole::System,
             Self::Lifecycle(_) => SegmentRole::Lifecycle,
@@ -121,6 +126,56 @@ pub struct AssistantSegment<TText = String> {
     pub text: TText,
     pub thinking: TText,
     pub complete: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PeerAgentSource {
+    Delegate,
+    Cleave,
+    A2a,
+}
+
+impl PeerAgentSource {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Delegate => "delegate",
+            Self::Cleave => "cleave",
+            Self::A2a => "a2a",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PeerAgentStatus {
+    Running,
+    Completed,
+    Failed,
+    Cancelled,
+    Deferred,
+}
+
+impl PeerAgentStatus {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Running => "running",
+            Self::Completed => "completed",
+            Self::Failed => "failed",
+            Self::Cancelled => "cancelled",
+            Self::Deferred => "deferred",
+        }
+    }
+
+    pub fn is_terminal(self) -> bool {
+        !matches!(self, Self::Running | Self::Deferred)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PeerAgentSegment<TText = String> {
+    pub label: TText,
+    pub source: PeerAgentSource,
+    pub status: PeerAgentStatus,
+    pub text: TText,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -228,6 +283,12 @@ pub fn presentation_for_role(
             emphasis: SegmentEmphasis::Normal,
             tool_category: None,
         },
+        SegmentRole::PeerAgent => SegmentPresentation {
+            role,
+            sigil: "⬡",
+            emphasis: SegmentEmphasis::Normal,
+            tool_category: None,
+        },
         SegmentRole::Tool => SegmentPresentation {
             role,
             sigil: "⚙",
@@ -330,4 +391,25 @@ mod tests {
         assert_eq!(projection.role(), SegmentRole::Media);
         assert_eq!(projection.presentation.sigil, "◈");
     }
+
+    #[test]
+    fn peer_agent_projection_uses_peer_role_and_terminal_status() {
+        let projection = ConversationSegmentProjection::<&str>::new(
+            ConversationSegmentKind::PeerAgent(PeerAgentSegment {
+                label: "scout",
+                source: PeerAgentSource::Delegate,
+                status: PeerAgentStatus::Completed,
+                text: "review complete",
+            }),
+        );
+
+        assert_eq!(projection.role(), SegmentRole::PeerAgent);
+        assert_eq!(projection.presentation.sigil, "⬡");
+        assert_eq!(projection.presentation.tool_category, None);
+        assert_eq!(PeerAgentSource::Delegate.as_str(), "delegate");
+        assert_eq!(PeerAgentStatus::Completed.as_str(), "completed");
+        assert!(PeerAgentStatus::Completed.is_terminal());
+        assert!(!PeerAgentStatus::Running.is_terminal());
+    }
+
 }

--- a/core/crates/omegon/src/tui/active_tool_stream.rs
+++ b/core/crates/omegon/src/tui/active_tool_stream.rs
@@ -1,7 +1,6 @@
 //! Active tool stream lane rendering for slim/full TUI layouts.
 
 use ratatui::prelude::*;
-use ratatui::style::Modifier;
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Paragraph, Widget, Wrap};
 
@@ -68,20 +67,21 @@ pub fn render_active_tool_stream_panel(
 
     let bg = t.surface_bg();
     let mut lines = Vec::new();
-    lines.push(Line::from(vec![
-        Span::styled("─ active tool ", Style::default().fg(t.border_dim()).bg(bg)),
-        Span::styled(
-            stream.name.as_str(),
-            Style::default()
-                .fg(t.accent())
-                .bg(bg)
-                .add_modifier(Modifier::BOLD),
-        ),
-        Span::styled(
-            format!(" · {}", format_short_elapsed(stream.started_at.elapsed())),
-            Style::default().fg(t.muted()).bg(bg),
-        ),
-    ]));
+    lines.push(crate::tui::horizontal_line::horizontal_line(
+        crate::tui::horizontal_line::HorizontalLineSpec::title("active tool")
+            .with_title_emphasis(crate::tui::horizontal_line::LineEmphasis::Muted)
+            .with_metric(
+                crate::tui::horizontal_line::LineMetric::new("", stream.name.as_str())
+                    .with_emphasis(crate::tui::horizontal_line::LineEmphasis::Strong),
+            )
+            .with_metric(crate::tui::horizontal_line::LineMetric::new(
+                "",
+                format_short_elapsed(stream.started_at.elapsed()),
+            )),
+        area.width,
+        t,
+        bg,
+    ));
     let max_tail = area.height.saturating_sub(1) as usize;
     let text_budget = area.width.saturating_sub(2) as usize;
     for line in stream.visible_lines(max_tail) {

--- a/core/crates/omegon/src/tui/conversation_render_projection.rs
+++ b/core/crates/omegon/src/tui/conversation_render_projection.rs
@@ -41,6 +41,7 @@ pub fn segment_chrome(
     let (role_label, sigil, role_color) = match presentation.role {
         SegmentRole::Operator => ("operator", "OP", t.accent()),
         SegmentRole::Assistant => ("assistant", "Ω", t.success()),
+        SegmentRole::PeerAgent => ("peer agent", "⬡", t.accent()),
         SegmentRole::Tool => {
             let category = presentation.tool_category.unwrap_or(ToolCategory::Generic);
             (category.label(), "⚙", tool_category_color(category, t))

--- a/core/crates/omegon/src/tui/glyphs.rs
+++ b/core/crates/omegon/src/tui/glyphs.rs
@@ -1,0 +1,89 @@
+//! Semantic glyph matrix for TUI chrome.
+//!
+//! Renderers ask for semantic glyph roles rather than hardcoding symbols. This
+//! keeps visual policy replaceable without coupling independent surfaces.
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RuleGlyphRole {
+    Horizontal,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ToolGlyphRole {
+    Running,
+    Completed,
+    Failed,
+    Detail,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct RuleGlyphMatrix {
+    pub horizontal: &'static str,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct ToolGlyphMatrix {
+    pub running: &'static str,
+    pub completed: &'static str,
+    pub failed: &'static str,
+    pub detail: &'static str,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct GlyphSet {
+    pub rule: RuleGlyphMatrix,
+    pub tool: ToolGlyphMatrix,
+}
+
+pub const UNICODE_GLYPHS: GlyphSet = GlyphSet {
+    rule: RuleGlyphMatrix { horizontal: "─" },
+    tool: ToolGlyphMatrix {
+        running: "◐",
+        completed: "✓",
+        failed: "✗",
+        detail: "↵",
+    },
+};
+
+impl GlyphSet {
+    pub fn rule(self, role: RuleGlyphRole) -> &'static str {
+        match role {
+            RuleGlyphRole::Horizontal => self.rule.horizontal,
+        }
+    }
+
+    pub fn tool(self, role: ToolGlyphRole) -> &'static str {
+        match role {
+            ToolGlyphRole::Running => self.tool.running,
+            ToolGlyphRole::Completed => self.tool.completed,
+            ToolGlyphRole::Failed => self.tool.failed,
+            ToolGlyphRole::Detail => self.tool.detail,
+        }
+    }
+}
+
+pub fn glyphs() -> &'static GlyphSet {
+    &UNICODE_GLYPHS
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use unicode_width::UnicodeWidthStr;
+
+    #[test]
+    fn core_glyphs_are_non_empty_and_single_cell() {
+        let glyphs = glyphs();
+        let values = [
+            glyphs.rule(RuleGlyphRole::Horizontal),
+            glyphs.tool(ToolGlyphRole::Running),
+            glyphs.tool(ToolGlyphRole::Completed),
+            glyphs.tool(ToolGlyphRole::Failed),
+            glyphs.tool(ToolGlyphRole::Detail),
+        ];
+        for value in values {
+            assert!(!value.is_empty());
+            assert_eq!(UnicodeWidthStr::width(value), 1, "{value:?}");
+        }
+    }
+}

--- a/core/crates/omegon/src/tui/horizontal_line.rs
+++ b/core/crates/omegon/src/tui/horizontal_line.rs
@@ -1,0 +1,288 @@
+//! Pure horizontal line grammar for TUI chrome.
+//!
+//! This module owns visual grammar only: title/metric layout, rule fill,
+//! width handling, and semantic emphasis styles. Surface modules retain their
+//! own state projection and pass small visual specs here.
+
+use std::borrow::Cow;
+
+use ratatui::prelude::*;
+use ratatui::style::Modifier;
+use ratatui::text::{Line, Span};
+use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
+
+use super::{glyphs, theme};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LineEmphasis {
+    Muted,
+    Normal,
+    Accent,
+    Strong,
+    Success,
+    Warning,
+    Error,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RulePlacement {
+    None,
+    Leading,
+    Trailing,
+    Surround,
+    Full,
+}
+
+#[derive(Debug, Clone)]
+pub struct LineMetric<'a> {
+    pub label: Cow<'a, str>,
+    pub value: Cow<'a, str>,
+    pub emphasis: LineEmphasis,
+}
+
+impl<'a> LineMetric<'a> {
+    pub fn new(label: impl Into<Cow<'a, str>>, value: impl Into<Cow<'a, str>>) -> Self {
+        Self {
+            label: label.into(),
+            value: value.into(),
+            emphasis: LineEmphasis::Muted,
+        }
+    }
+
+    pub fn with_emphasis(mut self, emphasis: LineEmphasis) -> Self {
+        self.emphasis = emphasis;
+        self
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct HorizontalLineSpec<'a> {
+    pub title: Option<Cow<'a, str>>,
+    pub title_emphasis: LineEmphasis,
+    pub metrics: Vec<LineMetric<'a>>,
+    pub rule: RulePlacement,
+}
+
+impl<'a> HorizontalLineSpec<'a> {
+    pub fn title(title: impl Into<Cow<'a, str>>) -> Self {
+        Self {
+            title: Some(title.into()),
+            title_emphasis: LineEmphasis::Accent,
+            metrics: Vec::new(),
+            rule: RulePlacement::Trailing,
+        }
+    }
+
+    pub fn rule(rule: RulePlacement) -> Self {
+        Self {
+            title: None,
+            title_emphasis: LineEmphasis::Muted,
+            metrics: Vec::new(),
+            rule,
+        }
+    }
+
+    pub fn with_title_emphasis(mut self, emphasis: LineEmphasis) -> Self {
+        self.title_emphasis = emphasis;
+        self
+    }
+
+    pub fn with_metric(mut self, metric: LineMetric<'a>) -> Self {
+        self.metrics.push(metric);
+        self
+    }
+}
+
+pub fn horizontal_line<'a>(
+    spec: HorizontalLineSpec<'a>,
+    width: u16,
+    t: &dyn theme::Theme,
+    bg: Color,
+) -> Line<'a> {
+    if width == 0 {
+        return Line::default();
+    }
+
+    let mut spans: Vec<Span<'a>> = Vec::new();
+    let rule_glyph = glyphs::glyphs().rule(glyphs::RuleGlyphRole::Horizontal);
+    let rule_style = Style::default().fg(t.border_dim()).bg(bg);
+
+    if spec.rule == RulePlacement::Full {
+        return Line::from(Span::styled(
+            repeat_to_width(rule_glyph, width as usize),
+            rule_style,
+        ));
+    }
+
+    if matches!(spec.rule, RulePlacement::Leading | RulePlacement::Surround) {
+        spans.push(Span::styled(format!("{rule_glyph} "), rule_style));
+    }
+
+    if let Some(title) = spec.title {
+        spans.push(Span::styled(
+            title.into_owned(),
+            emphasis_style(spec.title_emphasis, t, bg),
+        ));
+    }
+
+    for metric in spec.metrics {
+        if !spans.is_empty() {
+            spans.push(Span::styled(" · ", Style::default().fg(t.muted()).bg(bg)));
+        }
+        let text = if metric.label.is_empty() {
+            metric.value.into_owned()
+        } else {
+            format!("{} {}", metric.label, metric.value)
+        };
+        spans.push(Span::styled(text, emphasis_style(metric.emphasis, t, bg)));
+    }
+
+    let content_width: usize = spans
+        .iter()
+        .map(|span| UnicodeWidthStr::width(span.content.as_ref()))
+        .sum();
+    if content_width > width as usize {
+        return truncate_spans(spans, width as usize, t, bg);
+    }
+
+    if matches!(spec.rule, RulePlacement::Trailing | RulePlacement::Surround) {
+        let remaining = width as usize - content_width;
+        if remaining > 0 {
+            let rule_text = if content_width == 0 {
+                repeat_to_width(rule_glyph, remaining)
+            } else {
+                format!(
+                    " {}",
+                    repeat_to_width(rule_glyph, remaining.saturating_sub(1))
+                )
+            };
+            spans.push(Span::styled(rule_text, rule_style));
+        }
+    }
+
+    Line::from(spans)
+}
+
+fn emphasis_style(emphasis: LineEmphasis, t: &dyn theme::Theme, bg: Color) -> Style {
+    let fg = match emphasis {
+        LineEmphasis::Muted => t.muted(),
+        LineEmphasis::Normal => t.fg(),
+        LineEmphasis::Accent | LineEmphasis::Strong => t.accent_muted(),
+        LineEmphasis::Success => t.success(),
+        LineEmphasis::Warning => t.warning(),
+        LineEmphasis::Error => t.error(),
+    };
+    let style = Style::default().fg(fg).bg(bg);
+    if matches!(emphasis, LineEmphasis::Strong) {
+        style.add_modifier(Modifier::BOLD)
+    } else {
+        style
+    }
+}
+
+fn repeat_to_width(glyph: &str, width: usize) -> String {
+    if width == 0 {
+        return String::new();
+    }
+    glyph.repeat(width / UnicodeWidthStr::width(glyph).max(1))
+}
+
+fn truncate_spans<'a>(
+    spans: Vec<Span<'a>>,
+    width: usize,
+    t: &dyn theme::Theme,
+    bg: Color,
+) -> Line<'a> {
+    let text = spans
+        .iter()
+        .map(|span| span.content.as_ref())
+        .collect::<Vec<_>>()
+        .join("");
+    Line::from(Span::styled(
+        truncate_display_width(&text, width),
+        Style::default().fg(t.accent_muted()).bg(bg),
+    ))
+}
+
+fn truncate_display_width(text: &str, width: usize) -> String {
+    if UnicodeWidthStr::width(text) <= width {
+        return text.to_string();
+    }
+    if width == 0 {
+        return String::new();
+    }
+    let ellipsis = "…";
+    let ellipsis_width = UnicodeWidthStr::width(ellipsis);
+    if width <= ellipsis_width {
+        return ellipsis.to_string();
+    }
+    let budget = width - ellipsis_width;
+    let mut out = String::new();
+    let mut used = 0;
+    for ch in text.chars() {
+        let ch_width = UnicodeWidthChar::width(ch).unwrap_or(0);
+        if used + ch_width > budget {
+            break;
+        }
+        out.push(ch);
+        used += ch_width;
+    }
+    out.push_str(ellipsis);
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tui::theme::{Alpharius, Theme};
+
+    #[test]
+    fn full_rule_fills_requested_width() {
+        let line = horizontal_line(
+            HorizontalLineSpec::rule(RulePlacement::Full),
+            5,
+            &Alpharius,
+            Alpharius.surface_bg(),
+        );
+        assert_eq!(line.spans[0].content.as_ref(), "─────");
+    }
+
+    #[test]
+    fn title_metrics_and_trailing_rule_fit_width() {
+        let line = horizontal_line(
+            HorizontalLineSpec::title("active tool")
+                .with_title_emphasis(LineEmphasis::Muted)
+                .with_metric(LineMetric::new("name", "bash").with_emphasis(LineEmphasis::Strong))
+                .with_metric(LineMetric::new("elapsed", "2s")),
+            40,
+            &Alpharius,
+            Alpharius.surface_bg(),
+        );
+        let rendered = line
+            .spans
+            .iter()
+            .map(|span| span.content.as_ref())
+            .collect::<String>();
+        assert!(rendered.contains("active tool"), "{rendered}");
+        assert!(rendered.contains("name bash"), "{rendered}");
+        assert!(rendered.ends_with('─'), "{rendered}");
+        assert!(UnicodeWidthStr::width(rendered.as_str()) <= 40);
+    }
+
+    #[test]
+    fn narrow_line_truncates_without_overflow() {
+        let line = horizontal_line(
+            HorizontalLineSpec::title("very long title")
+                .with_metric(LineMetric::new("value", "abcdef")),
+            8,
+            &Alpharius,
+            Alpharius.surface_bg(),
+        );
+        let rendered = line
+            .spans
+            .iter()
+            .map(|span| span.content.as_ref())
+            .collect::<String>();
+        assert!(UnicodeWidthStr::width(rendered.as_str()) <= 8);
+    }
+}

--- a/core/crates/omegon/src/tui/mod.rs
+++ b/core/crates/omegon/src/tui/mod.rs
@@ -24,6 +24,8 @@ pub mod extension_overlays;
 pub mod focus_view;
 pub mod footer;
 pub mod footer_projection;
+pub mod glyphs;
+pub mod horizontal_line;
 pub mod image;
 pub mod instruments;
 pub mod layout_projection;

--- a/core/crates/omegon/src/tui/mod.rs
+++ b/core/crates/omegon/src/tui/mod.rs
@@ -4791,6 +4791,7 @@ impl App {
             let role = match segment.role() {
                 crate::surfaces::conversation::SegmentRole::Operator => "## Operator",
                 crate::surfaces::conversation::SegmentRole::Assistant => "## Assistant",
+                crate::surfaces::conversation::SegmentRole::PeerAgent => "## Peer Agent",
                 crate::surfaces::conversation::SegmentRole::Tool => "## Tool",
                 crate::surfaces::conversation::SegmentRole::System => "## System",
                 crate::surfaces::conversation::SegmentRole::Lifecycle => "## Event",

--- a/core/crates/omegon/src/tui/segment_components/assistant.rs
+++ b/core/crates/omegon/src/tui/segment_components/assistant.rs
@@ -98,6 +98,14 @@ fn assistant_block<'a>(
     }
 }
 
+fn presentation_label(presentation: &SegmentPresentation) -> &'static str {
+    match presentation.role {
+        crate::surfaces::conversation::SegmentRole::Assistant => "omegon",
+        crate::surfaces::conversation::SegmentRole::PeerAgent => "peer agent",
+        _ => "omegon",
+    }
+}
+
 fn push_identity_line<'a>(
     lines: &mut Vec<Line<'a>>,
     props: &AssistantRenderProps<'_>,
@@ -113,7 +121,10 @@ fn push_identity_line<'a>(
                 .bg(bg)
                 .add_modifier(Modifier::BOLD),
         ),
-        Span::styled("omegon", Style::default().fg(theme.border_dim()).bg(bg)),
+        Span::styled(
+            presentation_label(props.presentation),
+            Style::default().fg(theme.border_dim()).bg(bg),
+        ),
     ]));
 }
 

--- a/core/crates/omegon/src/tui/segment_components/separator.rs
+++ b/core/crates/omegon/src/tui/segment_components/separator.rs
@@ -1,7 +1,6 @@
 //! Turn separator segment component.
 
 use ratatui::prelude::*;
-use ratatui::text::{Line, Span};
 use ratatui::widgets::{Paragraph, Widget};
 
 use super::super::conversation_render_projection::SegmentRenderContext;
@@ -11,14 +10,14 @@ pub fn render(area: Rect, buf: &mut Buffer, ctx: &SegmentRenderContext<'_>) {
     if area.height == 0 || area.width < 4 {
         return;
     }
-    // Thin ruled divider with faded edges.
-    let pad = 2;
-    let rule_w = (area.width as usize).saturating_sub(pad * 2);
-    let line = Line::from(vec![
-        Span::styled(" ".repeat(pad), Style::default()),
-        Span::styled("─".repeat(rule_w), Style::default().fg(theme.border_dim())),
-        Span::styled(" ".repeat(pad), Style::default()),
-    ]);
+    let line = crate::tui::horizontal_line::horizontal_line(
+        crate::tui::horizontal_line::HorizontalLineSpec::rule(
+            crate::tui::horizontal_line::RulePlacement::Full,
+        ),
+        area.width,
+        theme,
+        ctx.theme.surface_bg(),
+    );
     Paragraph::new(line).render(area, buf);
 }
 

--- a/core/crates/omegon/src/tui/segment_detail.rs
+++ b/core/crates/omegon/src/tui/segment_detail.rs
@@ -44,6 +44,7 @@ fn segment_kind_label(segment: &Segment) -> &'static str {
     match segment.content {
         SegmentContent::UserPrompt { .. } => "user",
         SegmentContent::AssistantText { .. } => "assistant",
+        SegmentContent::PeerAgentText { .. } => "peer_agent",
         SegmentContent::ToolCard { .. } => "tool",
         SegmentContent::SystemNotification { .. } => "system",
         SegmentContent::LifecycleEvent { .. } => "lifecycle",

--- a/core/crates/omegon/src/tui/segments.rs
+++ b/core/crates/omegon/src/tui/segments.rs
@@ -14,8 +14,9 @@ use super::conversation_render_projection::SegmentRenderMetadata;
 use super::theme::Theme;
 use crate::surfaces::conversation::{
     AssistantSegment, BorrowedConversationSegmentProjection, ConversationSegmentKind,
-    ConversationSegmentProjection, ImageSegment, LifecycleSegment, ProjectConversationSegment,
-    SegmentPresentation, SegmentRole, SystemSegment, ToolSegment, UserSegment,
+    ConversationSegmentProjection, ImageSegment, LifecycleSegment, PeerAgentSegment,
+    PeerAgentSource, PeerAgentStatus, ProjectConversationSegment, SegmentPresentation, SegmentRole,
+    SystemSegment, ToolSegment, UserSegment,
 };
 
 const FILE_URL_ENCODE_SET: &percent_encoding::AsciiSet = &percent_encoding::CONTROLS
@@ -1024,6 +1025,15 @@ pub enum SegmentContent {
         complete: bool,
     },
 
+    /// Agent-to-agent response from delegated workers, cleave children, or
+    /// remote peer agents.
+    PeerAgentText {
+        label: String,
+        source: PeerAgentSource,
+        status: PeerAgentStatus,
+        text: String,
+    },
+
     /// Tool call with args and result.
     ToolCard {
         id: String,
@@ -1104,6 +1114,22 @@ impl Segment {
             },
         }
     }
+    pub fn peer_agent(
+        label: impl Into<String>,
+        source: PeerAgentSource,
+        status: PeerAgentStatus,
+        text: impl Into<String>,
+    ) -> Self {
+        Self {
+            meta: SegmentMeta::default(),
+            content: SegmentContent::PeerAgentText {
+                label: label.into(),
+                source,
+                status,
+                text: text.into(),
+            },
+        }
+    }
     pub fn tool_card(id: impl Into<String>, name: impl Into<String>) -> Self {
         Self {
             meta: SegmentMeta::default(),
@@ -1171,6 +1197,17 @@ impl<'a> ProjectConversationSegment<'a> for Segment {
                 text: text.as_str(),
                 thinking: thinking.as_str(),
                 complete: *complete,
+            }),
+            SegmentContent::PeerAgentText {
+                label,
+                source,
+                status,
+                text,
+            } => ConversationSegmentKind::PeerAgent(PeerAgentSegment {
+                label: label.as_str(),
+                source: *source,
+                status: *status,
+                text: text.as_str(),
             }),
             SegmentContent::ToolCard {
                 id,
@@ -1246,6 +1283,10 @@ impl Segment {
                 stream_updatable: !*complete,
                 ..SegmentCapabilities::timeline_item()
             },
+            SegmentContent::PeerAgentText { status, .. } => SegmentCapabilities {
+                stream_updatable: !status.is_terminal(),
+                ..SegmentCapabilities::timeline_item()
+            },
             SegmentContent::ToolCard {
                 is_error, complete, ..
             } => SegmentCapabilities {
@@ -1294,6 +1335,28 @@ impl Segment {
                 } else {
                     format!("[thinking]\n{thinking}\n\n[text]\n{text}")
                 }
+            }
+            SegmentContent::PeerAgentText {
+                label,
+                source,
+                status,
+                text,
+            } => {
+                let text = match mode {
+                    SegmentExportMode::Raw => text.trim_end().to_string(),
+                    SegmentExportMode::Plaintext => normalize_markdown_for_plaintext(text),
+                };
+                format!(
+                    "peer agent: {label}
+source: {}
+status: {}
+
+{text}",
+                    source.as_str(),
+                    status.as_str()
+                )
+                .trim_end()
+                .to_string()
             }
             SegmentContent::ToolCard {
                 name,
@@ -1409,6 +1472,25 @@ impl Segment {
                     &render_ctx,
                 );
             }
+            PeerAgentText {
+                text,
+                status,
+                ..
+            } => {
+                super::segment_components::assistant::render(
+                    super::segment_components::assistant::AssistantRenderProps {
+                        text,
+                        thinking: "",
+                        complete: status.is_terminal(),
+                        meta: &self.meta,
+                        presentation: &presentation,
+                        mode,
+                    },
+                    area,
+                    buf,
+                    &render_ctx,
+                );
+            }
             ToolCard {
                 name,
                 detail_args,
@@ -1503,6 +1585,9 @@ impl Segment {
                     wrapped_rows(text, width).max(1)
                 };
                 (text_rows + thinking_rows).max(1)
+            }
+            PeerAgentText { text, .. } if matches!(mode, SegmentRenderMode::Slim) => {
+                wrapped_rows(text, width).max(1)
             }
             AssistantText { text, thinking, .. } => {
                 let meta_line = if self.meta.model_id.is_some() || self.meta.provider.is_some() {
@@ -3499,6 +3584,40 @@ mod tests {
             op_count <= 1,
             "operator card should not duplicate the OP sigil in both title and body: {text}"
         );
+    }
+
+    #[test]
+    fn peer_agent_segment_projects_and_renders_peer_chrome() {
+        let seg = Segment::peer_agent(
+            "scout",
+            crate::surfaces::conversation::PeerAgentSource::Delegate,
+            crate::surfaces::conversation::PeerAgentStatus::Running,
+            "reviewing the patch",
+        );
+        let projection = seg.projection();
+        assert_eq!(projection.role(), SegmentRole::PeerAgent);
+        match projection.kind {
+            ConversationSegmentKind::PeerAgent(peer) => {
+                assert_eq!(peer.label, "scout");
+                assert_eq!(peer.source.as_str(), "delegate");
+                assert_eq!(peer.status.as_str(), "running");
+                assert_eq!(peer.text, "reviewing the patch");
+            }
+            other => panic!("expected peer agent projection, got {other:?}"),
+        }
+
+        let (area, mut buf) = make_buf(80, 8);
+        seg.render(
+            area,
+            &mut buf,
+            &Alpharius,
+            SegmentRenderMode::Full,
+            crate::settings::ToolDetail::Detailed,
+        );
+        let text = buf_text(&buf, area);
+        assert!(text.contains("peer agent"), "{text}");
+        assert!(text.contains("⬡"), "{text}");
+        assert!(text.contains("reviewing the patch"), "{text}");
     }
 
     #[test]

--- a/core/crates/omegon/src/tui/workbench.rs
+++ b/core/crates/omegon/src/tui/workbench.rs
@@ -722,21 +722,13 @@ fn workbench_rule_line<'a>(
     summary: String,
     width: u16,
 ) -> Line<'a> {
-    let rule_width = width.saturating_sub(summary.len() as u16 + 4) as usize;
-    Line::from(vec![
-        Span::styled("─ ", Style::default().fg(t.border_dim()).bg(bg)),
-        Span::styled(
-            summary,
-            Style::default()
-                .fg(t.accent_muted())
-                .bg(bg)
-                .add_modifier(Modifier::BOLD),
-        ),
-        Span::styled(
-            format!(" {}", "─".repeat(rule_width)),
-            Style::default().fg(t.border_dim()).bg(bg),
-        ),
-    ])
+    crate::tui::horizontal_line::horizontal_line(
+        crate::tui::horizontal_line::HorizontalLineSpec::title(summary)
+            .with_title_emphasis(crate::tui::horizontal_line::LineEmphasis::Strong),
+        width,
+        t,
+        bg,
+    )
 }
 
 fn worker_status_style(status: &str, t: &dyn theme::Theme, bg: ratatui::style::Color) -> Style {

--- a/docs/horizontal-line-system.md
+++ b/docs/horizontal-line-system.md
@@ -1,0 +1,40 @@
+---
+id: horizontal-line-system
+title: "TUI Horizontal Line Grammar"
+status: seed
+tags: []
+open_questions:
+  - "[assumption] A shared horizontal-line grammar can live as a pure rendering helper without owning surface-specific data models or lifecycle state."
+  - "Which first consumers should be migrated in MVP: workbench rule lines, separator component, active tool stream header, slim tool collapsed line, engine fallback/status line, or full tool card headers?"
+  - "How should the shared grammar expose theme/color semantics without importing or depending on individual surface components?"
+  - "What stable test contract should protect visual consistency: exact buffer snapshots, semantic span inspection, or focused width/truncation assertions?"
+dependencies: []
+related: []
+---
+
+# TUI Horizontal Line Grammar
+
+## Overview
+
+Design a shared, semantic rendering grammar for horizontal TUI lines (workbench, engine/status rows, slim/full tool call headers, separators) so width budgeting, metric ordering, color roles, and rule glyphs are consistent without re-coupling decoupled UI surfaces.
+
+## Decisions
+
+### Horizontal line system is a pure visual grammar module
+
+**Status:** proposed
+
+**Rationale:** To avoid re-coupling decoupled UI elements, the shared module must not own workbench, tool-card, footer, or segment state. It should accept a small semantic line spec plus theme/background and return Ratatui spans/lines. Surface modules remain responsible for their own data projection and choose which line specs to render.
+
+### Tool surface glyphs use a shared semantic glyph matrix
+
+**Status:** proposed
+
+**Rationale:** Tool surfaces need consistent iconography for tool lifecycle, result class, detail affordances, and line/rule chrome without hardcoding glyph strings in every renderer. A shared glyph matrix keeps visuals replaceable while preserving decoupling: surfaces ask for semantic glyph roles, not specific symbols.
+
+## Open Questions
+
+- [assumption] A shared horizontal-line grammar can live as a pure rendering helper without owning surface-specific data models or lifecycle state.
+- Which first consumers should be migrated in MVP: workbench rule lines, separator component, active tool stream header, slim tool collapsed line, engine fallback/status line, or full tool card headers?
+- How should the shared grammar expose theme/color semantics without importing or depending on individual surface components?
+- What stable test contract should protect visual consistency: exact buffer snapshots, semantic span inspection, or focused width/truncation assertions?


### PR DESCRIPTION
## Summary
- Add shared TUI glyph and horizontal-line grammar primitives.
- Migrate separator, workbench, and active-tool-stream line chrome onto the shared grammar.
- Add renderer-neutral peer-agent conversation representation for delegate/cleave/A2A-style output.
- Expose peer-agent role/payload through ACP and render peer-agent TUI chrome using the existing assistant body renderer.

## Validation
- cargo check -p omegon
- cargo test -p omegon horizontal_line --no-fail-fast
- cargo test -p omegon glyph --no-fail-fast
- cargo test -p omegon separator --no-fail-fast
- cargo test -p omegon peer_agent --no-fail-fast
- just test-commit
