### PR TITLE
feat(tui): add semantic tool chrome glyphs

### DIFF
--- a/core/crates/omegon/src/tui/active_tool_stream.rs
+++ b/core/crates/omegon/src/tui/active_tool_stream.rs
@@ -67,9 +67,14 @@ pub fn render_active_tool_stream_panel(
 
     let bg = t.surface_bg();
     let mut lines = Vec::new();
+    let glyphs = crate::tui::glyphs::glyphs();
+    let category = glyphs.tool_category(crate::tui::glyphs::tool_category_role_for_name(&stream.name));
+    let running = glyphs.tool_state(crate::tui::glyphs::ToolStateGlyphRole::Running);
     lines.push(crate::tui::horizontal_line::horizontal_line(
         crate::tui::horizontal_line::HorizontalLineSpec::title("active tool")
             .with_title_emphasis(crate::tui::horizontal_line::LineEmphasis::Muted)
+            .with_metric(crate::tui::horizontal_line::LineMetric::new("", running))
+            .with_metric(crate::tui::horizontal_line::LineMetric::new("", category))
             .with_metric(
                 crate::tui::horizontal_line::LineMetric::new("", stream.name.as_str())
                     .with_emphasis(crate::tui::horizontal_line::LineEmphasis::Strong),

--- a/core/crates/omegon/src/tui/glyphs.rs
+++ b/core/crates/omegon/src/tui/glyphs.rs
@@ -9,6 +9,28 @@ pub enum RuleGlyphRole {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ToolStateGlyphRole {
+    Running,
+    Completed,
+    Failed,
+    Waiting,
+    Cancelled,
+    Detail,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ToolCategoryGlyphRole {
+    Shell,
+    Read,
+    Write,
+    Search,
+    Design,
+    Memory,
+    Network,
+    Generic,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ToolGlyphRole {
     Running,
     Completed,
@@ -19,6 +41,28 @@ pub enum ToolGlyphRole {
 #[derive(Debug, Clone, Copy)]
 pub struct RuleGlyphMatrix {
     pub horizontal: &'static str,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct ToolStateGlyphMatrix {
+    pub running: &'static str,
+    pub completed: &'static str,
+    pub failed: &'static str,
+    pub waiting: &'static str,
+    pub cancelled: &'static str,
+    pub detail: &'static str,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct ToolCategoryGlyphMatrix {
+    pub shell: &'static str,
+    pub read: &'static str,
+    pub write: &'static str,
+    pub search: &'static str,
+    pub design: &'static str,
+    pub memory: &'static str,
+    pub network: &'static str,
+    pub generic: &'static str,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -33,6 +77,8 @@ pub struct ToolGlyphMatrix {
 pub struct GlyphSet {
     pub rule: RuleGlyphMatrix,
     pub tool: ToolGlyphMatrix,
+    pub tool_state: ToolStateGlyphMatrix,
+    pub tool_category: ToolCategoryGlyphMatrix,
 }
 
 pub const UNICODE_GLYPHS: GlyphSet = GlyphSet {
@@ -42,6 +88,24 @@ pub const UNICODE_GLYPHS: GlyphSet = GlyphSet {
         completed: "✓",
         failed: "✗",
         detail: "↵",
+    },
+    tool_state: ToolStateGlyphMatrix {
+        running: "◐",
+        completed: "✓",
+        failed: "✗",
+        waiting: "◌",
+        cancelled: "⊘",
+        detail: "↵",
+    },
+    tool_category: ToolCategoryGlyphMatrix {
+        shell: "$",
+        read: "◰",
+        write: "✎",
+        search: "⌕",
+        design: "◇",
+        memory: "◈",
+        network: "⇄",
+        generic: "•",
     },
 };
 
@@ -60,6 +124,71 @@ impl GlyphSet {
             ToolGlyphRole::Detail => self.tool.detail,
         }
     }
+
+    pub fn tool_state(self, role: ToolStateGlyphRole) -> &'static str {
+        match role {
+            ToolStateGlyphRole::Running => self.tool_state.running,
+            ToolStateGlyphRole::Completed => self.tool_state.completed,
+            ToolStateGlyphRole::Failed => self.tool_state.failed,
+            ToolStateGlyphRole::Waiting => self.tool_state.waiting,
+            ToolStateGlyphRole::Cancelled => self.tool_state.cancelled,
+            ToolStateGlyphRole::Detail => self.tool_state.detail,
+        }
+    }
+
+    pub fn tool_category(self, role: ToolCategoryGlyphRole) -> &'static str {
+        match role {
+            ToolCategoryGlyphRole::Shell => self.tool_category.shell,
+            ToolCategoryGlyphRole::Read => self.tool_category.read,
+            ToolCategoryGlyphRole::Write => self.tool_category.write,
+            ToolCategoryGlyphRole::Search => self.tool_category.search,
+            ToolCategoryGlyphRole::Design => self.tool_category.design,
+            ToolCategoryGlyphRole::Memory => self.tool_category.memory,
+            ToolCategoryGlyphRole::Network => self.tool_category.network,
+            ToolCategoryGlyphRole::Generic => self.tool_category.generic,
+        }
+    }
+}
+
+/// Classify a tool name into a visual category glyph role.
+///
+/// This is intentionally a presentation helper only: it does not import tool
+/// implementations or own tool semantics. Callers may use richer local state
+/// and bypass this name-based fallback when they have it.
+pub fn tool_category_role_for_name(name: &str) -> ToolCategoryGlyphRole {
+    let lower = name.to_ascii_lowercase();
+    match lower.as_str() {
+        "bash" | "terminal" | "shell" => ToolCategoryGlyphRole::Shell,
+        "read" | "view" => ToolCategoryGlyphRole::Read,
+        "write" | "edit" | "change" | "commit" => ToolCategoryGlyphRole::Write,
+        "codebase_search" | "search_documents" | "web_search" | "browser_search" | "rg" => {
+            ToolCategoryGlyphRole::Search
+        }
+        "design_tree" | "design_tree_update" | "create_drawing" | "create_d2_diagram" => {
+            ToolCategoryGlyphRole::Design
+        }
+        "memory_store" | "memory_recall" | "memory_query" | "store_memory_fact" => {
+            ToolCategoryGlyphRole::Memory
+        }
+        name if name.contains("search") => ToolCategoryGlyphRole::Search,
+        name if name.contains("memory") => ToolCategoryGlyphRole::Memory,
+        name if name.contains("design") || name.contains("drawing") => ToolCategoryGlyphRole::Design,
+        name if name.contains("fetch") || name.contains("browser") || name.contains("web") => {
+            ToolCategoryGlyphRole::Network
+        }
+        _ => ToolCategoryGlyphRole::Generic,
+    }
+}
+
+pub fn tool_state_role_for_status(status: &str) -> ToolStateGlyphRole {
+    match status {
+        "completed" | "done" | "merged_after_failure" => ToolStateGlyphRole::Completed,
+        "running" | "in_progress" => ToolStateGlyphRole::Running,
+        "failed" | "error" | "upstream_exhausted" => ToolStateGlyphRole::Failed,
+        "cancelled" | "canceled" => ToolStateGlyphRole::Cancelled,
+        "waiting" | "queued" | "pending" => ToolStateGlyphRole::Waiting,
+        _ => ToolStateGlyphRole::Detail,
+    }
 }
 
 pub fn glyphs() -> &'static GlyphSet {
@@ -72,6 +201,17 @@ mod tests {
     use unicode_width::UnicodeWidthStr;
 
     #[test]
+    fn tool_name_and_status_helpers_are_decoupled_presentation_fallbacks() {
+        assert_eq!(tool_category_role_for_name("bash"), ToolCategoryGlyphRole::Shell);
+        assert_eq!(tool_category_role_for_name("codebase_search"), ToolCategoryGlyphRole::Search);
+        assert_eq!(tool_category_role_for_name("memory_recall"), ToolCategoryGlyphRole::Memory);
+        assert_eq!(tool_category_role_for_name("unknown"), ToolCategoryGlyphRole::Generic);
+        assert_eq!(tool_state_role_for_status("running"), ToolStateGlyphRole::Running);
+        assert_eq!(tool_state_role_for_status("completed"), ToolStateGlyphRole::Completed);
+        assert_eq!(tool_state_role_for_status("failed"), ToolStateGlyphRole::Failed);
+    }
+
+    #[test]
     fn core_glyphs_are_non_empty_and_single_cell() {
         let glyphs = glyphs();
         let values = [
@@ -80,6 +220,20 @@ mod tests {
             glyphs.tool(ToolGlyphRole::Completed),
             glyphs.tool(ToolGlyphRole::Failed),
             glyphs.tool(ToolGlyphRole::Detail),
+            glyphs.tool_state(ToolStateGlyphRole::Running),
+            glyphs.tool_state(ToolStateGlyphRole::Completed),
+            glyphs.tool_state(ToolStateGlyphRole::Failed),
+            glyphs.tool_state(ToolStateGlyphRole::Waiting),
+            glyphs.tool_state(ToolStateGlyphRole::Cancelled),
+            glyphs.tool_state(ToolStateGlyphRole::Detail),
+            glyphs.tool_category(ToolCategoryGlyphRole::Shell),
+            glyphs.tool_category(ToolCategoryGlyphRole::Read),
+            glyphs.tool_category(ToolCategoryGlyphRole::Write),
+            glyphs.tool_category(ToolCategoryGlyphRole::Search),
+            glyphs.tool_category(ToolCategoryGlyphRole::Design),
+            glyphs.tool_category(ToolCategoryGlyphRole::Memory),
+            glyphs.tool_category(ToolCategoryGlyphRole::Network),
+            glyphs.tool_category(ToolCategoryGlyphRole::Generic),
         ];
         for value in values {
             assert!(!value.is_empty());

--- a/core/crates/omegon/src/tui/workbench.rs
+++ b/core/crates/omegon/src/tui/workbench.rs
@@ -656,17 +656,12 @@ fn render_cleave_workbench_panel(
         } else {
             format!(" · tasks {}/{}", child.tasks_done, child.tasks.len())
         };
-        let tool = child
-            .last_tool
-            .as_deref()
-            .map(|tool| format!(" · {tool}"))
-            .unwrap_or_default();
-        let text = crate::util::truncate(
-            &format!(
-                "{} {:<10}{}{}",
-                child.label, child.status, task_progress, tool
-            ),
-            area.width.saturating_sub(1) as usize,
+        let text = worker_chrome_line(
+            &child.label,
+            &child.status,
+            child.last_tool.as_deref(),
+            &task_progress,
+            area.width,
         );
         lines.push(Line::from(Span::styled(
             text,
@@ -702,17 +697,12 @@ fn render_delegate_workbench_panel(
         } else {
             format!(" · tasks {}/{}", child.tasks_done, child.tasks.len())
         };
-        let tool = child
-            .last_tool
-            .as_deref()
-            .map(|tool| format!(" · {tool}"))
-            .unwrap_or_default();
-        let text = crate::util::truncate(
-            &format!(
-                "{} {:<10}{}{}",
-                child.label, child.status, task_progress, tool
-            ),
-            area.width.saturating_sub(1) as usize,
+        let text = worker_chrome_line(
+            &child.label,
+            &child.status,
+            child.last_tool.as_deref(),
+            &task_progress,
+            area.width,
         );
         lines.push(Line::from(Span::styled(
             text,
@@ -723,6 +713,31 @@ fn render_delegate_workbench_panel(
         .style(Style::default().bg(bg))
         .wrap(Wrap { trim: false })
         .render(area, frame.buffer_mut());
+}
+
+
+fn worker_chrome_line(
+    label: &str,
+    status: &str,
+    last_tool: Option<&str>,
+    task_progress: &str,
+    width: u16,
+) -> String {
+    let glyphs = crate::tui::glyphs::glyphs();
+    let state = glyphs.tool_state(crate::tui::glyphs::tool_state_role_for_status(status));
+    let category = last_tool
+        .map(crate::tui::glyphs::tool_category_role_for_name)
+        .map(|role| glyphs.tool_category(role));
+    let tool = last_tool
+        .map(|tool| match category {
+            Some(category) => format!(" · {category} {tool}"),
+            None => format!(" · {tool}"),
+        })
+        .unwrap_or_default();
+    crate::util::truncate(
+        &format!("{state} {label} {status:<10}{task_progress}{tool}"),
+        width.saturating_sub(1) as usize,
+    )
 }
 
 fn workbench_rule_line<'a>(

--- a/docs/tui-polish.md
+++ b/docs/tui-polish.md
@@ -1,0 +1,15 @@
+---
+id: tui-polish
+title: "TUI Polish Workstream"
+status: exploring
+tags: [tui, polish, ratatui, tachyonfx]
+open_questions: []
+dependencies: []
+related: []
+---
+
+# TUI Polish Workstream
+
+## Overview
+
+Explore and implement Ratatui widget, TachyonFX, and UI chrome polish for the single-line TUI surfaces recently factored into shared glyph/horizontal-line grammar. Target low-risk visual improvements to workbench, active tool stream, separators, tool surface, footer/status chrome, and peer-agent representation without recoupling surface state.


### PR DESCRIPTION
## Summary
- Expand the TUI glyph matrix with decoupled tool state and category glyph roles.
- Add presentation-only fallback classifiers for tool names and statuses.
- Use semantic glyphs in the active tool stream header and workbench worker rows.
- Add a lightweight tui-polish design note for the Ratatui/TachyonFX polish workstream.

## Decoupling boundary
- Glyph roles remain visual vocabulary only.
- Workbench and active-tool-stream keep ownership of their local state projection.
- No cleave/delegate/tool business state moved into shared chrome.

## Validation
- cargo check -p omegon
- cargo test -p omegon glyph --no-fail-fast
- cargo test -p omegon active_tool_stream --no-fail-fast
- cargo test -p omegon workbench --no-fail-fast
