### PR TITLE
Release 0.27 mechanics validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [Semantic V
 
 ### Fixed
 
+- Clear the release lint gate by grouping active-tool tail rendering style parameters and keeping the persisted OAuth precedence regression test's process-wide auth environment lock out of async execution.
 - Accept-loop the OAuth callback listener for Anthropic, OpenAI/Codex, and Antigravity logins: browser speculative preconnections, favicon requests, and redirects from stale login tabs no longer abort the login after the operator completed authentication in the browser.
 - Route interactive fallback LLM calls with the fallback bridge model while preserving the selected profile model, preventing OpenAI/Codex startup fallback from sending `gpt-5.5` to Anthropic.
 - Initialize the loop's active-model tracking from the bridge runtime model so TurnEnd events and session-log entries emitted before the first per-turn refresh report the real fallback model instead of the profile model.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,6 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [Semantic V
 
 ## [Unreleased]
 
-### Fixed
-
-- The TUI footer/model card now renders the model actually served by the runtime bridge when startup installed a fallback bridge (selected provider had no credentials), with a warning line naming the unavailable operator-selected model. Previously the footer showed the profile-selected model (e.g. `gpt-5.5`) even while every request was being served by the fallback provider, making it look like the wrong provider was active.
-
 ### Added
 
 - Add redacted provider-auth and route-state diagnostic tracing for auth.json path selection, credential source/probe decisions, OAuth refresh/write-back, login outcomes, and fallback/disconnected route causes so relaunch login regressions leave an attributable trail.
@@ -62,6 +58,8 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [Semantic V
 - Import discovered external provider credentials into Omegon auth storage once at startup so OpenAI/Codex OAuth survives rebuilt binary relinks and subsequent session hydration uses internal auth.json.
 - Adopt valid external provider credentials during startup env hydration when Omegon auth storage is missing or expired, preventing rebuilt sessions from falling back to login-only mode.
 - Prefer refreshable persisted OAuth credentials over hydrated OAuth env vars so stale `CHATGPT_OAUTH_TOKEN` session values cannot shadow `auth.json` refresh for OpenAI/Codex.
+- The TUI footer/model card now renders the model actually served by the runtime bridge when startup installed a fallback bridge (selected provider had no credentials), with a warning line naming the unavailable operator-selected model. Previously the footer showed the profile-selected model (e.g. `gpt-5.5`) even while every request was being served by the fallback provider, making it look like the wrong provider was active.
+
 ## [0.27.0] - 2026-06-11
 
 0.27.0 is a hardening and surface-coherence line. It makes provider/auth routing explicit instead of implicit, gives operators truthful TUI status when credentials or fallbacks are involved, expands the backend capability substrate for future console clients, and continues extracting lifecycle/TUI surfaces behind shared semantic boundaries.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [Semantic V
 
 ### Added
 
+- Trace auth.json provider key-set deltas on credential writes, refreshes, and logout so future OpenAI/Codex credential disappearance incidents identify the mutating operation and whether `openai-codex` was dropped. Auth updates now also refuse to replace an unparsable existing auth store with a partial credential file.
 - Add redacted provider-auth and route-state diagnostic tracing for auth.json path selection, credential source/probe decisions, OAuth refresh/write-back, login outcomes, and fallback/disconnected route causes so relaunch login regressions leave an attributable trail.
 - Rebuild the release binary inside `just link` before selecting the binary to alias so local `omegon --version` cannot point at a stale artifact from an older HEAD.
 - Add peer-agent conversation representation/projection support so delegate/cleave/A2A output can carry producer identity independently from assistant/tool rendering.

--- a/core/crates/omegon/src/auth.rs
+++ b/core/crates/omegon/src/auth.rs
@@ -2491,8 +2491,8 @@ mod tests {
         assert_eq!(env_keys[0], "ANTHROPIC_API_KEY");
     }
 
-    #[tokio::test]
-    async fn resolve_with_refresh_prefers_persisted_oauth_over_oauth_env() {
+    #[test]
+    fn resolve_with_refresh_prefers_persisted_oauth_over_oauth_env() {
         let dir = tempfile::tempdir().unwrap();
         let override_path = dir.path().join("auth.json");
         let _guard = TEST_AUTH_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
@@ -2519,7 +2519,11 @@ mod tests {
         )
         .expect("write persisted codex auth");
 
-        let resolved = resolve_with_refresh("openai-codex").await;
+        let resolved = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("build test runtime")
+            .block_on(resolve_with_refresh("openai-codex"));
 
         unsafe {
             match original_auth {

--- a/core/crates/omegon/src/auth.rs
+++ b/core/crates/omegon/src/auth.rs
@@ -877,14 +877,11 @@ pub fn write_credentials(provider: &str, creds: &OAuthCredentials) -> anyhow::Re
     let _ = std::fs::create_dir_all(path.parent().unwrap());
 
     with_auth_json_lock(&path, || {
-        let mut auth: Value = if path.exists() {
-            let content = std::fs::read_to_string(&path)?;
-            serde_json::from_str(&content).unwrap_or(json!({}))
-        } else {
-            json!({})
-        };
+        let mut auth = read_auth_json_for_update(&path, "write_credentials", provider)?;
 
+        let before_keys = auth_json_provider_keys(&auth);
         auth[provider] = serde_json::to_value(creds)?;
+        trace_auth_json_key_delta("write_credentials", provider, &before_keys, &auth);
         atomic_write_auth_json(&path, &auth)?;
         set_auth_file_permissions(&path)?;
         let (auth_path, auth_path_source) = auth_path_trace_fields();
@@ -1009,8 +1006,7 @@ pub fn logout_provider(provider: &str) -> anyhow::Result<()> {
     }
 
     with_auth_json_lock(&path, || {
-        let content = std::fs::read_to_string(&path)?;
-        let mut auth: Value = serde_json::from_str(&content)?;
+        let mut auth = read_auth_json_for_update(&path, "logout_provider", canonical)?;
 
         let auth_key = auth_json_key(canonical);
 
@@ -1019,9 +1015,11 @@ pub fn logout_provider(provider: &str) -> anyhow::Result<()> {
         }
 
         // Remove the provider's entry
+        let before_keys = auth_json_provider_keys(&auth);
         if let Some(obj) = auth.as_object_mut() {
             obj.remove(auth_key);
         }
+        trace_auth_json_key_delta("logout_provider", auth_key, &before_keys, &auth);
 
         // Write back
         atomic_write_auth_json(&path, &auth)?;
@@ -2032,17 +2030,19 @@ fn write_credentials_with_extra(
         auth_json_path().ok_or_else(|| anyhow::anyhow!("Cannot determine home directory"))?;
     let _ = std::fs::create_dir_all(path.parent().unwrap());
     with_auth_json_lock(&path, || {
-        let mut auth: Value = if path.exists() {
-            let content = std::fs::read_to_string(&path)?;
-            serde_json::from_str(&content).unwrap_or(json!({}))
-        } else {
-            json!({})
-        };
+        let mut auth = read_auth_json_for_update(&path, "write_credentials_with_extra", provider)?;
         let mut entry = serde_json::to_value(creds)?;
         if let Some(id) = account_id {
             entry["accountId"] = json!(id);
         }
+        let before_keys = auth_json_provider_keys(&auth);
         auth[provider] = entry;
+        trace_auth_json_key_delta(
+            "write_credentials_with_extra",
+            provider,
+            &before_keys,
+            &auth,
+        );
         atomic_write_auth_json(&path, &auth)?;
         set_auth_file_permissions(&path)?;
         let (auth_path, auth_path_source) = auth_path_trace_fields();
@@ -2081,20 +2081,103 @@ fn write_refreshed_credentials(provider: &str, creds: &OAuthCredentials) -> anyh
         auth_json_path().ok_or_else(|| anyhow::anyhow!("Cannot determine home directory"))?;
     let _ = std::fs::create_dir_all(path.parent().unwrap());
     with_auth_json_lock(&path, || {
-        let mut auth: Value = if path.exists() {
-            let content = std::fs::read_to_string(&path)?;
-            serde_json::from_str(&content).unwrap_or(json!({}))
-        } else {
-            json!({})
-        };
+        let mut auth = read_auth_json_for_update(&path, "write_refreshed_credentials", provider)?;
         let existing_entry = auth.get(provider);
-        auth[provider] = refreshed_credential_entry(provider, creds, existing_entry)?;
+        let refreshed_entry = refreshed_credential_entry(provider, creds, existing_entry)?;
+        let before_keys = auth_json_provider_keys(&auth);
+        auth[provider] = refreshed_entry;
+        trace_auth_json_key_delta("write_refreshed_credentials", provider, &before_keys, &auth);
         atomic_write_auth_json(&path, &auth)?;
         set_auth_file_permissions(&path)?;
         let (auth_path, auth_path_source) = auth_path_trace_fields();
         tracing::info!(provider, auth_path = %auth_path, auth_path_source, expires = creds.expires, "persisted refreshed provider credentials to auth.json");
         Ok(())
     })
+}
+
+fn read_auth_json_for_update(
+    path: &Path,
+    operation: &'static str,
+    provider: &str,
+) -> anyhow::Result<Value> {
+    if !path.exists() {
+        return Ok(json!({}));
+    }
+
+    let content = std::fs::read_to_string(path)?;
+    match serde_json::from_str(&content) {
+        Ok(auth) => Ok(auth),
+        Err(error) => {
+            let (auth_path, auth_path_source) = auth_path_trace_fields();
+            tracing::error!(
+                operation,
+                provider,
+                auth_path = %auth_path,
+                auth_path_source,
+                error = %error,
+                content_len = content.len(),
+                "auth.json parse failed before credential update; refusing to replace provider store with partial data"
+            );
+            Err(error.into())
+        }
+    }
+}
+
+fn auth_json_provider_keys(auth: &Value) -> Vec<String> {
+    let mut keys = auth
+        .as_object()
+        .map(|obj| obj.keys().cloned().collect::<Vec<_>>())
+        .unwrap_or_default();
+    keys.sort();
+    keys
+}
+
+fn trace_auth_json_key_delta(
+    operation: &'static str,
+    provider: &str,
+    before_keys: &[String],
+    after: &Value,
+) {
+    let after_keys = auth_json_provider_keys(after);
+    let removed: Vec<&str> = before_keys
+        .iter()
+        .filter(|key| !after_keys.contains(key))
+        .map(String::as_str)
+        .collect();
+    let added: Vec<&str> = after_keys
+        .iter()
+        .filter(|key| !before_keys.contains(key))
+        .map(String::as_str)
+        .collect();
+    let dropped_openai_codex = before_keys.iter().any(|key| key == "openai-codex")
+        && !after_keys.iter().any(|key| key == "openai-codex");
+    let (auth_path, auth_path_source) = auth_path_trace_fields();
+
+    tracing::info!(
+        operation,
+        provider,
+        auth_path = %auth_path,
+        auth_path_source,
+        before_provider_count = before_keys.len(),
+        after_provider_count = after_keys.len(),
+        added = ?added,
+        removed = ?removed,
+        openai_codex_present_before = before_keys.iter().any(|key| key == "openai-codex"),
+        openai_codex_present_after = after_keys.iter().any(|key| key == "openai-codex"),
+        "auth.json provider key set changed"
+    );
+
+    if dropped_openai_codex && provider != "openai-codex" {
+        tracing::error!(
+            operation,
+            provider,
+            auth_path = %auth_path,
+            auth_path_source,
+            before_keys = ?before_keys,
+            after_keys = ?after_keys,
+            "auth.json mutation dropped openai-codex credentials while writing another provider"
+        );
+    }
 }
 
 fn atomic_write_auth_json(path: &Path, auth: &Value) -> anyhow::Result<()> {
@@ -2703,6 +2786,61 @@ mod tests {
             serde_json::from_str(&std::fs::read_to_string(&auth_path).unwrap()).unwrap();
         assert_eq!(contents["test-provider"]["access"], "test-access-token");
         assert_eq!(contents["test-provider"]["refresh"], "test-refresh-token");
+    }
+
+    #[test]
+    fn writing_one_provider_preserves_existing_codex_credentials() {
+        let dir = tempfile::tempdir().unwrap();
+        let override_path = dir.path().join("auth.json");
+        let codex = OAuthCredentials {
+            cred_type: "oauth".into(),
+            access: "codex-access-token".into(),
+            refresh: "codex-refresh-token".into(),
+            expires: 9_999_999_999_999,
+        };
+        let anthropic = OAuthCredentials {
+            cred_type: "oauth".into(),
+            access: "anthropic-access-token".into(),
+            refresh: "anthropic-refresh-token".into(),
+            expires: 9_999_999_999_999,
+        };
+
+        with_auth_json_path_env(Some(&override_path), || {
+            write_credentials_with_extra("openai-codex", &codex, Some("acct_preserved"))
+                .expect("write codex auth");
+            write_credentials("anthropic", &anthropic).expect("write anthropic auth");
+
+            let persisted_codex = read_credentials("openai-codex").expect("codex preserved");
+            assert_eq!(persisted_codex.access, "codex-access-token");
+            assert_eq!(persisted_codex.refresh, "codex-refresh-token");
+            assert_eq!(
+                read_credential_extra("openai-codex", "accountId").as_deref(),
+                Some("acct_preserved")
+            );
+        });
+    }
+
+    #[test]
+    fn credential_write_refuses_to_replace_unparsable_auth_json() {
+        let dir = tempfile::tempdir().unwrap();
+        let override_path = dir.path().join("auth.json");
+        std::fs::write(&override_path, "{not json").unwrap();
+        let creds = OAuthCredentials {
+            cred_type: "oauth".into(),
+            access: "new-access-token".into(),
+            refresh: "new-refresh-token".into(),
+            expires: 9_999_999_999_999,
+        };
+
+        with_auth_json_path_env(Some(&override_path), || {
+            let err = write_credentials("anthropic", &creds)
+                .expect_err("malformed existing auth.json must not be replaced");
+            assert!(!err.to_string().is_empty());
+            assert_eq!(
+                std::fs::read_to_string(&override_path).unwrap(),
+                "{not json"
+            );
+        });
     }
 
     #[test]

--- a/core/crates/omegon/src/tui/active_tool_stream.rs
+++ b/core/crates/omegon/src/tui/active_tool_stream.rs
@@ -129,17 +129,21 @@ fn append_tail_line(
     ]));
 }
 
+struct TailRenderStyle {
+    content_form: crate::surfaces::conversation::ContentForm,
+    tail_style: Style,
+    bg: Color,
+}
+
 fn append_visible_tail(
     lines: &mut Vec<Line<'_>>,
     stream: &ActiveToolStream,
     max_tail: usize,
     text_budget: usize,
-    content_form: crate::surfaces::conversation::ContentForm,
-    tail_style: Style,
-    bg: Color,
+    style: TailRenderStyle,
     t: &dyn theme::Theme,
 ) {
-    let prefix = match content_form {
+    let prefix = match style.content_form {
         crate::surfaces::conversation::ContentForm::Log => "│ ",
         crate::surfaces::conversation::ContentForm::Diff => "╎ ",
         crate::surfaces::conversation::ContentForm::Json
@@ -163,8 +167,8 @@ fn append_visible_tail(
                     prefix,
                     &expand_tabs(&plain),
                     text_budget,
-                    tail_style,
-                    bg,
+                    style.tail_style,
+                    style.bg,
                     t,
                 );
             }
@@ -178,8 +182,8 @@ fn append_visible_tail(
             prefix,
             &strip_control_preserving_tabs(line),
             text_budget,
-            tail_style,
-            bg,
+            style.tail_style,
+            style.bg,
             t,
         );
     }
@@ -247,9 +251,11 @@ pub fn render_active_tool_stream_panel(
         stream,
         max_tail,
         text_budget,
-        content_form,
-        tail_style,
-        bg,
+        TailRenderStyle {
+            content_form,
+            tail_style,
+            bg,
+        },
         t,
     );
 

--- a/docs/release-0.27.0-exploration.md
+++ b/docs/release-0.27.0-exploration.md
@@ -1,0 +1,375 @@
++++
+id = "release-0-27-0-exploration"
+kind = "document"
+title = "0.27.0 release exploration"
+status = "exploring"
+tags = ["release", "0.27.0", "hardening", "ui", "auth", "provider-routing"]
+aliases = ["0.27.0 release exploration", "release-0.27.0"]
+imported_reference = false
+
+[publication]
+enabled = false
+visibility = "private"
++++
+
+# 0.27.0 release exploration
+
+## Purpose
+
+This document captures release exploration findings for the 0.27.0 line: feature work to target after the release, bug fixes that should be considered release blockers or release-hardening work, hardening opportunities, and UI polish opportunities.
+
+This is a working document, not a final release note. The release note source of truth remains `CHANGELOG.md`; this document is for triage and prioritization.
+
+## Current release posture
+
+0.27.0 is already a large surface-coherence and provider-routing line. Recent commits and changelog entries show major work in four clusters:
+
+1. **Provider/auth route control** — explicit startup/login/model-switch routing, fallback/disconnected route state, route warnings, `/auth status` route details, and credential diagnostics.
+2. **Workbench/lifecycle visibility** — Plan Dock promoted to Workbench, slim-mode plan rows, lifecycle workstream projection, and active/incomplete plan retention.
+3. **Console/ACP backend surfaces** — assistant capability inventory, assistant readiness, assistant run read models, secret readiness, blocked/completed run states.
+4. **Conversation/presentation semantics** — peer-agent conversation representation, semantic tool chrome/glyph registry, producer identity separated from content form.
+
+The line is feature-rich enough that further broad feature work should be biased toward post-release unless it closes an observable release blocker.
+
+
+## Mechanics validation update — 2026-06-13
+
+Release-state inspection in `release/0.27-mechanics-validation` found:
+
+- Workspace version remains `0.27.0` in `Cargo.toml`.
+- No local `v0.27.*` tag is present after upstream fetch, so this checkout is still in pre-tag `0.27.0` stabilization posture rather than `0.27.1` patch posture.
+- `core/release.toml` uses shared workspace versioning and `v{{version}}` tag naming.
+- `[Unreleased]` in `CHANGELOG.md` has been normalized to one canonical Added/Changed/Fixed sequence; auth-implementation changelog text from the sibling auth-integrity checkout was intentionally not imported because that code change is outside this workstream.
+
+Release decision: continue as **pre-tag 0.27.0 stabilization** unless another workstream discovers that `v0.27.0` was already published elsewhere. Do not retag if a remote `v0.27.0` appears; reframe remaining work as `0.27.1` patch hardening in that case.
+
+## Findings: bug fixes to target for this release
+
+### 1. Auth store integrity: OpenAI/Codex credential disappearance
+
+**Status:** active hardening in progress.
+
+Observed failure:
+
+- Startup selected `openai-codex:gpt-5.5`.
+- `auth.json` existed at `/Users/wilson/.config/omegon/auth.json`.
+- The startup auth probe reported `provider_entry_exists=false` for `openai-codex`.
+- `/login openai-codex` then persisted a fresh `openai-codex` entry with `accountId` and subsequent probes resolved it successfully.
+
+What is known:
+
+- Provider mapping is correct: `openai-codex` uses auth key `openai-codex` and env var `CHATGPT_OAUTH_TOKEN`.
+- The failure was not env-var priority/order; the stored provider entry was absent at startup.
+- External Codex CLI rescue was unavailable because `~/.codex/auth.json` did not exist.
+
+Release-target fix/hardening already started:
+
+- Auth write paths now trace provider key-set deltas on credential writes, refreshes, and logout.
+- Auth updates now refuse to replace an unparsable existing `auth.json` with a partial store.
+- Regression coverage verifies writing another provider preserves existing `openai-codex` credentials and malformed auth stores are not overwritten.
+
+Release blocker question:
+
+- Run one relaunch cycle with the patched binary and confirm startup hydrates/resolves existing `openai-codex` without `/login`.
+
+### 2. Startup route truthfulness must remain non-negotiable
+
+0.27.0 changed startup fallback behavior from implicit to explicit. The release should not ship any path where the TUI footer, session log, or route state claims one provider/model while requests are served by another.
+
+Must verify before release:
+
+- Selected provider missing credentials + no explicit fallback enters disconnected state.
+- Selected provider missing credentials + explicit fallback displays both selected and served model accurately.
+- `/login` transitions route state to connected and updates visible status without restart.
+- `/model` and model-tier switches route through the controller and do not bypass diagnostics.
+
+### 3. OAuth callback accept-loop regression risk
+
+Recent fix: OAuth callback listeners now accept-loop instead of failing on speculative preconnect/favicon/stale-tab requests.
+
+Release validation should cover:
+
+- Anthropic login.
+- OpenAI/Codex login.
+- Antigravity login if available.
+- Stale browser tab hitting callback endpoint before the actual OAuth redirect.
+
+This is release-relevant because login reliability is foundational for the provider-routing changes.
+
+### 4. `just link` and binary freshness
+
+Recent fix: `just link` rebuilds release binary before linking so `omegon --version` cannot point at stale HEAD.
+
+Release validation should include:
+
+- `just link` from a dirty-but-source-valid tree does not install stale artifacts.
+- `omegon --version` after `just link` matches current commit/version metadata.
+- The installed binary contains the latest auth tracing/hardening before relaunch testing.
+
+### 5. Changelog structure has duplicate `[Unreleased]` subsection headings
+
+Current `CHANGELOG.md` now has `### Added`, `### Fixed`, then another `### Added`/`Changed`/`Fixed` sequence under `[Unreleased]`. This is valid Markdown but weak release hygiene.
+
+Release-target fix:
+
+- Consolidate `[Unreleased]` headings into canonical Keep-a-Changelog order before tagging.
+- Move release-hardening auth entries into the right section.
+
+## Findings: hardening opportunities
+
+### 1. Auth store write audit trail
+
+The new key-delta traces make future credential disappearance attributable through normal write paths. More hardening options:
+
+- Include a short hash/fingerprint of the provider key set, not credential values.
+- Log writer operation context for startup import, external adoption, refresh, login, logout, and API-key login distinctly.
+- Consider a `.bak` file for the last valid `auth.json` before each atomic write.
+- Consider schema validation before accepting existing auth stores.
+- Consider a repair command: `omegon auth doctor --repair`.
+
+Tradeoff: backup/repair adds storage and recovery complexity; trace-only is lower risk for 0.27.0.
+
+### 2. Auth store concurrency and lock robustness
+
+Current lock path is an adjacent `.lock` file with retry. Opportunities:
+
+- Include lock holder PID/timestamp in the lock file.
+- On timeout, report stale lock diagnostics.
+- Consider stale-lock recovery with age threshold.
+- Add tests for concurrent writes preserving all providers.
+
+### 3. Provider-route state machine coverage
+
+The provider-route controller is now central. It needs invariant tests:
+
+- Every public path that changes auth/model state emits a route event.
+- Route selected/served/disconnected/fallback state is serializable to TUI, ACP, and CLI status from the same DTO.
+- Route state cannot claim connected if credential ledger says missing/expired.
+
+### 4. Release preflight for operator workflow regressions
+
+Add or document a focused local release-hardening checklist:
+
+- `just test-commit`
+- `just lint`
+- targeted auth tests
+- manual login smoke for OAuth providers
+- `just link`
+- relaunch with `openai-codex:gpt-5.5`
+- `/auth status`
+- `/model` switch smoke
+- Workbench active-plan smoke
+
+### 5. Extension SDK compatibility warnings
+
+Recent startup logs show incompatible or missing local extensions:
+
+- `omegon-design` SDK contract older than minimum.
+- `omegon-voice` SDK contract older than minimum.
+- `aether`/`shuttle` missing binaries.
+- `vox` permission denied.
+
+These are not necessarily core release blockers, but 0.27.0 surfaces extension capability inventory more prominently. The operator experience should distinguish core release health from local extension drift.
+
+Opportunity:
+
+- Group extension warnings into a concise startup/diagnostic surface.
+- Provide `omegon extension doctor` guidance or reuse capability inventory readiness fields.
+
+## Findings: future feature work
+
+### 1. Auth doctor and credential provenance UI
+
+Build on provider-route diagnostics with a first-class `auth doctor` flow:
+
+- Show auth path source (`default` vs `OMEGON_AUTH_JSON_PATH`).
+- Show provider entries present/missing/expired without secrets.
+- Show external fallback availability (`~/.codex/auth.json`, Claude Code, Gemini CLI, etc.).
+- Show last auth-store mutation operation from logs/audit trail.
+- Offer safe repair: restore backup, re-import external credential, or re-login.
+
+### 2. Unified route/state projection across TUI, CLI, ACP
+
+The release line introduced route-control pieces. Future work should complete the semantic projection:
+
+- One provider route DTO consumed by TUI footer, `/auth status`, ACP, and session logs.
+- Include selected model, served model, credential source, fallback reason, and remediation.
+- Avoid renderer-specific route logic.
+
+### 3. Workbench as operational state, not only UI
+
+Workbench is now the visible operational state for plans, cleave, delegate, and workstreams. Future work:
+
+- Persist Workbench state explicitly enough to recover after restart.
+- Add Workbench reconciliation warnings when assistant final claims conflict with active tasks.
+- Connect Workbench rows to lifecycle/design/OpenSpec provenance.
+- Provide command registry actions for Workbench operations instead of TUI-only arms.
+
+### 4. Capability inventory as release/readiness substrate
+
+The console/ACP capability inventory work can become a release readiness layer:
+
+- Installed extensions and SDK compatibility.
+- Secret readiness.
+- Assistant launch readiness.
+- Package/helper tool availability.
+- Provider/auth route readiness.
+
+Future feature: `omegon readiness` or `omegon doctor` that assembles these into a single operator-facing health report.
+
+### 5. Prompt/loop provenance safety
+
+Recent prompt-surface directives call out prompt templates and `/loop` as executable instruction sources. Future work:
+
+- Preview/validate prompt templates before execution.
+- Record provenance for queued prompts.
+- Add explicit safety handling for repeated `/loop` execution.
+- Share command registry safety metadata with ACP/CLI/TUI.
+
+## Findings: UI polish opportunities
+
+### 1. Provider route footer clarity
+
+The footer/model card should clearly distinguish:
+
+- selected profile model
+- served bridge model
+- fallback provider
+- disconnected/login-required state
+- credential source and expiry state where useful
+
+Avoid dense text in Slim mode. Suggested pattern:
+
+- Connected: `Codex · gpt-5.5 · OAuth`
+- Fallback: `Selected Codex unavailable → serving Claude Fable`
+- Disconnected: `Codex login required · /login openai-codex`
+
+### 2. Workbench visual hierarchy
+
+Workbench has accumulated plan rows, workstreams, delegate/cleave progress, and lifecycle state. Polish opportunities:
+
+- Use stable glyph grammar for todo/in-progress/done/blocked.
+- Keep Slim mode compact but preserve actionable state.
+- Avoid duplicate tool-call cards when Workbench already represents the operation.
+- Add stale/inconsistent indicators when plan state and assistant prose diverge.
+
+### 3. Startup warning grouping
+
+Startup currently can emit many warnings: provider auth, extension SDK drift, missing binaries, route disconnected state, web auth mode, etc.
+
+Polish:
+
+- Group warnings by domain: Auth, Extensions, Tools, Project.
+- Show high-priority remediation first.
+- Keep noisy extension drift out of the main route/auth warning unless it blocks the selected task.
+
+### 4. `/auth status` readability
+
+`/auth status` should be the operator’s first stop for login issues.
+
+Polish opportunities:
+
+- Show selected route and served bridge at top.
+- Show auth store path and source.
+- Show provider table with: status, credential source, expiry/refreshable, external fallback available.
+- For missing selected provider, print exact remediation command.
+
+### 5. Release/doctor UI
+
+A release-hardening line benefits from an operator-facing health command:
+
+- `omegon doctor`
+- `omegon auth doctor`
+- `omegon extension doctor`
+- `omegon release preflight`
+
+This can start as text output and later project into TUI/ACP.
+
+## Release mechanics findings
+
+### Version/tag state
+
+- Workspace version is currently `0.27.0` in `Cargo.toml`.
+- `core/release.toml` is configured for shared workspace versioning and `v{{version}}` tags.
+- The `just release` recipe expects a clean tree, runs `just preflight`, verifies a stable semver version, updates milestone state, commits `chore(release): <version>`, tags `v<version>`, and builds the release binary.
+- `just preflight` is the intended release-readiness guard; it checks branch/version/changelog/install docs/manifest wiring before mutation.
+- Release branch helpers exist: `just branch-release` and `just merge-release-forward`, matching the documented trunk + `release/X.Y` stabilization model.
+
+Implication: if this is still pre-tag 0.27.0 stabilization, release-hardening commits should either land on `release/0.27` or land on `main` before `just release`. If `v0.27.0` has already been published, these findings should be reframed as 0.27.1 patch hardening rather than a refreshed 0.27.0 artifact.
+
+### Available local validation gates
+
+Focused gates observed in `justfile`:
+
+- `just test-commit` — changed-crate Rust validation for focused commits.
+- `just test-rust` — full Rust workspace test gate.
+- `just lint` — fmt, check, clippy for full workspace/all targets.
+- `just upstream-provider-check` — cheap provider drift and upstream version checks.
+- `just preflight` — release preflight before release mutation.
+- `just link` — rebuild/install dev binary.
+
+Release-hardening validation should use focused tests during iteration, then at minimum `just test-commit`, `just lint`, `just preflight`, and `just link` before tagging. Full `just test-rust` remains the stronger release gate when time permits.
+
+### Provider-route code surface requiring release attention
+
+The active route implementation lives in `core/crates/omegon/src/route.rs` with:
+
+- `ProviderRoute::{Serving, Fallback, LoginPending, Disconnected}`.
+- `CredentialLedger` as the real credential probe.
+- `RouteController::resolve_startup` for selected/fallback/disconnected startup state.
+- route events consumed by IPC/MQTT/TUI surfaces.
+
+Risk area: this is now central infrastructure. Any remaining path that creates an LLM bridge or changes provider/model/auth state outside `RouteController` is a release risk because it can make status surfaces lie.
+
+## Parallelizable workstreams
+
+The three most obvious parallelizable workstreams are:
+
+1. **Release mechanics and validation hygiene** — owned by this Omegon/operator session on `release/0.27-mechanics-validation`. Scope: changelog normalization, release/tag decisioning, validation gates, `just link` freshness, and final release readiness.
+2. **UI polish** — owned by `omegon-secundus` on `release/0.27-ui-polish`. Scope: provider-route footer clarity, `/auth status` readability, Workbench visual hierarchy, and startup warning grouping.
+3. **Auth/store integrity and provider-route correctness** — owned by `omegon-quartus` on `release/0.27-auth-integrity`. Scope: Codex credential disappearance, auth-store write safety, relaunch/no-login validation, and route-controller invariants.
+
+Detailed handoff docs:
+
+- [[release-0.27.0-workstream-mechanics-validation|0.27.0 workstream — release mechanics and validation hygiene]]
+- [[release-0.27.0-workstream-ui-polish|0.27.0 workstream — UI polish]]
+- [[release-0.27.0-workstream-auth-integrity|0.27.0 workstream — auth/store integrity and provider-route correctness]]
+
+## Proposed release triage
+
+### Must fix before 0.27.0 tag
+
+- Complete and validate auth-store integrity hardening.
+- Confirm relaunch with existing `openai-codex` auth does not require `/login`.
+- Consolidate `[Unreleased]` changelog headings.
+- Run focused provider-route/auth regression tests.
+- Run `just link` and verify installed binary freshness.
+
+### Should fix if low risk
+
+- Add concurrent auth write preservation test.
+- Add clearer auth-store parse failure operator message.
+- Add route-state smoke command or checklist entry.
+- Reduce startup warning noise around unrelated extension drift.
+
+### Defer to post-release
+
+- Full `auth doctor` repair workflow.
+- Auth store backups and restore command.
+- Unified readiness/doctor surface across providers/extensions/secrets.
+- Workbench persistence/recovery beyond current projection.
+- Larger UI layout redesigns.
+
+## Open questions
+
+1. Should 0.27.0 be treated as already tagged/released and this work become 0.27.1 hardening, or is this a release-line stabilization pass before a refreshed 0.27.0 artifact?
+2. Do we want a `release/0.27` branch for this hardening, or continue focused direct commits on `main`?
+3. Should auth-store backup/restore be included now, or is trace + parse-refusal sufficient for this release?
+4. Which OAuth providers are available for manual smoke on this machine before tag?
+
+## Immediate next steps
+
+1. Finish the current auth-store integrity patch: run focused tests, `just lint` or `just test-commit`, then commit.
+2. Relaunch the linked binary with `openai-codex:gpt-5.5` and confirm no `/login` is required.
+3. Consolidate `CHANGELOG.md` `[Unreleased]` sections.
+4. Decide whether remaining items are release blockers or post-release tasks.

--- a/docs/release-0.27.0-exploration.md
+++ b/docs/release-0.27.0-exploration.md
@@ -31,7 +31,6 @@ This is a working document, not a final release note. The release note source of
 
 The line is feature-rich enough that further broad feature work should be biased toward post-release unless it closes an observable release blocker.
 
-
 ## Mechanics validation update — 2026-06-13
 
 Release-state inspection in `release/0.27-mechanics-validation` found:

--- a/docs/release-0.27.0-workstream-auth-integrity.md
+++ b/docs/release-0.27.0-workstream-auth-integrity.md
@@ -1,0 +1,111 @@
++++
+id = "release-0-27-0-workstream-auth-integrity"
+kind = "document"
+title = "0.27.0 workstream — auth/store integrity and provider-route correctness"
+status = "exploring"
+tags = ["release", "0.27.0", "workstream", "auth", "provider-routing", "hardening"]
+aliases = ["0.27 auth integrity", "auth store integrity workstream"]
+imported_reference = false
+
+[publication]
+enabled = false
+visibility = "private"
++++
+
+# 0.27.0 workstream — auth/store integrity and provider-route correctness
+
+## Owner
+
+Primary owner: **omegon-quartus**.
+
+## Branch
+
+`release/0.27-auth-integrity`
+
+Branch created from current `main` HEAD: `07027739 fix(auth): prefer refreshable oauth credentials`.
+
+## Mission
+
+Make provider authentication and provider-route state reliable enough for the 0.27.0 release. The main release risk is not lack of features; it is an operator being forced to re-login or seeing route/model status that does not match actual credential and bridge state.
+
+## Inputs
+
+- [[release-0.27.0-exploration|0.27.0 release exploration]]
+- `core/crates/omegon/src/auth.rs`
+- `core/crates/omegon/src/setup.rs`
+- `core/crates/omegon/src/route.rs`
+- `core/crates/omegon/src/providers.rs`
+- `core/crates/omegon/src/main.rs`
+- auth/route tests in `auth.rs`, `setup.rs`, `route.rs`, `main.rs`
+
+## Current findings
+
+Observed bug:
+
+- Startup selected `openai-codex:gpt-5.5`.
+- `auth.json` existed but did not contain the `openai-codex` provider entry at startup.
+- `/login openai-codex` restored the entry and route resolution immediately worked.
+- External Codex CLI auth did not exist, so fallback import could not rescue the missing entry.
+
+Current hardening already applied in the active working tree:
+
+- Auth write paths trace provider key-set deltas.
+- Auth writes refuse to replace an unparsable existing auth store with a partial credential file.
+- Regression tests cover preservation of existing `openai-codex` credentials while writing another provider and refusal to overwrite malformed auth JSON.
+
+Important candidate root cause now addressed:
+
+- Previous auth update code used `serde_json::from_str(...).unwrap_or(json!({}))` in multiple write paths. A malformed/transiently unreadable store could therefore become `{}` plus the provider currently being written, dropping unrelated credentials such as `openai-codex`.
+
+## Scope
+
+### In scope
+
+- Finish and validate auth-store integrity hardening.
+- Verify all auth write paths preserve unrelated provider entries.
+- Add concurrent write preservation coverage if feasible.
+- Confirm `openai-codex` accountId survives refresh/login/adoption paths.
+- Confirm startup env hydration reads valid stored Codex auth and does not require `/login` after relaunch.
+- Confirm route state cannot claim connected when credential ledger reports missing/expired.
+- Confirm `/login`, `/logout`, `/model`, and model-tier/offline switches route through `RouteController` where applicable.
+
+### Out of scope
+
+- UI copy/layout polish except where needed for correct route truthfulness.
+- Release script and changelog mechanics.
+- New provider integrations.
+- Full auth backup/restore workflow unless required to close a release blocker.
+
+## Acceptance criteria
+
+- Existing `openai-codex` credentials cannot be dropped by normal auth writes for another provider.
+- Malformed existing `auth.json` is not replaced by a partial provider store.
+- Focused auth tests pass.
+- Relaunch with stored `openai-codex` credentials reaches connected route state without `/login`.
+- `/auth status` reports `openai-codex` authenticated when the stored entry exists and is valid.
+- If the selected provider is missing/expired, startup route state is disconnected or explicit fallback — never silent fallback.
+- Findings and any remaining risks are recorded in [[release-0.27.0-exploration]].
+
+## Suggested task breakdown
+
+1. Review current auth diff in `core/crates/omegon/src/auth.rs`.
+2. Run focused tests:
+   - `cargo test -p omegon credential_write_refuses_to_replace_unparsable_auth_json`
+   - `cargo test -p omegon writing_one_provider_preserves_existing_codex_credentials`
+   - `cargo test -p omegon refreshed_codex_entry_preserves_existing_account_id`
+3. Add any missing tests for concurrent writes or adoption/refresh preservation if low risk.
+4. Run `just link` from the patched branch.
+5. Relaunch with `openai-codex:gpt-5.5`; confirm no `/login` required.
+6. Inspect `~/.config/omegon/omegon.log` for auth key-delta traces and startup route resolution.
+7. Commit auth integrity patch.
+
+## Risks
+
+- Logging provider key names is acceptable; never log credential values.
+- Backups/repair are tempting but may be too large for this release branch. Trace + parse-refusal may be the right 0.27.0-sized fix.
+- Route correctness spans multiple files. Avoid duplicating route logic outside `RouteController`; test invariants instead.
+
+## Coordination notes
+
+- Coordinate with `release/0.27-ui-polish` for operator-facing wording around missing credentials and route remediation.
+- Coordinate with `release/0.27-mechanics-validation` before final validation because this workstream owns the highest-risk release bug.

--- a/docs/release-0.27.0-workstream-mechanics-validation.md
+++ b/docs/release-0.27.0-workstream-mechanics-validation.md
@@ -1,0 +1,138 @@
++++
+id = "release-0-27-0-workstream-mechanics-validation"
+kind = "document"
+title = "0.27.0 workstream — release mechanics and validation hygiene"
+status = "exploring"
+tags = ["release", "0.27.0", "workstream", "validation", "release-mechanics"]
+aliases = ["0.27 mechanics validation", "release mechanics validation workstream"]
+imported_reference = false
+
+[publication]
+enabled = false
+visibility = "private"
++++
+
+# 0.27.0 workstream — release mechanics and validation hygiene
+
+## Owner
+
+Primary owner: **current Omegon session / operator pair**.
+
+## Branch
+
+`release/0.27-mechanics-validation`
+
+Branch created from current `main` HEAD: `07027739 fix(auth): prefer refreshable oauth credentials`.
+
+## Mission
+
+Make the 0.27.0 release process boring: clean release notes, clear version/tag state, repeatable validation gates, and explicit release-vs-patch decisioning.
+
+This workstream owns release hygiene, not broad product changes.
+
+## Inputs
+
+- [[release-0.27.0-exploration|0.27.0 release exploration]]
+- `CHANGELOG.md`
+- `Cargo.toml`
+- `core/release.toml`
+- `justfile`
+- `scripts/release_preflight.py`
+- `scripts/release_branch.py`
+- release-related tests under `tests/`
+
+## Current findings
+
+- Workspace version is `0.27.0`. No local `v0.27.*` tag was present after upstream fetch, so this checkout is in pre-tag `0.27.0` stabilization posture.
+- `core/release.toml` uses shared versioning and `v{{version}}` tags.
+- `just release` expects a clean tree, `just preflight`, stable semver, milestone update, release commit, tag, and release build.
+- Release branch helpers exist: `just branch-release` and `just merge-release-forward`.
+- `CHANGELOG.md` previously had duplicated `[Unreleased]` subsection groups after recent hardening edits; this checkout now has one canonical Added/Changed/Fixed sequence.
+- Recent `just link` hardening should be included in validation: installed binary must not lag source HEAD.
+
+## Scope
+
+### In scope
+
+- Consolidate `[Unreleased]` changelog headings into canonical Keep-a-Changelog order.
+- Ensure release-hardening entries are correctly classified under Added/Changed/Fixed.
+- Verify whether this is pre-tag `0.27.0` stabilization or should become `0.27.1` patch hardening.
+- Run or repair release validation gates:
+  - `just test-commit`
+  - `just lint`
+  - `just preflight`
+  - `just link`
+  - optional: `just test-rust` if time permits
+- Document any gate failures with concrete file/test ownership.
+- Confirm `omegon --version` after `just link` reflects the current build.
+- Produce the final release decision note: tag 0.27.0 vs patch 0.27.1.
+
+### Out of scope
+
+- Provider auth implementation fixes except where needed to unblock release gates.
+- TUI layout or footer polish.
+- Extension SDK compatibility remediation unless it blocks `just preflight` or release packaging.
+- New product features.
+
+## Acceptance criteria
+
+- `[Unreleased]` in `CHANGELOG.md` has a single canonical section sequence.
+- Release mechanics decision is recorded: pre-tag 0.27.0 stabilization or 0.27.1 patch.
+- Required validation gates are run and results recorded.
+- If a validation gate fails, the failure is either fixed or assigned to another release workstream with evidence.
+- `just link` has been run successfully after hardening patches, and installed binary freshness is verified.
+- Workstream commits use conventional commit messages.
+
+## Suggested task breakdown
+
+1. Inspect release state:
+   - `git status --short`
+   - `git tag --list 'v0.27*'`
+   - `git branch --show-current`
+   - `grep '^version = ' Cargo.toml`
+2. Normalize `CHANGELOG.md`.
+   - Status: done in this checkout; duplicated `[Unreleased]` Added/Fixed sections were consolidated into one canonical Added/Changed/Fixed sequence. Auth-implementation changelog text from the sibling auth-integrity checkout was intentionally not imported because its code change is outside this workstream.
+3. Run focused release-hygiene validation:
+   - `just test-commit`
+   - `just lint`
+   - `just preflight`
+4. Run `just link`; verify `omegon --version`.
+5. Write release decision result back into [[release-0.27.0-exploration]].
+6. Commit the mechanics/validation workstream.
+
+## Risks
+
+- Full `just lint`/`just test-rust` may expose unrelated long-standing failures. Do not silently absorb those into this workstream; record and route them.
+- If `v0.27.0` already exists remotely, do not attempt to retag. Reframe as `0.27.1` patch hardening.
+- Release scripts may require clean tree; coordinate with the other workstreams before running mutation-producing release commands.
+
+## Coordination notes
+
+- Coordinate with `release/0.27-auth-integrity` before final release validation because auth-store hardening is currently the most release-relevant bug fix.
+- Coordinate with `release/0.27-ui-polish` only for release notes and validation smoke; UI polish should not block mechanics unless it exposes route truthfulness regressions.
+
+
+## Release decision
+
+Current decision: **pre-tag 0.27.0 stabilization**.
+
+Evidence:
+
+- `Cargo.toml` declares `version = "0.27.0"`.
+- `core/release.toml` declares shared versioning and `v{{version}}` tags.
+- `git tag --list 'v0.27*'` returned no local `0.27` tags after upstream fetch.
+
+If a remote/published `v0.27.0` tag appears before final release work, do not retag; convert remaining hardening to `0.27.1` patch work.
+
+## Validation log
+
+- `just test-commit`: **passed**. The changed-path detector found no affected Rust crates for the docs/changelog-only mechanics slice, so cargo tests were skipped.
+- `just lint`: **failed outside this workstream scope**. `cargo fmt --all --check` and `cargo check --workspace` passed, then clippy reported:
+  - `core/crates/omegon/src/tui/active_tool_stream.rs:132`: `clippy::too_many_arguments` on `append_visible_tail`; route to the UI polish workstream.
+  - `core/crates/omegon/src/auth.rs:2498`: `clippy::await_holding_lock` in `resolve_with_refresh_prefers_persisted_oauth_over_oauth_env`; route to the auth-integrity workstream.
+- `just source-clean`: **passed after commit**; source tree clean.
+- `just preflight`: **failed by branch/workspace role policy**, not by release content: current branch is `release/0.27-mechanics-validation`, while preflight only accepts `main` or `release/X.Y`, and this checkout has no release workspace role set. Rerun from `release/0.27`/`main` with release role when cutting.
+- `just link`: **passed**. It rebuilt `target/release/omegon`, linked aliases to that binary, installed bundled skills/catalog, and printed `omegon 0.27.0 (e7234c1 2026-06-13)`.
+- Binary freshness check: **passed** via `target/release/omegon --version` and an interactive shell sourcing `~/.omegon/dev-alias.sh`; both reported `omegon 0.27.0 (e7234c1 2026-06-13)`.
+
+Validation status: mechanics normalization and binary freshness are complete. Final release readiness remains blocked on the UI/auth clippy failures or an explicit release-owner waiver, plus rerunning `just preflight` from an accepted release branch/workspace role.

--- a/docs/release-0.27.0-workstream-mechanics-validation.md
+++ b/docs/release-0.27.0-workstream-mechanics-validation.md
@@ -127,12 +127,11 @@ If a remote/published `v0.27.0` tag appears before final release work, do not re
 ## Validation log
 
 - `just test-commit`: **passed**. The changed-path detector found no affected Rust crates for the docs/changelog-only mechanics slice, so cargo tests were skipped.
-- `just lint`: **failed outside this workstream scope**. `cargo fmt --all --check` and `cargo check --workspace` passed, then clippy reported:
-  - `core/crates/omegon/src/tui/active_tool_stream.rs:132`: `clippy::too_many_arguments` on `append_visible_tail`; route to the UI polish workstream.
-  - `core/crates/omegon/src/auth.rs:2498`: `clippy::await_holding_lock` in `resolve_with_refresh_prefers_persisted_oauth_over_oauth_env`; route to the auth-integrity workstream.
+- `just test-rust`: **passed** for the full workspace release test gate.
+- `just lint`: **passed** after clearing the two clippy release-gate blockers: active-tool tail rendering now groups style parameters, and the persisted OAuth precedence regression test keeps its process-wide auth environment lock out of async execution.
 - `just source-clean`: **passed after commit**; source tree clean.
 - `just preflight`: **failed by branch/workspace role policy**, not by release content: current branch is `release/0.27-mechanics-validation`, while preflight only accepts `main` or `release/X.Y`, and this checkout has no release workspace role set. Rerun from `release/0.27`/`main` with release role when cutting.
-- `just link`: **passed**. It rebuilt `target/release/omegon`, linked aliases to that binary, installed bundled skills/catalog, and printed `omegon 0.27.0 (e7234c1 2026-06-13)`.
-- Binary freshness check: **passed** via `target/release/omegon --version` and an interactive shell sourcing `~/.omegon/dev-alias.sh`; both reported `omegon 0.27.0 (e7234c1 2026-06-13)`.
+- `just link`: **passed**. It rebuilt `target/release/omegon`, linked aliases to that binary, installed bundled skills/catalog, and printed `omegon 0.27.0 (8a30d45 2026-06-13)`.
+- Binary freshness check: **passed** via `target/release/omegon --version` and an interactive shell sourcing `~/.omegon/dev-alias.sh`; both reported `omegon 0.27.0 (8a30d45 2026-06-13)`.
 
-Validation status: mechanics normalization and binary freshness are complete. Final release readiness remains blocked on the UI/auth clippy failures or an explicit release-owner waiver, plus rerunning `just preflight` from an accepted release branch/workspace role.
+Validation status: mechanics normalization, lint, focused changed-crate validation, full workspace release tests, and binary freshness are complete. Final release readiness still requires rerunning `just preflight` from an accepted release branch/workspace role.

--- a/docs/release-0.27.0-workstream-ui-polish.md
+++ b/docs/release-0.27.0-workstream-ui-polish.md
@@ -1,0 +1,109 @@
++++
+id = "release-0-27-0-workstream-ui-polish"
+kind = "document"
+title = "0.27.0 workstream — UI polish"
+status = "exploring"
+tags = ["release", "0.27.0", "workstream", "ui", "tui", "polish"]
+aliases = ["0.27 UI polish", "release UI polish workstream"]
+imported_reference = false
+
+[publication]
+enabled = false
+visibility = "private"
++++
+
+# 0.27.0 workstream — UI polish
+
+## Owner
+
+Primary owner: **omegon-secundus**.
+
+## Branch
+
+`release/0.27-ui-polish`
+
+Branch created from current `main` HEAD: `07027739 fix(auth): prefer refreshable oauth credentials`.
+
+## Mission
+
+Make 0.27.0’s operator-facing surfaces truthful, legible, and calm. The release has added provider-route state, Workbench visibility, command safety metadata, and capability/readiness surfaces; UI polish should reduce confusion without reopening core architecture.
+
+## Inputs
+
+- [[release-0.27.0-exploration|0.27.0 release exploration]]
+- `core/crates/omegon/src/tui/footer.rs`
+- `core/crates/omegon/src/tui/mod.rs`
+- `core/crates/omegon/src/features/auth.rs`
+- `core/crates/omegon/src/route.rs`
+- Workbench/plan rendering helpers under `core/crates/omegon/src/tools.rs` and TUI modules
+- startup warning paths in `core/crates/omegon/src/main.rs` / `setup.rs`
+
+## Current findings
+
+- Provider-route surfaces now distinguish selected vs served route state, fallback, login-pending, and disconnected states.
+- Recent bugs made truthful footer/model display release-critical; UI must not imply the selected provider is serving when fallback or disconnected state is active.
+- Workbench is now operational state for plans, cleave, delegate, and lifecycle workstreams; it must stay compact in Slim mode but preserve actionable state.
+- Startup logs can be noisy because provider/auth warnings and local extension drift appear in the same launch window.
+
+## Scope
+
+### In scope
+
+- Improve provider route footer/model-card clarity.
+- Improve `/auth status` readability around selected route, served bridge, credential state, and remediation.
+- Group startup warnings by domain where low risk:
+  - Auth
+  - Extensions
+  - Tools
+  - Project
+- Keep unrelated extension drift from masking selected-provider auth failures.
+- Tighten Workbench visual hierarchy:
+  - stable glyph grammar
+  - compact plan rows
+  - clear blocked/waiting/in-progress/done state
+  - no duplicate successful `/plan` noise if Workbench already represents it
+- Add or adjust focused snapshot/unit tests for UI formatting where practical.
+
+### Out of scope
+
+- Core provider-route state-machine changes.
+- Auth-store write-path fixes.
+- Release script mechanics.
+- Large TUI redesigns or new alternate frontends.
+- Extension SDK upgrades unless needed to reduce warning presentation noise.
+
+## Acceptance criteria
+
+- Footer/model-card copy clearly distinguishes connected, fallback, and disconnected states.
+- Missing selected-provider credentials show exact remediation, e.g. `/login openai-codex`.
+- `/auth status` remains readable in narrow terminals and includes selected/served route truth.
+- Startup warnings are less noisy or at least more domain-separated.
+- Workbench rows remain compact and actionable in Slim mode.
+- Any UI changes have focused tests or snapshot-style assertions where the project already has coverage seams.
+
+## Suggested task breakdown
+
+1. Inspect current route/footer rendering:
+   - route warning projection
+   - footer model card
+   - `/auth status` output
+2. Draft copy variants for three states:
+   - Connected: `Codex · gpt-5.5 · OAuth`
+   - Fallback: `Selected Codex unavailable → serving Claude Fable`
+   - Disconnected: `Codex login required · /login openai-codex`
+3. Patch the smallest rendering layer that consumes existing route state.
+4. Group or prioritize startup warnings without changing underlying diagnostics.
+5. Run focused UI/auth/status tests.
+6. Update [[release-0.27.0-exploration]] with shipped polish and remaining deferrals.
+7. Commit on `release/0.27-ui-polish`.
+
+## Risks
+
+- UI polish can accidentally hide diagnostic detail needed for release debugging. Prefer progressive disclosure: concise visible summary plus detailed `/auth status` or log trail.
+- Do not duplicate route logic in TUI. Consume semantic route/controller state.
+- Avoid broad layout churn in the release branch; release polish should be minimal and testable.
+
+## Coordination notes
+
+- Coordinate with `release/0.27-auth-integrity` for exact auth remediation wording and credential-state fields.
+- Coordinate with `release/0.27-mechanics-validation` for final changelog entries and release validation smoke.


### PR DESCRIPTION
## Summary
- Capture the 0.27.0 release exploration and workstream handoff docs.
- Normalize the [Unreleased] changelog section into one canonical Added/Changed/Fixed sequence.
- Clear release lint blockers in active tool tail rendering and the persisted OAuth precedence regression test.
- Record release validation evidence and preflight branch/workspace-role constraint.

## Validation
- just lint
- just test-commit
- just test-rust
- just source-clean
- just link

## Notes
- Release posture remains pre-tag 0.27.0 stabilization.
- just preflight must be rerun from main or release/0.27 with release workspace role set.