### PR TITLE
UI polish for release 0.27

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [Semantic V
 - Slim Workbench plan rows now keep active and todo items visible before completed items when compact height forces overflow.
 - Disconnected TUI engine footer rows now name the selected provider and exact `/login <provider>` remediation instead of a generic provider warning.
 - Slim tool summary rows now render detail affordances as right-aligned inline controls using compact key glyphs such as `⌃O details`.
+- TUI engine footer rows now use flex-style spacing so row values align against the right edge while preserving label/value styling.
 - TUI conversation rendering now marks the explicitly selected segment, shows queued prompt info below the operator editor, and shows an `Enter: details` hint only for selected segments with detail affordances.
 - Keep extension JSON-RPC request IDs monotonic after optional `initialize` timeouts, and update extension test fixtures to echo dynamic request IDs.
 - Start decoupling TUI conversation segments by moving role/emphasis/tool visual projection types into a dedicated conversation projection module.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [Semantic V
 
 ### Changed
 
+- Slim Workbench plan rows now keep active and todo items visible before completed items when compact height forces overflow.
 - TUI conversation rendering now marks the explicitly selected segment, shows queued prompt info below the operator editor, and shows an `Enter: details` hint only for selected segments with detail affordances.
 - Keep extension JSON-RPC request IDs monotonic after optional `initialize` timeouts, and update extension test fixtures to echo dynamic request IDs.
 - Start decoupling TUI conversation segments by moving role/emphasis/tool visual projection types into a dedicated conversation projection module.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [Semantic V
 
 - Slim Workbench plan rows now keep active and todo items visible before completed items when compact height forces overflow.
 - Disconnected TUI engine footer rows now name the selected provider and exact `/login <provider>` remediation instead of a generic provider warning.
+- Slim tool summary rows now render detail affordances as right-aligned inline controls using compact key glyphs such as `⌃O details`.
 - TUI conversation rendering now marks the explicitly selected segment, shows queued prompt info below the operator editor, and shows an `Enter: details` hint only for selected segments with detail affordances.
 - Keep extension JSON-RPC request IDs monotonic after optional `initialize` timeouts, and update extension test fixtures to echo dynamic request IDs.
 - Start decoupling TUI conversation segments by moving role/emphasis/tool visual projection types into a dedicated conversation projection module.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [Semantic V
 ### Changed
 
 - Slim Workbench plan rows now keep active and todo items visible before completed items when compact height forces overflow.
+- Disconnected TUI engine footer rows now name the selected provider and exact `/login <provider>` remediation instead of a generic provider warning.
 - TUI conversation rendering now marks the explicitly selected segment, shows queued prompt info below the operator editor, and shows an `Enter: details` hint only for selected segments with detail affordances.
 - Keep extension JSON-RPC request IDs monotonic after optional `initialize` timeouts, and update extension test fixtures to echo dynamic request IDs.
 - Start decoupling TUI conversation segments by moving role/emphasis/tool visual projection types into a dedicated conversation projection module.

--- a/core/crates/omegon/src/surfaces/inline.rs
+++ b/core/crates/omegon/src/surfaces/inline.rs
@@ -1,0 +1,128 @@
+//! Renderer-neutral inline row composition primitives.
+//!
+//! Inline rows describe a single horizontal line as semantic left/right cell
+//! groups. Renderers decide glyphs, colors, and exact truncation, but the
+//! projection keeps right-side affordances first-class instead of burying them
+//! in left-flow text.
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InlineRow<T = String> {
+    pub left: Vec<InlineCell<T>>,
+    pub right: Vec<InlineCell<T>>,
+    pub overflow: InlineOverflowPolicy,
+}
+
+impl<T> InlineRow<T> {
+    pub fn new(left: Vec<InlineCell<T>>, right: Vec<InlineCell<T>>) -> Self {
+        Self {
+            left,
+            right,
+            overflow: InlineOverflowPolicy::PreserveRight,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InlineCell<T = String> {
+    pub text: T,
+    pub role: InlineCellRole,
+    pub priority: InlinePriority,
+}
+
+impl<T> InlineCell<T> {
+    pub fn new(text: T, role: InlineCellRole) -> Self {
+        Self {
+            text,
+            role,
+            priority: InlinePriority::Normal,
+        }
+    }
+
+    pub fn with_priority(mut self, priority: InlinePriority) -> Self {
+        self.priority = priority;
+        self
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InlineCellRole {
+    Label,
+    Value,
+    Metadata,
+    Affordance,
+    Separator,
+    Status,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum InlinePriority {
+    Low,
+    Normal,
+    High,
+    Required,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InlineOverflowPolicy {
+    PreserveRight,
+    DropRightWhenCrowded,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InlineAffordance {
+    Details,
+    Expand,
+    Open,
+    Select,
+}
+
+impl InlineAffordance {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Details => "details",
+            Self::Expand => "expand",
+            Self::Open => "open",
+            Self::Select => "select",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum KeyChord {
+    Ctrl(char),
+    Enter,
+    Esc,
+    Tab,
+    ShiftTab,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ActionHint {
+    pub action: InlineAffordance,
+    pub key: KeyChord,
+}
+
+impl ActionHint {
+    pub fn new(action: InlineAffordance, key: KeyChord) -> Self {
+        Self { action, key }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn inline_row_keeps_affordances_structured() {
+        let row = InlineRow::new(
+            vec![InlineCell::new("bash", InlineCellRole::Value)],
+            vec![
+                InlineCell::new("details", InlineCellRole::Affordance)
+                    .with_priority(InlinePriority::Required),
+            ],
+        );
+        assert_eq!(row.left[0].role, InlineCellRole::Value);
+        assert_eq!(row.right[0].role, InlineCellRole::Affordance);
+        assert_eq!(row.overflow, InlineOverflowPolicy::PreserveRight);
+    }
+}

--- a/core/crates/omegon/src/surfaces/mod.rs
+++ b/core/crates/omegon/src/surfaces/mod.rs
@@ -4,5 +4,6 @@ pub mod conversation;
 pub mod dashboard;
 pub mod editor;
 pub mod footer;
+pub mod inline;
 pub mod instruments;
 pub mod layout;

--- a/core/crates/omegon/src/tui/footer.rs
+++ b/core/crates/omegon/src/tui/footer.rs
@@ -281,10 +281,23 @@ impl FooterData {
         }
 
         if !self.provider_connected {
+            let provider_label = crate::auth::provider_by_id(&self.model_provider)
+                .map(|p| p.display_name)
+                .unwrap_or(self.model_provider.as_str());
+            let status_text = if self.model_provider.trim().is_empty() {
+                "⚠ provider login required".to_string()
+            } else {
+                format!("⚠ {provider_label} login required")
+            };
+            let action_text = if self.model_provider.trim().is_empty() {
+                "/login <provider>".to_string()
+            } else {
+                format!("/login {}", self.model_provider)
+            };
             push_row(
                 &mut lines,
                 "status",
-                "⚠ no provider".to_string(),
+                status_text,
                 value_width,
                 t.border_dim(),
                 t.warning(),
@@ -293,7 +306,7 @@ impl FooterData {
             push_row(
                 &mut lines,
                 "action",
-                "/login to connect".to_string(),
+                action_text,
                 value_width,
                 t.border_dim(),
                 t.muted(),
@@ -1901,10 +1914,26 @@ mod tests {
             .unwrap();
 
         let text = render_to_string(&terminal);
-        assert!(text.contains("no provider"), "got {text}");
+        assert!(text.contains("OpenAI API login required"), "got {text}");
+        assert!(text.contains("/login openai"), "got {text}");
         assert!(!text.contains("stale row sentinel"), "got {text}");
         assert!(!text.contains("codex 0%"), "got {text}");
         assert!(!text.contains("T9"), "got {text}");
+    }
+
+    #[test]
+    fn left_panel_disconnected_provider_names_exact_login_command() {
+        let data = FooterData {
+            model_id: "openai-codex:gpt-5.5".into(),
+            model_provider: "openai-codex".into(),
+            provider_connected: false,
+            ..Default::default()
+        };
+        let text = render_left_panel_text(&data, 72, 6);
+
+        assert!(text.contains("OpenAI/Codex login required"), "got {text}");
+        assert!(text.contains("/login openai-codex"), "got {text}");
+        assert!(!text.contains("/login to connect"), "got {text}");
     }
 
     #[test]

--- a/core/crates/omegon/src/tui/footer.rs
+++ b/core/crates/omegon/src/tui/footer.rs
@@ -6,7 +6,7 @@
 use chrono::{DateTime, Utc};
 use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, Clear, Padding, Paragraph};
-use unicode_width::UnicodeWidthChar;
+use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 use super::model_catalog::ModelCatalog;
 use super::theme::Theme;
@@ -483,6 +483,35 @@ impl FooterData {
         frame.render_widget(Clear, inner);
         let widget = Paragraph::new(lines).style(Style::default().bg(bg));
         frame.render_widget(widget, inner);
+    }
+
+    fn engine_flex_row(
+        label: &str,
+        value: String,
+        row_width: usize,
+        label_width: usize,
+        value_max_width: usize,
+        label_color: Color,
+        value_color: Color,
+        value_bold: bool,
+    ) -> Line<'static> {
+        let label_text = format!(" {:<width$} ", label, width = label_width);
+        let label_display_width = UnicodeWidthStr::width(label_text.as_str());
+        let value_budget = value_max_width.min(row_width.saturating_sub(label_display_width + 1));
+        let value_text = truncate_for_width(&value, value_budget);
+        let value_display_width = UnicodeWidthStr::width(value_text.as_str());
+        let spacer_width = row_width.saturating_sub(label_display_width + value_display_width);
+
+        let mut value_style = Style::default().fg(value_color);
+        if value_bold {
+            value_style = value_style.add_modifier(Modifier::BOLD);
+        }
+
+        Line::from(vec![
+            Span::styled(label_text, Style::default().fg(label_color)),
+            Span::raw(" ".repeat(spacer_width)),
+            Span::styled(value_text, value_style),
+        ])
     }
 
     fn render_memory_section(&self, area: Rect, frame: &mut Frame, t: &dyn Theme) {
@@ -1244,6 +1273,53 @@ mod tests {
                 data.render(frame.area(), frame, &super::super::theme::Alpharius);
             })
             .unwrap();
+    }
+
+    #[test]
+    fn engine_flex_row_right_aligns_value() {
+        let line = FooterData::engine_flex_row(
+            "model",
+            "gpt-5.5".to_string(),
+            32,
+            7,
+            22,
+            Color::Blue,
+            Color::White,
+            true,
+        );
+        let text = line
+            .spans
+            .iter()
+            .map(|span| span.content.as_ref())
+            .collect::<String>();
+
+        assert_eq!(UnicodeWidthStr::width(text.as_str()), 32);
+        assert!(text.starts_with(" model   "), "{text:?}");
+        assert!(text.ends_with("gpt-5.5"), "{text:?}");
+        assert!(text.contains("  gpt-5.5"), "{text:?}");
+    }
+
+    #[test]
+    fn engine_flex_row_truncates_value_before_right_edge() {
+        let line = FooterData::engine_flex_row(
+            "limit",
+            "codex 100% left · 7d 40% left · credits metered · ok".to_string(),
+            28,
+            7,
+            18,
+            Color::Blue,
+            Color::White,
+            false,
+        );
+        let text = line
+            .spans
+            .iter()
+            .map(|span| span.content.as_ref())
+            .collect::<String>();
+
+        assert_eq!(UnicodeWidthStr::width(text.as_str()), 28);
+        assert!(text.starts_with(" limit   "), "{text:?}");
+        assert!(text.ends_with('…'), "{text:?}");
     }
 
     #[test]

--- a/core/crates/omegon/src/tui/inline_render.rs
+++ b/core/crates/omegon/src/tui/inline_render.rs
@@ -1,0 +1,196 @@
+//! Ratatui adapters for renderer-neutral inline row projections.
+
+use ratatui::prelude::*;
+use unicode_width::UnicodeWidthStr;
+
+use crate::surfaces::inline::{
+    ActionHint, InlineAffordance, InlineCell, InlineCellRole, InlineOverflowPolicy, InlineRow,
+    KeyChord,
+};
+
+use super::theme::Theme;
+
+const ELLIPSIS: &str = "…";
+
+pub fn key_chord_label(chord: KeyChord) -> String {
+    match chord {
+        KeyChord::Ctrl(ch) => format!("⌃{}", ch.to_ascii_uppercase()),
+        KeyChord::Enter => "↵".to_string(),
+        KeyChord::Esc => "Esc".to_string(),
+        KeyChord::Tab => "Tab".to_string(),
+        KeyChord::ShiftTab => "⇧Tab".to_string(),
+    }
+}
+
+pub fn action_hint_label(hint: ActionHint) -> String {
+    format!("{} {}", key_chord_label(hint.key), hint.action.label())
+}
+
+pub fn details_hint_cell() -> InlineCell<String> {
+    InlineCell::new(
+        action_hint_label(ActionHint::new(
+            InlineAffordance::Details,
+            KeyChord::Ctrl('O'),
+        )),
+        InlineCellRole::Affordance,
+    )
+    .with_priority(crate::surfaces::inline::InlinePriority::Required)
+}
+
+pub fn expand_hint_cell() -> InlineCell<String> {
+    InlineCell::new(
+        action_hint_label(ActionHint::new(
+            InlineAffordance::Expand,
+            KeyChord::Ctrl('O'),
+        )),
+        InlineCellRole::Affordance,
+    )
+    .with_priority(crate::surfaces::inline::InlinePriority::Required)
+}
+
+pub fn render_inline_text_row(row: &InlineRow<String>, width: u16) -> String {
+    let width = width as usize;
+    if width == 0 {
+        return String::new();
+    }
+
+    let left = join_cells(&row.left);
+    let right = join_cells(&row.right);
+    match (left.is_empty(), right.is_empty()) {
+        (true, true) => String::new(),
+        (false, true) => truncate_display(&left, width),
+        (true, false) => match row.overflow {
+            InlineOverflowPolicy::PreserveRight => {
+                right_align(&truncate_display(&right, width), width)
+            }
+            InlineOverflowPolicy::DropRightWhenCrowded => truncate_display(&right, width),
+        },
+        (false, false) => render_split_text(&left, &right, width, row.overflow),
+    }
+}
+
+pub fn render_inline_row(
+    row: &InlineRow<String>,
+    width: u16,
+    t: &dyn Theme,
+    bg: Color,
+) -> Line<'static> {
+    let text = render_inline_text_row(row, width);
+    Line::from(Span::styled(text, Style::default().fg(t.fg()).bg(bg)))
+}
+
+fn render_split_text(
+    left: &str,
+    right: &str,
+    width: usize,
+    overflow: InlineOverflowPolicy,
+) -> String {
+    let right_width = UnicodeWidthStr::width(right);
+    match overflow {
+        InlineOverflowPolicy::PreserveRight if right_width < width => {
+            let left_budget = width.saturating_sub(right_width).saturating_sub(1);
+            let left = truncate_display(left, left_budget);
+            let used = UnicodeWidthStr::width(left.as_str()) + right_width;
+            let gap = width.saturating_sub(used).max(1);
+            format!("{left}{}{right}", " ".repeat(gap))
+        }
+        InlineOverflowPolicy::PreserveRight => truncate_display(right, width),
+        InlineOverflowPolicy::DropRightWhenCrowded
+            if UnicodeWidthStr::width(left) + 1 + right_width <= width =>
+        {
+            let gap = width
+                .saturating_sub(UnicodeWidthStr::width(left) + right_width)
+                .max(1);
+            format!("{left}{}{right}", " ".repeat(gap))
+        }
+        InlineOverflowPolicy::DropRightWhenCrowded => truncate_display(left, width),
+    }
+}
+
+fn join_cells(cells: &[InlineCell<String>]) -> String {
+    cells
+        .iter()
+        .filter(|cell| !cell.text.is_empty())
+        .map(|cell| cell.text.as_str())
+        .collect::<Vec<_>>()
+        .join(" · ")
+}
+
+fn right_align(text: &str, width: usize) -> String {
+    let text_width = UnicodeWidthStr::width(text);
+    if text_width >= width {
+        text.to_string()
+    } else {
+        format!("{}{text}", " ".repeat(width - text_width))
+    }
+}
+
+fn truncate_display(text: &str, budget: usize) -> String {
+    if budget == 0 {
+        return String::new();
+    }
+    if UnicodeWidthStr::width(text) <= budget {
+        return text.to_string();
+    }
+    if budget <= UnicodeWidthStr::width(ELLIPSIS) {
+        return ELLIPSIS.to_string();
+    }
+
+    let mut out = String::new();
+    let mut used = 0usize;
+    let ellipsis_width = UnicodeWidthStr::width(ELLIPSIS);
+    for ch in text.chars() {
+        let ch_width = unicode_width::UnicodeWidthChar::width(ch).unwrap_or(0);
+        if used + ch_width + ellipsis_width > budget {
+            break;
+        }
+        out.push(ch);
+        used += ch_width;
+    }
+    out.push_str(ELLIPSIS);
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::surfaces::inline::{InlineCellRole, InlinePriority};
+
+    #[test]
+    fn ctrl_key_uses_compact_glyph() {
+        assert_eq!(key_chord_label(KeyChord::Ctrl('o')), "⌃O");
+        assert_eq!(
+            action_hint_label(ActionHint::new(
+                InlineAffordance::Details,
+                KeyChord::Ctrl('O')
+            )),
+            "⌃O details"
+        );
+    }
+
+    #[test]
+    fn text_row_right_aligns_affordance() {
+        let row = InlineRow::new(
+            vec![InlineCell::new("bash".to_string(), InlineCellRole::Value)],
+            vec![details_hint_cell()],
+        );
+        let rendered = render_inline_text_row(&row, 32);
+        assert_eq!(UnicodeWidthStr::width(rendered.as_str()), 32);
+        assert!(rendered.ends_with("⌃O details"), "{rendered:?}");
+    }
+
+    #[test]
+    fn text_row_truncates_left_before_required_right() {
+        let row = InlineRow::new(
+            vec![InlineCell::new(
+                "very long command summary with many tokens".to_string(),
+                InlineCellRole::Value,
+            )],
+            vec![details_hint_cell().with_priority(InlinePriority::Required)],
+        );
+        let rendered = render_inline_text_row(&row, 28);
+        assert_eq!(UnicodeWidthStr::width(rendered.as_str()), 28);
+        assert!(rendered.contains('…'), "{rendered:?}");
+        assert!(rendered.ends_with("⌃O details"), "{rendered:?}");
+    }
+}

--- a/core/crates/omegon/src/tui/inline_render.rs
+++ b/core/crates/omegon/src/tui/inline_render.rs
@@ -11,6 +11,7 @@ use crate::surfaces::inline::{
 use super::theme::Theme;
 
 const ELLIPSIS: &str = "…";
+pub const DETAILS_HINT_LABEL: &str = "⌃O details";
 
 pub fn key_chord_label(chord: KeyChord) -> String {
     match chord {
@@ -27,14 +28,8 @@ pub fn action_hint_label(hint: ActionHint) -> String {
 }
 
 pub fn details_hint_cell() -> InlineCell<String> {
-    InlineCell::new(
-        action_hint_label(ActionHint::new(
-            InlineAffordance::Details,
-            KeyChord::Ctrl('O'),
-        )),
-        InlineCellRole::Affordance,
-    )
-    .with_priority(crate::surfaces::inline::InlinePriority::Required)
+    InlineCell::new(DETAILS_HINT_LABEL.to_string(), InlineCellRole::Affordance)
+        .with_priority(crate::surfaces::inline::InlinePriority::Required)
 }
 
 pub fn expand_hint_cell() -> InlineCell<String> {

--- a/core/crates/omegon/src/tui/mod.rs
+++ b/core/crates/omegon/src/tui/mod.rs
@@ -9667,7 +9667,30 @@ mod slash_command_parsing_tests {
         let rows = slim_plan_rows(&snapshot, 40, 4);
         assert_eq!(
             rows.iter().map(|row| row.text.as_str()).collect::<Vec<_>>(),
-            vec!["2. todo    Step 1", "3. todo    Step 2", "+5 more"]
+            vec!["2. todo    Step 1", "3. todo    Step 2", "+6 more"]
+        );
+    }
+
+    #[test]
+    fn slim_plan_overflow_count_matches_actual_hidden_rows() {
+        let snapshot = PlanDisplaySnapshot::from_json(serde_json::json!({
+            "mode": "executing",
+            "completed": 3,
+            "total": 5,
+            "items": [
+                {"description": "done one", "status": "done"},
+                {"description": "done two", "status": "done"},
+                {"description": "done three", "status": "done"},
+                {"description": "active", "status": "active"},
+                {"description": "todo", "status": "todo"}
+            ]
+        }))
+        .unwrap();
+
+        let rows = slim_plan_rows(&snapshot, 80, 4);
+        assert_eq!(
+            rows.iter().map(|row| row.text.as_str()).collect::<Vec<_>>(),
+            vec!["4. active  active", "5. todo    todo", "+3 more"]
         );
     }
 
@@ -9695,7 +9718,7 @@ mod slash_command_parsing_tests {
             vec![
                 "4. active  Record lint blocker",
                 "5. todo    Commit mechanics docs",
-                "+3 more"
+                "+4 more"
             ]
         );
         assert!(snapshot.hint_state(4).matches_active_next_visible());

--- a/core/crates/omegon/src/tui/mod.rs
+++ b/core/crates/omegon/src/tui/mod.rs
@@ -25,6 +25,7 @@ pub mod focus_view;
 pub mod footer;
 pub mod footer_projection;
 pub mod image;
+pub mod inline_render;
 pub mod instruments;
 pub mod layout_projection;
 pub mod model_catalog;

--- a/core/crates/omegon/src/tui/mod.rs
+++ b/core/crates/omegon/src/tui/mod.rs
@@ -9616,6 +9616,12 @@ mod slash_command_parsing_tests {
     use crossterm::event::{KeyCode, KeyModifiers};
     use tokio::sync::mpsc;
 
+    impl SlimPlanHintState {
+        fn matches_active_next_visible(self) -> bool {
+            matches!(self, SlimPlanHintState::Active { next_visible: true })
+        }
+    }
+
     // ── Profile ───────────────────────────────────────────
 
     #[test]
@@ -9661,8 +9667,38 @@ mod slash_command_parsing_tests {
         let rows = slim_plan_rows(&snapshot, 40, 4);
         assert_eq!(
             rows.iter().map(|row| row.text.as_str()).collect::<Vec<_>>(),
-            vec!["1. done    Step 0", "2. todo    Step 1", "+5 more"]
+            vec!["2. todo    Step 1", "3. todo    Step 2", "+5 more"]
         );
+    }
+
+    #[test]
+    fn slim_plan_overflow_hides_done_before_active_or_todo() {
+        let snapshot = PlanDisplaySnapshot::from_json(serde_json::json!({
+            "mode": "executing",
+            "completed": 3,
+            "total": 6,
+            "items": [
+                {"description": "Copy release handoff docs", "status": "done"},
+                {"description": "Normalize changelog", "status": "done"},
+                {"description": "Inspect release state", "status": "done"},
+                {"description": "Record lint blocker", "status": "active"},
+                {"description": "Commit mechanics docs", "status": "todo"},
+                {"description": "Push branch", "status": "todo"}
+            ]
+        }))
+        .unwrap();
+
+        let rows = slim_plan_rows(&snapshot, 80, 4);
+        let text = rows.iter().map(|row| row.text.as_str()).collect::<Vec<_>>();
+        assert_eq!(
+            text,
+            vec![
+                "4. active  Record lint blocker",
+                "5. todo    Commit mechanics docs",
+                "+3 more"
+            ]
+        );
+        assert!(snapshot.hint_state(4).matches_active_next_visible());
     }
 
     #[test]
@@ -9885,9 +9921,7 @@ mod slash_command_parsing_tests {
         );
         assert_eq!(
             snapshot.hint_state(4),
-            SlimPlanHintState::Active {
-                next_visible: false
-            }
+            SlimPlanHintState::Active { next_visible: true }
         );
     }
 

--- a/core/crates/omegon/src/tui/segments.rs
+++ b/core/crates/omegon/src/tui/segments.rs
@@ -11,7 +11,7 @@ use tui_syntax_highlight::Highlighter;
 use unicode_width::UnicodeWidthStr;
 
 use super::conversation_render_projection::SegmentRenderMetadata;
-use super::inline_render::{details_hint_cell, render_inline_text_row};
+use super::inline_render::{DETAILS_HINT_LABEL, details_hint_cell, render_inline_text_row};
 use super::theme::Theme;
 use crate::surfaces::conversation::{
     AssistantSegment, BorrowedConversationSegmentProjection, ConversationSegmentKind,
@@ -560,7 +560,9 @@ pub(crate) fn slim_tool_summary_cells(
 }
 
 fn slim_tool_overflow_hint(hidden_count: usize, hidden_cells: &[&String]) -> String {
-    let has_expandable_hidden_cell = hidden_cells.iter().any(|cell| cell.contains("⌃O details"));
+    let has_expandable_hidden_cell = hidden_cells
+        .iter()
+        .any(|cell| cell.contains(DETAILS_HINT_LABEL));
     if has_expandable_hidden_cell {
         format!("+{hidden_count} more · ⌃O details")
     } else {
@@ -621,7 +623,7 @@ pub(crate) fn slim_tool_collapsed_line(width: u16, cells: &[String]) -> String {
     let (left_cells, right_cells): (Vec<_>, Vec<_>) = cells
         .iter()
         .cloned()
-        .partition(|cell| !cell.contains("⌃O details"));
+        .partition(|cell| !cell.contains(DETAILS_HINT_LABEL));
     let row = InlineRow::new(
         left_cells
             .into_iter()
@@ -2410,8 +2412,12 @@ mod tests {
         let live_rows = slim_tool_live_rows(12, &cells);
 
         assert_eq!(slim_tool_overflow_hint(1, &[]), "+1 more");
-        assert!(!detail_rows.iter().any(|row| row.contains("⌃O details")));
-        assert!(!live_rows.iter().any(|row| row.contains("⌃O details")));
+        assert!(
+            !detail_rows
+                .iter()
+                .any(|row| row.contains(DETAILS_HINT_LABEL))
+        );
+        assert!(!live_rows.iter().any(|row| row.contains(DETAILS_HINT_LABEL)));
     }
 
     #[test]
@@ -2422,7 +2428,7 @@ mod tests {
             "gamma".to_string(),
             "delta".to_string(),
             "epsilon".to_string(),
-            "⌃O details".to_string(),
+            DETAILS_HINT_LABEL.to_string(),
         ];
 
         let _detail_rows = slim_tool_detail_lines(42, &cells);
@@ -2444,7 +2450,7 @@ mod tests {
         let cells = vec![
             "bash".to_string(),
             "git status --short".to_string(),
-            "⌃O details".to_string(),
+            DETAILS_HINT_LABEL.to_string(),
         ];
         let rendered = slim_tool_collapsed_line(56, &cells);
 
@@ -2453,7 +2459,7 @@ mod tests {
             rendered.starts_with("bash · git status --short"),
             "{rendered:?}"
         );
-        assert!(rendered.ends_with("⌃O details"), "{rendered:?}");
+        assert!(rendered.ends_with(DETAILS_HINT_LABEL), "{rendered:?}");
         assert!(
             rendered.contains("  ⌃O details"),
             "affordance should be separated by flex spacer: {rendered:?}"
@@ -2465,13 +2471,13 @@ mod tests {
         let cells = vec![
             "bash".to_string(),
             "very long command summary with enough tokens to overflow".to_string(),
-            "⌃O details".to_string(),
+            DETAILS_HINT_LABEL.to_string(),
         ];
         let rendered = slim_tool_collapsed_line(44, &cells);
 
         assert_eq!(UnicodeWidthStr::width(rendered.as_str()), 28);
         assert!(rendered.contains('…'), "{rendered:?}");
-        assert!(rendered.ends_with("⌃O details"), "{rendered:?}");
+        assert!(rendered.ends_with(DETAILS_HINT_LABEL), "{rendered:?}");
     }
 
     #[test]
@@ -2673,7 +2679,7 @@ mod tests {
         assert!(text.contains("git"), "{text}");
         assert!(text.contains("git status --short"), "{text}");
         assert!(text.contains("2 lines · M src/tui/segments.rs"), "{text}");
-        assert!(text.contains("⌃O details"), "{text}");
+        assert!(text.contains(DETAILS_HINT_LABEL), "{text}");
     }
 
     #[test]
@@ -2716,7 +2722,7 @@ mod tests {
         assert!(text.contains("running"), "{text}");
         assert!(text.contains("├") || text.contains("└"), "{text}");
         assert!(text.contains("git -C /Users/wilson/workspace"), "{text}");
-        assert!(text.contains("⌃O details"), "{text}");
+        assert!(text.contains(DETAILS_HINT_LABEL), "{text}");
     }
 
     #[test]
@@ -2753,7 +2759,10 @@ mod tests {
         let text = buf_text(&buf, area);
         assert!(text.contains("git"), "{text}");
         assert!(!text.contains("├") && !text.contains("└"), "{text}");
-        assert!(text.contains("⌃O details") || text.contains("…"), "{text}");
+        assert!(
+            text.contains(DETAILS_HINT_LABEL) || text.contains("…"),
+            "{text}"
+        );
     }
 
     #[test]
@@ -2941,7 +2950,7 @@ mod tests {
         assert!(text.contains("11.4s"), "{text}");
         assert!(text.contains("bundle ready"), "{text}");
         assert!(text.contains("├") || text.contains("└"), "{text}");
-        assert!(text.contains("⌃O details"), "{text}");
+        assert!(text.contains(DETAILS_HINT_LABEL), "{text}");
     }
 
     #[test]

--- a/core/crates/omegon/src/tui/segments.rs
+++ b/core/crates/omegon/src/tui/segments.rs
@@ -11,12 +11,14 @@ use tui_syntax_highlight::Highlighter;
 use unicode_width::UnicodeWidthStr;
 
 use super::conversation_render_projection::SegmentRenderMetadata;
+use super::inline_render::{details_hint_cell, render_inline_text_row};
 use super::theme::Theme;
 use crate::surfaces::conversation::{
     AssistantSegment, BorrowedConversationSegmentProjection, ConversationSegmentKind,
     ConversationSegmentProjection, ImageSegment, LifecycleSegment, ProjectConversationSegment,
     SegmentPresentation, SegmentRole, SystemSegment, ToolSegment, UserSegment,
 };
+use crate::surfaces::inline::{InlineCell, InlineCellRole, InlineRow};
 
 const FILE_URL_ENCODE_SET: &percent_encoding::AsciiSet = &percent_encoding::CONTROLS
     .add(b' ')
@@ -552,17 +554,15 @@ pub(crate) fn slim_tool_summary_cells(
         cells.push(summarize_live_tool_progress(live_partial, started_at));
     }
     if tool_has_expandable_detail(detail_args, detail_result, live_partial) {
-        cells.push("Ctrl+O details".to_string());
+        cells.push(details_hint_cell().text);
     }
     cells
 }
 
 fn slim_tool_overflow_hint(hidden_count: usize, hidden_cells: &[&String]) -> String {
-    let has_expandable_hidden_cell = hidden_cells
-        .iter()
-        .any(|cell| cell.contains("Ctrl+O details"));
+    let has_expandable_hidden_cell = hidden_cells.iter().any(|cell| cell.contains("⌃O details"));
     if has_expandable_hidden_cell {
-        format!("+{hidden_count} more · Ctrl+O details")
+        format!("+{hidden_count} more · ⌃O details")
     } else {
         format!("+{hidden_count} more")
     }
@@ -613,12 +613,26 @@ fn slim_tool_detail_lines(width: u16, cells: &[String]) -> Vec<String> {
 }
 
 pub(crate) fn slim_tool_collapsed_line(width: u16, cells: &[String]) -> String {
-    let budget = width.saturating_sub(16) as usize;
+    let budget = width.saturating_sub(16);
     if cells.is_empty() {
-        String::new()
-    } else {
-        crate::util::truncate(&cells.join(" · "), budget)
+        return String::new();
     }
+
+    let (left_cells, right_cells): (Vec<_>, Vec<_>) = cells
+        .iter()
+        .cloned()
+        .partition(|cell| !cell.contains("⌃O details"));
+    let row = InlineRow::new(
+        left_cells
+            .into_iter()
+            .map(|cell| InlineCell::new(cell, InlineCellRole::Value))
+            .collect(),
+        right_cells
+            .into_iter()
+            .map(|cell| InlineCell::new(cell, InlineCellRole::Affordance))
+            .collect(),
+    );
+    render_inline_text_row(&row, budget)
 }
 
 pub(crate) fn slim_tool_live_rows(width: u16, cells: &[String]) -> Vec<String> {
@@ -2396,8 +2410,8 @@ mod tests {
         let live_rows = slim_tool_live_rows(12, &cells);
 
         assert_eq!(slim_tool_overflow_hint(1, &[]), "+1 more");
-        assert!(!detail_rows.iter().any(|row| row.contains("Ctrl+O details")));
-        assert!(!live_rows.iter().any(|row| row.contains("Ctrl+O details")));
+        assert!(!detail_rows.iter().any(|row| row.contains("⌃O details")));
+        assert!(!live_rows.iter().any(|row| row.contains("⌃O details")));
     }
 
     #[test]
@@ -2408,7 +2422,7 @@ mod tests {
             "gamma".to_string(),
             "delta".to_string(),
             "epsilon".to_string(),
-            "Ctrl+O details".to_string(),
+            "⌃O details".to_string(),
         ];
 
         let _detail_rows = slim_tool_detail_lines(42, &cells);
@@ -2416,13 +2430,48 @@ mod tests {
 
         assert_eq!(
             slim_tool_overflow_hint(1, &[&cells[5]]),
-            "+1 more · Ctrl+O details"
+            "+1 more · ⌃O details"
         );
         assert!(
             live_rows
                 .iter()
-                .any(|row| row.contains("+1 more · Ctrl+O details"))
+                .any(|row| row.contains("+1 more · ⌃O details"))
         );
+    }
+
+    #[test]
+    fn slim_tool_collapsed_line_right_aligns_details_affordance() {
+        let cells = vec![
+            "bash".to_string(),
+            "git status --short".to_string(),
+            "⌃O details".to_string(),
+        ];
+        let rendered = slim_tool_collapsed_line(56, &cells);
+
+        assert_eq!(UnicodeWidthStr::width(rendered.as_str()), 40);
+        assert!(
+            rendered.starts_with("bash · git status --short"),
+            "{rendered:?}"
+        );
+        assert!(rendered.ends_with("⌃O details"), "{rendered:?}");
+        assert!(
+            rendered.contains("  ⌃O details"),
+            "affordance should be separated by flex spacer: {rendered:?}"
+        );
+    }
+
+    #[test]
+    fn slim_tool_collapsed_line_preserves_details_when_left_truncates() {
+        let cells = vec![
+            "bash".to_string(),
+            "very long command summary with enough tokens to overflow".to_string(),
+            "⌃O details".to_string(),
+        ];
+        let rendered = slim_tool_collapsed_line(44, &cells);
+
+        assert_eq!(UnicodeWidthStr::width(rendered.as_str()), 28);
+        assert!(rendered.contains('…'), "{rendered:?}");
+        assert!(rendered.ends_with("⌃O details"), "{rendered:?}");
     }
 
     #[test]
@@ -2624,7 +2673,7 @@ mod tests {
         assert!(text.contains("git"), "{text}");
         assert!(text.contains("git status --short"), "{text}");
         assert!(text.contains("2 lines · M src/tui/segments.rs"), "{text}");
-        assert!(text.contains("Ctrl+O details"), "{text}");
+        assert!(text.contains("⌃O details"), "{text}");
     }
 
     #[test]
@@ -2667,7 +2716,7 @@ mod tests {
         assert!(text.contains("running"), "{text}");
         assert!(text.contains("├") || text.contains("└"), "{text}");
         assert!(text.contains("git -C /Users/wilson/workspace"), "{text}");
-        assert!(text.contains("Ctrl+O details"), "{text}");
+        assert!(text.contains("⌃O details"), "{text}");
     }
 
     #[test]
@@ -2704,10 +2753,7 @@ mod tests {
         let text = buf_text(&buf, area);
         assert!(text.contains("git"), "{text}");
         assert!(!text.contains("├") && !text.contains("└"), "{text}");
-        assert!(
-            text.contains("Ctrl+O details") || text.contains("…"),
-            "{text}"
-        );
+        assert!(text.contains("⌃O details") || text.contains("…"), "{text}");
     }
 
     #[test]
@@ -2895,7 +2941,7 @@ mod tests {
         assert!(text.contains("11.4s"), "{text}");
         assert!(text.contains("bundle ready"), "{text}");
         assert!(text.contains("├") || text.contains("└"), "{text}");
-        assert!(text.contains("Ctrl+O details"), "{text}");
+        assert!(text.contains("⌃O details"), "{text}");
     }
 
     #[test]

--- a/core/crates/omegon/src/tui/segments.rs
+++ b/core/crates/omegon/src/tui/segments.rs
@@ -564,7 +564,7 @@ fn slim_tool_overflow_hint(hidden_count: usize, hidden_cells: &[&String]) -> Str
         .iter()
         .any(|cell| cell.contains(DETAILS_HINT_LABEL));
     if has_expandable_hidden_cell {
-        format!("+{hidden_count} more · ⌃O details")
+        format!("+{hidden_count} more · {DETAILS_HINT_LABEL}")
     } else {
         format!("+{hidden_count} more")
     }
@@ -2436,12 +2436,12 @@ mod tests {
 
         assert_eq!(
             slim_tool_overflow_hint(1, &[&cells[5]]),
-            "+1 more · ⌃O details"
+            format!("+1 more · {DETAILS_HINT_LABEL}")
         );
         assert!(
             live_rows
                 .iter()
-                .any(|row| row.contains("+1 more · ⌃O details"))
+                .any(|row| row.contains(&format!("+1 more · {DETAILS_HINT_LABEL}")))
         );
     }
 
@@ -2461,7 +2461,7 @@ mod tests {
         );
         assert!(rendered.ends_with(DETAILS_HINT_LABEL), "{rendered:?}");
         assert!(
-            rendered.contains("  ⌃O details"),
+            rendered.contains(&format!("  {DETAILS_HINT_LABEL}")),
             "affordance should be separated by flex spacer: {rendered:?}"
         );
     }

--- a/core/crates/omegon/src/tui/slim_plan.rs
+++ b/core/crates/omegon/src/tui/slim_plan.rs
@@ -255,10 +255,11 @@ impl PlanDisplaySnapshot {
         } else {
             max_items
         };
+        let visible = prioritized_plan_item_indices(&self.items, visible_items, hidden > 0);
         self.items
             .iter()
             .position(|item| matches!(item.status, PlanDisplayStatus::Todo))
-            .is_some_and(|idx| idx < visible_items)
+            .is_some_and(|idx| visible.contains(&idx))
     }
 }
 
@@ -289,9 +290,11 @@ pub fn slim_plan_rows(
     } else {
         max_items
     };
+    let visible = prioritized_plan_item_indices(&snapshot.items, visible_items, hidden > 0);
     let text_budget = width.saturating_sub(2) as usize;
     let mut rows = Vec::new();
-    for (idx, item) in snapshot.items.iter().take(visible_items).enumerate() {
+    for idx in visible {
+        let item = &snapshot.items[idx];
         let label = item.status.label();
         let line = format!("{}. {label:<7} {}", idx + 1, item.description);
         rows.push(PlanDisplayRow {
@@ -306,6 +309,39 @@ pub fn slim_plan_rows(
         });
     }
     rows
+}
+
+fn prioritized_plan_item_indices(
+    items: &[PlanDisplayItem],
+    visible_items: usize,
+    overflowing: bool,
+) -> Vec<usize> {
+    if visible_items == 0 {
+        return Vec::new();
+    }
+    if !overflowing {
+        return (0..items.len().min(visible_items)).collect();
+    }
+
+    let mut selected = Vec::new();
+    for status in [
+        PlanDisplayStatus::Active,
+        PlanDisplayStatus::Todo,
+        PlanDisplayStatus::Skipped,
+        PlanDisplayStatus::Done,
+    ] {
+        for (idx, item) in items.iter().enumerate() {
+            if item.status == status && !selected.contains(&idx) {
+                selected.push(idx);
+                if selected.len() == visible_items {
+                    selected.sort_unstable();
+                    return selected;
+                }
+            }
+        }
+    }
+    selected.sort_unstable();
+    selected
 }
 
 fn legacy_plan_item(raw: &str) -> Option<(String, PlanDisplayStatus)> {

--- a/core/crates/omegon/src/tui/slim_plan.rs
+++ b/core/crates/omegon/src/tui/slim_plan.rs
@@ -291,6 +291,7 @@ pub fn slim_plan_rows(
         max_items
     };
     let visible = prioritized_plan_item_indices(&snapshot.items, visible_items, hidden > 0);
+    let hidden_count = snapshot.items.len().saturating_sub(visible.len());
     let text_budget = width.saturating_sub(2) as usize;
     let mut rows = Vec::new();
     for idx in visible {
@@ -302,9 +303,9 @@ pub fn slim_plan_rows(
             status: Some(item.status),
         });
     }
-    if hidden > 0 {
+    if hidden_count > 0 {
         rows.push(PlanDisplayRow {
-            text: format!("+{hidden} more"),
+            text: format!("+{hidden_count} more"),
             status: None,
         });
     }

--- a/docs/release-0.27.0-exploration.md
+++ b/docs/release-0.27.0-exploration.md
@@ -218,6 +218,8 @@ Recent prompt-surface directives call out prompt templates and `/loop` as execut
 
 ### 1. Provider route footer clarity
 
+Shipped release-polish update: disconnected Slim engine footer rows now name the selected provider and exact remediation command, e.g. `OpenAI/Codex login required` plus `/login openai-codex`, instead of a generic provider warning. Focused `left_panel` tests cover the copy and stale-row cleanup.
+
 The footer/model card should clearly distinguish:
 
 - selected profile model

--- a/docs/release-0.27.0-exploration.md
+++ b/docs/release-0.27.0-exploration.md
@@ -1,0 +1,365 @@
++++
+id = "release-0-27-0-exploration"
+kind = "document"
+title = "0.27.0 release exploration"
+status = "exploring"
+tags = ["release", "0.27.0", "hardening", "ui", "auth", "provider-routing"]
+aliases = ["0.27.0 release exploration", "release-0.27.0"]
+imported_reference = false
+
+[publication]
+enabled = false
+visibility = "private"
++++
+
+# 0.27.0 release exploration
+
+## Purpose
+
+This document captures release exploration findings for the 0.27.0 line: feature work to target after the release, bug fixes that should be considered release blockers or release-hardening work, hardening opportunities, and UI polish opportunities.
+
+This is a working document, not a final release note. The release note source of truth remains `CHANGELOG.md`; this document is for triage and prioritization.
+
+## Current release posture
+
+0.27.0 is already a large surface-coherence and provider-routing line. Recent commits and changelog entries show major work in four clusters:
+
+1. **Provider/auth route control** — explicit startup/login/model-switch routing, fallback/disconnected route state, route warnings, `/auth status` route details, and credential diagnostics.
+2. **Workbench/lifecycle visibility** — Plan Dock promoted to Workbench, slim-mode plan rows, lifecycle workstream projection, and active/incomplete plan retention.
+3. **Console/ACP backend surfaces** — assistant capability inventory, assistant readiness, assistant run read models, secret readiness, blocked/completed run states.
+4. **Conversation/presentation semantics** — peer-agent conversation representation, semantic tool chrome/glyph registry, producer identity separated from content form.
+
+The line is feature-rich enough that further broad feature work should be biased toward post-release unless it closes an observable release blocker.
+
+## Findings: bug fixes to target for this release
+
+### 1. Auth store integrity: OpenAI/Codex credential disappearance
+
+**Status:** active hardening in progress.
+
+Observed failure:
+
+- Startup selected `openai-codex:gpt-5.5`.
+- `auth.json` existed at `/Users/wilson/.config/omegon/auth.json`.
+- The startup auth probe reported `provider_entry_exists=false` for `openai-codex`.
+- `/login openai-codex` then persisted a fresh `openai-codex` entry with `accountId` and subsequent probes resolved it successfully.
+
+What is known:
+
+- Provider mapping is correct: `openai-codex` uses auth key `openai-codex` and env var `CHATGPT_OAUTH_TOKEN`.
+- The failure was not env-var priority/order; the stored provider entry was absent at startup.
+- External Codex CLI rescue was unavailable because `~/.codex/auth.json` did not exist.
+
+Release-target fix/hardening already started:
+
+- Auth write paths now trace provider key-set deltas on credential writes, refreshes, and logout.
+- Auth updates now refuse to replace an unparsable existing `auth.json` with a partial store.
+- Regression coverage verifies writing another provider preserves existing `openai-codex` credentials and malformed auth stores are not overwritten.
+
+Release blocker question:
+
+- Run one relaunch cycle with the patched binary and confirm startup hydrates/resolves existing `openai-codex` without `/login`.
+
+### 2. Startup route truthfulness must remain non-negotiable
+
+0.27.0 changed startup fallback behavior from implicit to explicit. The release should not ship any path where the TUI footer, session log, or route state claims one provider/model while requests are served by another.
+
+Must verify before release:
+
+- Selected provider missing credentials + no explicit fallback enters disconnected state.
+- Selected provider missing credentials + explicit fallback displays both selected and served model accurately.
+- `/login` transitions route state to connected and updates visible status without restart.
+- `/model` and model-tier switches route through the controller and do not bypass diagnostics.
+
+### 3. OAuth callback accept-loop regression risk
+
+Recent fix: OAuth callback listeners now accept-loop instead of failing on speculative preconnect/favicon/stale-tab requests.
+
+Release validation should cover:
+
+- Anthropic login.
+- OpenAI/Codex login.
+- Antigravity login if available.
+- Stale browser tab hitting callback endpoint before the actual OAuth redirect.
+
+This is release-relevant because login reliability is foundational for the provider-routing changes.
+
+### 4. `just link` and binary freshness
+
+Recent fix: `just link` rebuilds release binary before linking so `omegon --version` cannot point at stale HEAD.
+
+Release validation should include:
+
+- `just link` from a dirty-but-source-valid tree does not install stale artifacts.
+- `omegon --version` after `just link` matches current commit/version metadata.
+- The installed binary contains the latest auth tracing/hardening before relaunch testing.
+
+### 5. Changelog structure has duplicate `[Unreleased]` subsection headings
+
+Current `CHANGELOG.md` now has `### Added`, `### Fixed`, then another `### Added`/`Changed`/`Fixed` sequence under `[Unreleased]`. This is valid Markdown but weak release hygiene.
+
+Release-target fix:
+
+- Consolidate `[Unreleased]` headings into canonical Keep-a-Changelog order before tagging.
+- Move release-hardening auth entries into the right section.
+
+## Findings: hardening opportunities
+
+### 1. Auth store write audit trail
+
+The new key-delta traces make future credential disappearance attributable through normal write paths. More hardening options:
+
+- Include a short hash/fingerprint of the provider key set, not credential values.
+- Log writer operation context for startup import, external adoption, refresh, login, logout, and API-key login distinctly.
+- Consider a `.bak` file for the last valid `auth.json` before each atomic write.
+- Consider schema validation before accepting existing auth stores.
+- Consider a repair command: `omegon auth doctor --repair`.
+
+Tradeoff: backup/repair adds storage and recovery complexity; trace-only is lower risk for 0.27.0.
+
+### 2. Auth store concurrency and lock robustness
+
+Current lock path is an adjacent `.lock` file with retry. Opportunities:
+
+- Include lock holder PID/timestamp in the lock file.
+- On timeout, report stale lock diagnostics.
+- Consider stale-lock recovery with age threshold.
+- Add tests for concurrent writes preserving all providers.
+
+### 3. Provider-route state machine coverage
+
+The provider-route controller is now central. It needs invariant tests:
+
+- Every public path that changes auth/model state emits a route event.
+- Route selected/served/disconnected/fallback state is serializable to TUI, ACP, and CLI status from the same DTO.
+- Route state cannot claim connected if credential ledger says missing/expired.
+
+### 4. Release preflight for operator workflow regressions
+
+Add or document a focused local release-hardening checklist:
+
+- `just test-commit`
+- `just lint`
+- targeted auth tests
+- manual login smoke for OAuth providers
+- `just link`
+- relaunch with `openai-codex:gpt-5.5`
+- `/auth status`
+- `/model` switch smoke
+- Workbench active-plan smoke
+
+### 5. Extension SDK compatibility warnings
+
+Recent startup logs show incompatible or missing local extensions:
+
+- `omegon-design` SDK contract older than minimum.
+- `omegon-voice` SDK contract older than minimum.
+- `aether`/`shuttle` missing binaries.
+- `vox` permission denied.
+
+These are not necessarily core release blockers, but 0.27.0 surfaces extension capability inventory more prominently. The operator experience should distinguish core release health from local extension drift.
+
+Opportunity:
+
+- Group extension warnings into a concise startup/diagnostic surface.
+- Provide `omegon extension doctor` guidance or reuse capability inventory readiness fields.
+
+## Findings: future feature work
+
+### 1. Auth doctor and credential provenance UI
+
+Build on provider-route diagnostics with a first-class `auth doctor` flow:
+
+- Show auth path source (`default` vs `OMEGON_AUTH_JSON_PATH`).
+- Show provider entries present/missing/expired without secrets.
+- Show external fallback availability (`~/.codex/auth.json`, Claude Code, Gemini CLI, etc.).
+- Show last auth-store mutation operation from logs/audit trail.
+- Offer safe repair: restore backup, re-import external credential, or re-login.
+
+### 2. Unified route/state projection across TUI, CLI, ACP
+
+The release line introduced route-control pieces. Future work should complete the semantic projection:
+
+- One provider route DTO consumed by TUI footer, `/auth status`, ACP, and session logs.
+- Include selected model, served model, credential source, fallback reason, and remediation.
+- Avoid renderer-specific route logic.
+
+### 3. Workbench as operational state, not only UI
+
+Workbench is now the visible operational state for plans, cleave, delegate, and workstreams. Future work:
+
+- Persist Workbench state explicitly enough to recover after restart.
+- Add Workbench reconciliation warnings when assistant final claims conflict with active tasks.
+- Connect Workbench rows to lifecycle/design/OpenSpec provenance.
+- Provide command registry actions for Workbench operations instead of TUI-only arms.
+
+### 4. Capability inventory as release/readiness substrate
+
+The console/ACP capability inventory work can become a release readiness layer:
+
+- Installed extensions and SDK compatibility.
+- Secret readiness.
+- Assistant launch readiness.
+- Package/helper tool availability.
+- Provider/auth route readiness.
+
+Future feature: `omegon readiness` or `omegon doctor` that assembles these into a single operator-facing health report.
+
+### 5. Prompt/loop provenance safety
+
+Recent prompt-surface directives call out prompt templates and `/loop` as executable instruction sources. Future work:
+
+- Preview/validate prompt templates before execution.
+- Record provenance for queued prompts.
+- Add explicit safety handling for repeated `/loop` execution.
+- Share command registry safety metadata with ACP/CLI/TUI.
+
+## Findings: UI polish opportunities
+
+### 1. Provider route footer clarity
+
+The footer/model card should clearly distinguish:
+
+- selected profile model
+- served bridge model
+- fallback provider
+- disconnected/login-required state
+- credential source and expiry state where useful
+
+Avoid dense text in Slim mode. Suggested pattern:
+
+- Connected: `Codex · gpt-5.5 · OAuth`
+- Fallback: `Selected Codex unavailable → serving Claude Fable`
+- Disconnected: `Codex login required · /login openai-codex`
+
+### 2. Workbench visual hierarchy
+
+Shipped release-polish update: Slim Workbench plan overflow now prioritizes actionable rows (`active`, then `todo`) before completed rows, preserving full plan context while hiding done items first when vertical space is constrained. Focused `slim_plan` tests cover the policy and hint behavior.
+
+Workbench has accumulated plan rows, workstreams, delegate/cleave progress, and lifecycle state. Remaining polish opportunities:
+
+- Use stable glyph grammar for todo/in-progress/done/blocked.
+- Keep Slim mode compact but preserve actionable state.
+- Avoid duplicate tool-call cards when Workbench already represents the operation.
+- Add stale/inconsistent indicators when plan state and assistant prose diverge.
+
+### 3. Startup warning grouping
+
+Startup currently can emit many warnings: provider auth, extension SDK drift, missing binaries, route disconnected state, web auth mode, etc.
+
+Polish:
+
+- Group warnings by domain: Auth, Extensions, Tools, Project.
+- Show high-priority remediation first.
+- Keep noisy extension drift out of the main route/auth warning unless it blocks the selected task.
+
+### 4. `/auth status` readability
+
+`/auth status` should be the operator’s first stop for login issues.
+
+Polish opportunities:
+
+- Show selected route and served bridge at top.
+- Show auth store path and source.
+- Show provider table with: status, credential source, expiry/refreshable, external fallback available.
+- For missing selected provider, print exact remediation command.
+
+### 5. Release/doctor UI
+
+A release-hardening line benefits from an operator-facing health command:
+
+- `omegon doctor`
+- `omegon auth doctor`
+- `omegon extension doctor`
+- `omegon release preflight`
+
+This can start as text output and later project into TUI/ACP.
+
+## Release mechanics findings
+
+### Version/tag state
+
+- Workspace version is currently `0.27.0` in `Cargo.toml`.
+- `core/release.toml` is configured for shared workspace versioning and `v{{version}}` tags.
+- The `just release` recipe expects a clean tree, runs `just preflight`, verifies a stable semver version, updates milestone state, commits `chore(release): <version>`, tags `v<version>`, and builds the release binary.
+- `just preflight` is the intended release-readiness guard; it checks branch/version/changelog/install docs/manifest wiring before mutation.
+- Release branch helpers exist: `just branch-release` and `just merge-release-forward`, matching the documented trunk + `release/X.Y` stabilization model.
+
+Implication: if this is still pre-tag 0.27.0 stabilization, release-hardening commits should either land on `release/0.27` or land on `main` before `just release`. If `v0.27.0` has already been published, these findings should be reframed as 0.27.1 patch hardening rather than a refreshed 0.27.0 artifact.
+
+### Available local validation gates
+
+Focused gates observed in `justfile`:
+
+- `just test-commit` — changed-crate Rust validation for focused commits.
+- `just test-rust` — full Rust workspace test gate.
+- `just lint` — fmt, check, clippy for full workspace/all targets.
+- `just upstream-provider-check` — cheap provider drift and upstream version checks.
+- `just preflight` — release preflight before release mutation.
+- `just link` — rebuild/install dev binary.
+
+Release-hardening validation should use focused tests during iteration, then at minimum `just test-commit`, `just lint`, `just preflight`, and `just link` before tagging. Full `just test-rust` remains the stronger release gate when time permits.
+
+### Provider-route code surface requiring release attention
+
+The active route implementation lives in `core/crates/omegon/src/route.rs` with:
+
+- `ProviderRoute::{Serving, Fallback, LoginPending, Disconnected}`.
+- `CredentialLedger` as the real credential probe.
+- `RouteController::resolve_startup` for selected/fallback/disconnected startup state.
+- route events consumed by IPC/MQTT/TUI surfaces.
+
+Risk area: this is now central infrastructure. Any remaining path that creates an LLM bridge or changes provider/model/auth state outside `RouteController` is a release risk because it can make status surfaces lie.
+
+## Parallelizable workstreams
+
+The three most obvious parallelizable workstreams are:
+
+1. **Release mechanics and validation hygiene** — owned by this Omegon/operator session on `release/0.27-mechanics-validation`. Scope: changelog normalization, release/tag decisioning, validation gates, `just link` freshness, and final release readiness.
+2. **UI polish** — owned by `omegon-secundus` on `release/0.27-ui-polish`. Scope: provider-route footer clarity, `/auth status` readability, Workbench visual hierarchy, and startup warning grouping.
+3. **Auth/store integrity and provider-route correctness** — owned by `omegon-quartus` on `release/0.27-auth-integrity`. Scope: Codex credential disappearance, auth-store write safety, relaunch/no-login validation, and route-controller invariants.
+
+Detailed handoff docs:
+
+- [[release-0.27.0-workstream-mechanics-validation|0.27.0 workstream — release mechanics and validation hygiene]]
+- [[release-0.27.0-workstream-ui-polish|0.27.0 workstream — UI polish]]
+- [[release-0.27.0-workstream-auth-integrity|0.27.0 workstream — auth/store integrity and provider-route correctness]]
+
+## Proposed release triage
+
+### Must fix before 0.27.0 tag
+
+- Complete and validate auth-store integrity hardening.
+- Confirm relaunch with existing `openai-codex` auth does not require `/login`.
+- Consolidate `[Unreleased]` changelog headings.
+- Run focused provider-route/auth regression tests.
+- Run `just link` and verify installed binary freshness.
+
+### Should fix if low risk
+
+- Add concurrent auth write preservation test.
+- Add clearer auth-store parse failure operator message.
+- Add route-state smoke command or checklist entry.
+- Reduce startup warning noise around unrelated extension drift.
+
+### Defer to post-release
+
+- Full `auth doctor` repair workflow.
+- Auth store backups and restore command.
+- Unified readiness/doctor surface across providers/extensions/secrets.
+- Workbench persistence/recovery beyond current projection.
+- Larger UI layout redesigns.
+
+## Open questions
+
+1. Should 0.27.0 be treated as already tagged/released and this work become 0.27.1 hardening, or is this a release-line stabilization pass before a refreshed 0.27.0 artifact?
+2. Do we want a `release/0.27` branch for this hardening, or continue focused direct commits on `main`?
+3. Should auth-store backup/restore be included now, or is trace + parse-refusal sufficient for this release?
+4. Which OAuth providers are available for manual smoke on this machine before tag?
+
+## Immediate next steps
+
+1. Finish the current auth-store integrity patch: run focused tests, `just lint` or `just test-commit`, then commit.
+2. Relaunch the linked binary with `openai-codex:gpt-5.5` and confirm no `/login` is required.
+3. Consolidate `CHANGELOG.md` `[Unreleased]` sections.
+4. Decide whether remaining items are release blockers or post-release tasks.

--- a/docs/release-0.27.0-workstream-ui-polish.md
+++ b/docs/release-0.27.0-workstream-ui-polish.md
@@ -41,6 +41,7 @@ Make 0.27.0’s operator-facing surfaces truthful, legible, and calm. The releas
 ## Progress
 
 - Shipped Slim Workbench overflow prioritization so active/todo plan rows stay visible before completed rows when the plan lane is height-constrained. Focused `cargo test -p omegon slim_plan -- --nocapture` coverage passes.
+- Shipped disconnected footer remediation copy so the engine panel names the selected provider and exact `/login <provider>` command. Focused `cargo test -p omegon left_panel -- --nocapture` coverage passes.
 
 ## Current findings
 

--- a/docs/release-0.27.0-workstream-ui-polish.md
+++ b/docs/release-0.27.0-workstream-ui-polish.md
@@ -43,6 +43,7 @@ Make 0.27.0’s operator-facing surfaces truthful, legible, and calm. The releas
 - Shipped Slim Workbench overflow prioritization so active/todo plan rows stay visible before completed rows when the plan lane is height-constrained. Focused `cargo test -p omegon slim_plan -- --nocapture` coverage passes.
 - Shipped disconnected footer remediation copy so the engine panel names the selected provider and exact `/login <provider>` command. Focused `cargo test -p omegon left_panel -- --nocapture` coverage passes.
 - Shipped the first inline/flex-row migration for Slim tool summaries: detail affordances now use compact `⌃O details` glyphs and right-align behind an elastic spacer. Focused `cargo test -p omegon 'slim_tool_' -- --nocapture` coverage passes.
+- Shipped footer engine-row flex spacing so label/value rows keep styling while aligning values to the right edge. Focused `cargo test -p omegon engine_flex_row -- --nocapture` and `cargo test -p omegon left_panel -- --nocapture` coverage passes.
 
 ## Current findings
 

--- a/docs/release-0.27.0-workstream-ui-polish.md
+++ b/docs/release-0.27.0-workstream-ui-polish.md
@@ -42,6 +42,7 @@ Make 0.27.0’s operator-facing surfaces truthful, legible, and calm. The releas
 
 - Shipped Slim Workbench overflow prioritization so active/todo plan rows stay visible before completed rows when the plan lane is height-constrained. Focused `cargo test -p omegon slim_plan -- --nocapture` coverage passes.
 - Shipped disconnected footer remediation copy so the engine panel names the selected provider and exact `/login <provider>` command. Focused `cargo test -p omegon left_panel -- --nocapture` coverage passes.
+- Shipped the first inline/flex-row migration for Slim tool summaries: detail affordances now use compact `⌃O details` glyphs and right-align behind an elastic spacer. Focused `cargo test -p omegon 'slim_tool_' -- --nocapture` coverage passes.
 
 ## Current findings
 

--- a/docs/release-0.27.0-workstream-ui-polish.md
+++ b/docs/release-0.27.0-workstream-ui-polish.md
@@ -1,0 +1,113 @@
++++
+id = "release-0-27-0-workstream-ui-polish"
+kind = "document"
+title = "0.27.0 workstream — UI polish"
+status = "exploring"
+tags = ["release", "0.27.0", "workstream", "ui", "tui", "polish"]
+aliases = ["0.27 UI polish", "release UI polish workstream"]
+imported_reference = false
+
+[publication]
+enabled = false
+visibility = "private"
++++
+
+# 0.27.0 workstream — UI polish
+
+## Owner
+
+Primary owner: **omegon-secundus**.
+
+## Branch
+
+`release/0.27-ui-polish`
+
+Branch created from current `main` HEAD: `07027739 fix(auth): prefer refreshable oauth credentials`.
+
+## Mission
+
+Make 0.27.0’s operator-facing surfaces truthful, legible, and calm. The release has added provider-route state, Workbench visibility, command safety metadata, and capability/readiness surfaces; UI polish should reduce confusion without reopening core architecture.
+
+## Inputs
+
+- [[release-0.27.0-exploration|0.27.0 release exploration]]
+- `core/crates/omegon/src/tui/footer.rs`
+- `core/crates/omegon/src/tui/mod.rs`
+- `core/crates/omegon/src/features/auth.rs`
+- `core/crates/omegon/src/route.rs`
+- Workbench/plan rendering helpers under `core/crates/omegon/src/tools.rs` and TUI modules
+- startup warning paths in `core/crates/omegon/src/main.rs` / `setup.rs`
+
+## Progress
+
+- Shipped Slim Workbench overflow prioritization so active/todo plan rows stay visible before completed rows when the plan lane is height-constrained. Focused `cargo test -p omegon slim_plan -- --nocapture` coverage passes.
+
+## Current findings
+
+- Provider-route surfaces now distinguish selected vs served route state, fallback, login-pending, and disconnected states.
+- Recent bugs made truthful footer/model display release-critical; UI must not imply the selected provider is serving when fallback or disconnected state is active.
+- Workbench is now operational state for plans, cleave, delegate, and lifecycle workstreams; it must stay compact in Slim mode but preserve actionable state.
+- Startup logs can be noisy because provider/auth warnings and local extension drift appear in the same launch window.
+
+## Scope
+
+### In scope
+
+- Improve provider route footer/model-card clarity.
+- Improve `/auth status` readability around selected route, served bridge, credential state, and remediation.
+- Group startup warnings by domain where low risk:
+  - Auth
+  - Extensions
+  - Tools
+  - Project
+- Keep unrelated extension drift from masking selected-provider auth failures.
+- Tighten Workbench visual hierarchy:
+  - stable glyph grammar
+  - compact plan rows
+  - clear blocked/waiting/in-progress/done state
+  - no duplicate successful `/plan` noise if Workbench already represents it
+- Add or adjust focused snapshot/unit tests for UI formatting where practical.
+
+### Out of scope
+
+- Core provider-route state-machine changes.
+- Auth-store write-path fixes.
+- Release script mechanics.
+- Large TUI redesigns or new alternate frontends.
+- Extension SDK upgrades unless needed to reduce warning presentation noise.
+
+## Acceptance criteria
+
+- Footer/model-card copy clearly distinguishes connected, fallback, and disconnected states.
+- Missing selected-provider credentials show exact remediation, e.g. `/login openai-codex`.
+- `/auth status` remains readable in narrow terminals and includes selected/served route truth.
+- Startup warnings are less noisy or at least more domain-separated.
+- Workbench rows remain compact and actionable in Slim mode.
+- Any UI changes have focused tests or snapshot-style assertions where the project already has coverage seams.
+
+## Suggested task breakdown
+
+1. Inspect current route/footer rendering:
+   - route warning projection
+   - footer model card
+   - `/auth status` output
+2. Draft copy variants for three states:
+   - Connected: `Codex · gpt-5.5 · OAuth`
+   - Fallback: `Selected Codex unavailable → serving Claude Fable`
+   - Disconnected: `Codex login required · /login openai-codex`
+3. Patch the smallest rendering layer that consumes existing route state.
+4. Group or prioritize startup warnings without changing underlying diagnostics.
+5. Run focused UI/auth/status tests.
+6. Update [[release-0.27.0-exploration]] with shipped polish and remaining deferrals.
+7. Commit on `release/0.27-ui-polish`.
+
+## Risks
+
+- UI polish can accidentally hide diagnostic detail needed for release debugging. Prefer progressive disclosure: concise visible summary plus detailed `/auth status` or log trail.
+- Do not duplicate route logic in TUI. Consume semantic route/controller state.
+- Avoid broad layout churn in the release branch; release polish should be minimal and testable.
+
+## Coordination notes
+
+- Coordinate with `release/0.27-auth-integrity` for exact auth remediation wording and credential-state fields.
+- Coordinate with `release/0.27-mechanics-validation` for final changelog entries and release validation smoke.


### PR DESCRIPTION
## Summary

- keep active/todo Workbench plan rows visible before completed rows when Slim mode overflows
- show selected-provider login remediation in the engine footer when disconnected
- add inline row affordance primitives and migrate Slim tool summaries to right-aligned `⌃O details`
- align engine footer row values against the right edge while preserving label/value styling

## Validation

- `cargo test -p omegon slim_plan -- --nocapture`
- `cargo test -p omegon left_panel -- --nocapture`
- `cargo test -p omegon inline -- --nocapture`
- `cargo test -p omegon 'slim_tool_' -- --nocapture`
- `cargo test -p omegon engine_flex_row -- --nocapture`
- `validate` on:
  - `core/crates/omegon/src/tui/footer.rs`
  - `core/crates/omegon/src/tui/inline_render.rs`
  - `core/crates/omegon/src/tui/segments.rs`
  - `core/crates/omegon/src/tui/slim_plan.rs`
