### PR TITLE
fix: mediate outside-workspace permissions consistently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,7 +75,8 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [Semantic V
 - Added a source-agnostic skill suggestion helper that evaluates parsed bundled, user-installed, Armory-installed, or project-local skills against profile, intent, and project-signal evidence without performing runtime injection, preserving external metadata diagnostics instead of silently dropping malformed activation hints.
 
 ### Fixed
-- Made outside-workspace permission prompts wait for an explicit operator allow/deny decision instead of timing out as a denial after 120 seconds; `--dangerously-bypass-permissions` still bypasses the prompt before it is raised.
+- Routed bash workspace-boundary hits through the same typed permission mediation as read/write/edit so approved outside-workspace shell writes retry instead of remaining bash-local blocks.
+- Made outside-workspace permission prompts wait for an explicit operator allow/deny decision instead of timing out as a denial after 120 seconds; explicit run cancellation still unblocks the wait as a denial/cancelled decision, and `--dangerously-bypass-permissions` still bypasses the prompt before it is raised.
 - Unified provider credential reads through canonical auth.json keys so OpenAI Codex OAuth aliases resolve the persisted `openai-codex` grant instead of forcing reauthentication after rebuilds.
 - Isolated the voice bridge extension fixture from ambient Kubernetes substrate environment so full-suite runs do not reject the native test extension.
 - Avoid caching Pkl binary availability so env-mutating tests or runtime PATH changes cannot poison agent manifest loading for the rest of the process.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [Semantic V
 - Added a source-agnostic skill suggestion helper that evaluates parsed bundled, user-installed, Armory-installed, or project-local skills against profile, intent, and project-signal evidence without performing runtime injection, preserving external metadata diagnostics instead of silently dropping malformed activation hints.
 
 ### Fixed
+- Made outside-workspace permission prompts wait for an explicit operator allow/deny decision instead of timing out as a denial after 120 seconds; `--dangerously-bypass-permissions` still bypasses the prompt before it is raised.
 - Unified provider credential reads through canonical auth.json keys so OpenAI Codex OAuth aliases resolve the persisted `openai-codex` grant instead of forcing reauthentication after rebuilds.
 - Isolated the voice bridge extension fixture from ambient Kubernetes substrate environment so full-suite runs do not reject the native test extension.
 - Avoid caching Pkl binary availability so env-mutating tests or runtime PATH changes cannot poison agent manifest loading for the rest of the process.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [Semantic V
 - Added a source-agnostic skill suggestion helper that evaluates parsed bundled, user-installed, Armory-installed, or project-local skills against profile, intent, and project-signal evidence without performing runtime injection, preserving external metadata diagnostics instead of silently dropping malformed activation hints.
 
 ### Fixed
+- Guarded auth.json writes and logout mutations in test builds so credential mutation paths fail fast unless `OMEGON_AUTH_JSON_PATH` points at an explicit fixture, preventing test-suite runs from mutating the operator's real `~/.config/omegon/auth.json`.
 - Routed bash workspace-boundary hits through the same typed permission mediation as read/write/edit so approved outside-workspace shell writes retry instead of remaining bash-local blocks.
 - Made outside-workspace permission prompts wait for an explicit operator allow/deny decision instead of timing out as a denial after 120 seconds; explicit run cancellation still unblocks the wait as a denial/cancelled decision, and `--dangerously-bypass-permissions` still bypasses the prompt before it is raised.
 - Unified provider credential reads through canonical auth.json keys so OpenAI Codex OAuth aliases resolve the persisted `openai-codex` grant instead of forcing reauthentication after rebuilds.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [Semantic V
 - Added a source-agnostic skill suggestion helper that evaluates parsed bundled, user-installed, Armory-installed, or project-local skills against profile, intent, and project-signal evidence without performing runtime injection, preserving external metadata diagnostics instead of silently dropping malformed activation hints.
 
 ### Fixed
+- Documented that bash permission mediation is static/advisory for common shell forms and that hard filesystem containment belongs to the sandbox layer.
 - Guarded auth.json writes and logout mutations in test builds so credential mutation paths fail fast unless `OMEGON_AUTH_JSON_PATH` points at an explicit fixture, preventing test-suite runs from mutating the operator's real `~/.config/omegon/auth.json`.
 - Routed bash workspace-boundary hits through the same typed permission mediation as read/write/edit so approved outside-workspace shell writes retry instead of remaining bash-local blocks.
 - Made outside-workspace permission prompts wait for an explicit operator allow/deny decision instead of timing out as a denial after 120 seconds; explicit run cancellation still unblocks the wait as a denial/cancelled decision, and `--dangerously-bypass-permissions` still bypasses the prompt before it is raised.

--- a/core/crates/omegon/src/auth.rs
+++ b/core/crates/omegon/src/auth.rs
@@ -881,6 +881,7 @@ pub fn read_credential_extra(provider: &str, field: &str) -> Option<String> {
 pub fn write_credentials(provider: &str, creds: &OAuthCredentials) -> anyhow::Result<()> {
     let path =
         auth_json_path().ok_or_else(|| anyhow::anyhow!("Cannot determine home directory"))?;
+    assert_test_auth_json_override_for_write(&path)?;
     let _ = std::fs::create_dir_all(path.parent().unwrap());
 
     with_auth_json_lock(&path, || {
@@ -1009,6 +1010,7 @@ pub fn logout_provider(provider: &str) -> anyhow::Result<()> {
 
     let path =
         auth_json_path().ok_or_else(|| anyhow::anyhow!("Cannot determine home directory"))?;
+    assert_test_auth_json_override_for_write(&path)?;
 
     if !path.exists() {
         return Ok(());
@@ -2038,6 +2040,7 @@ fn write_credentials_with_extra(
 ) -> anyhow::Result<()> {
     let path =
         auth_json_path().ok_or_else(|| anyhow::anyhow!("Cannot determine home directory"))?;
+    assert_test_auth_json_override_for_write(&path)?;
     let _ = std::fs::create_dir_all(path.parent().unwrap());
     with_auth_json_lock(&path, || {
         let mut auth = read_auth_json_for_update(&path, "write_credentials_with_extra", provider)?;
@@ -2095,6 +2098,7 @@ fn refreshed_credential_entry(
 fn write_refreshed_credentials(provider: &str, creds: &OAuthCredentials) -> anyhow::Result<()> {
     let path =
         auth_json_path().ok_or_else(|| anyhow::anyhow!("Cannot determine home directory"))?;
+    assert_test_auth_json_override_for_write(&path)?;
     let _ = std::fs::create_dir_all(path.parent().unwrap());
     with_auth_json_lock(&path, || {
         let mut auth = read_auth_json_for_update(&path, "write_refreshed_credentials", provider)?;
@@ -2115,6 +2119,27 @@ fn write_refreshed_credentials(provider: &str, creds: &OAuthCredentials) -> anyh
         tracing::info!(provider, auth_path = %auth_path, auth_path_source, expires = creds.expires, "persisted refreshed provider credentials to auth.json");
         Ok(())
     })
+}
+
+
+fn assert_test_auth_json_override_for_write(path: &Path) -> anyhow::Result<()> {
+    #[cfg(test)]
+    {
+        let override_path = std::env::var("OMEGON_AUTH_JSON_PATH")
+            .map(|value| !value.trim().is_empty())
+            .unwrap_or(false);
+        if !override_path {
+            anyhow::bail!(
+                "test attempted to write default auth.json path without OMEGON_AUTH_JSON_PATH override: {}",
+                path.display()
+            );
+        }
+    }
+    #[cfg(not(test))]
+    {
+        let _ = path;
+    }
+    Ok(())
 }
 
 fn read_auth_json_for_update(
@@ -2789,10 +2814,16 @@ mod tests {
             assert_eq!(auth_json_path().as_deref(), Some(override_path.as_path()));
         });
 
-        with_auth_json_path_env(None, || {
-            let path = auth_json_path().expect("default auth path");
-            assert!(path.ends_with(".config/omegon/auth.json"));
-        });
+        let original = std::env::var("OMEGON_AUTH_JSON_PATH").ok();
+        unsafe { std::env::remove_var("OMEGON_AUTH_JSON_PATH") };
+        let path = auth_json_path().expect("default auth path");
+        unsafe {
+            match original {
+                Some(value) => std::env::set_var("OMEGON_AUTH_JSON_PATH", value),
+                None => std::env::remove_var("OMEGON_AUTH_JSON_PATH"),
+            }
+        }
+        assert!(path.ends_with(".config/omegon/auth.json"));
     }
 
     #[test]

--- a/core/crates/omegon/src/auth.rs
+++ b/core/crates/omegon/src/auth.rs
@@ -2125,6 +2125,10 @@ fn write_refreshed_credentials(provider: &str, creds: &OAuthCredentials) -> anyh
 fn assert_test_auth_json_override_for_write(path: &Path) -> anyhow::Result<()> {
     #[cfg(test)]
     {
+        // Test builds must never mutate the operator's real auth store.
+        // Credential tests are required to mount an explicit fixture via
+        // OMEGON_AUTH_JSON_PATH so full-suite runs cannot delete live OAuth
+        // grants such as openai-codex.
         let override_path = std::env::var("OMEGON_AUTH_JSON_PATH")
             .map(|value| !value.trim().is_empty())
             .unwrap_or(false);

--- a/core/crates/omegon/src/loop.rs
+++ b/core/crates/omegon/src/loop.rs
@@ -2753,6 +2753,29 @@ async fn dispatch_single_tool(
 }
 
 #[allow(clippy::too_many_arguments)]
+async fn wait_for_permission_response(
+    rx: std::sync::mpsc::Receiver<omegon_traits::PermissionResponse>,
+    cancel: CancellationToken,
+) -> omegon_traits::PermissionResponse {
+    let (notify_tx, mut notify_rx) = tokio::sync::mpsc::unbounded_channel();
+    tokio::task::spawn_blocking(move || {
+        let _ = notify_tx.send(rx.recv());
+    });
+
+    // Permission prompts are an operator control boundary, not a soft failure.
+    // Match Claude Code semantics: once a tool needs outside-workspace access,
+    // the run waits until the operator allows or denies it. There is no passive
+    // timeout. Explicit run cancellation still unblocks as a denial/cancelled
+    // decision, and pre-approved paths or --dangerously-bypass-permissions avoid
+    // this branch upstream.
+    tokio::select! {
+        _ = cancel.cancelled() => omegon_traits::PermissionResponse::Deny,
+        response = notify_rx.recv() => response
+            .and_then(Result::ok)
+            .unwrap_or(omegon_traits::PermissionResponse::Deny),
+    }
+}
+
 async fn execute_tool_invocation(
     bus: &crate::bus::EventBus,
     visible_call_id: &str,
@@ -3082,17 +3105,7 @@ async fn execute_tool_invocation(
                     respond,
                 });
 
-                tokio::task::spawn_blocking(move || {
-                    // Permission prompts are an operator control boundary, not a
-                    // soft failure. Match Claude Code semantics: once a tool
-                    // needs outside-workspace access, the run waits here until
-                    // the operator allows or denies it. The bypass door remains
-                    // `--dangerously-bypass-permissions`, which prevents this
-                    // prompt from being raised in the first place.
-                    rx.recv().unwrap_or(omegon_traits::PermissionResponse::Deny)
-                })
-                .await
-                .unwrap_or(omegon_traits::PermissionResponse::Deny)
+                wait_for_permission_response(rx, cancel.clone()).await
             };
 
             match response {
@@ -4005,6 +4018,56 @@ mod tests {
     use super::*;
     use crate::behavior::{EvidenceAssessment, EvidenceSufficiency, ProgressSignal};
     use omegon_traits::{OodaPhase, ToolCapability, ToolDefinition, ToolProvider};
+
+    #[tokio::test]
+    async fn permission_wait_remains_pending_without_operator_response() {
+        let (_tx, rx) = std::sync::mpsc::channel();
+        let cancel = CancellationToken::new();
+
+        let result = tokio::time::timeout(
+            std::time::Duration::from_millis(100),
+            wait_for_permission_response(rx, cancel),
+        )
+        .await;
+
+        assert!(
+            result.is_err(),
+            "permission wait must not auto-deny on a passive timeout"
+        );
+    }
+
+    #[tokio::test]
+    async fn permission_wait_cancellation_unblocks_as_deny() {
+        let (_tx, rx) = std::sync::mpsc::channel();
+        let cancel = CancellationToken::new();
+        let child = cancel.child_token();
+
+        let task = tokio::spawn(wait_for_permission_response(rx, child));
+        cancel.cancel();
+
+        let response = tokio::time::timeout(std::time::Duration::from_secs(1), task)
+            .await
+            .expect("permission wait should observe cancellation")
+            .expect("permission wait task should not panic");
+        assert_eq!(response, omegon_traits::PermissionResponse::Deny);
+    }
+
+    #[tokio::test]
+    async fn permission_wait_returns_explicit_operator_response() {
+        let (tx, rx) = std::sync::mpsc::channel();
+        let cancel = CancellationToken::new();
+
+        tx.send(omegon_traits::PermissionResponse::Allow)
+            .expect("send permission response");
+
+        let response = tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            wait_for_permission_response(rx, cancel),
+        )
+        .await
+        .expect("permission wait should complete after explicit response");
+        assert_eq!(response, omegon_traits::PermissionResponse::Allow);
+    }
 
     fn test_tool_catalog() -> ToolCapabilityCatalog {
         ToolCapabilityCatalog::from_tool_defs(&[

--- a/core/crates/omegon/src/loop.rs
+++ b/core/crates/omegon/src/loop.rs
@@ -3083,8 +3083,13 @@ async fn execute_tool_invocation(
                 });
 
                 tokio::task::spawn_blocking(move || {
-                    rx.recv_timeout(std::time::Duration::from_secs(120))
-                        .unwrap_or(omegon_traits::PermissionResponse::Deny)
+                    // Permission prompts are an operator control boundary, not a
+                    // soft failure. Match Claude Code semantics: once a tool
+                    // needs outside-workspace access, the run waits here until
+                    // the operator allows or denies it. The bypass door remains
+                    // `--dangerously-bypass-permissions`, which prevents this
+                    // prompt from being raised in the first place.
+                    rx.recv().unwrap_or(omegon_traits::PermissionResponse::Deny)
                 })
                 .await
                 .unwrap_or(omegon_traits::PermissionResponse::Deny)

--- a/core/crates/omegon/src/main.rs
+++ b/core/crates/omegon/src/main.rs
@@ -9369,12 +9369,35 @@ mod tests {
         );
     }
 
+    struct EnvVarGuard {
+        key: &'static str,
+        original: Option<String>,
+    }
+
+    impl EnvVarGuard {
+        fn set_path(key: &'static str, value: &std::path::Path) -> Self {
+            let original = std::env::var(key).ok();
+            unsafe { std::env::set_var(key, value) };
+            Self { key, original }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            unsafe {
+                match &self.original {
+                    Some(value) => std::env::set_var(self.key, value),
+                    None => std::env::remove_var(self.key),
+                }
+            }
+        }
+    }
+
     #[test]
     fn remote_slash_logout_accepts_openai_codex_provider() {
         let dir = tempfile::tempdir().unwrap();
         let auth_path = dir.path().join("auth.json");
-        let original_auth = std::env::var("OMEGON_AUTH_JSON_PATH").ok();
-        unsafe { std::env::set_var("OMEGON_AUTH_JSON_PATH", &auth_path) };
+        let _auth_env = EnvVarGuard::set_path("OMEGON_AUTH_JSON_PATH", &auth_path);
 
         let rt = tokio::runtime::Runtime::new().unwrap();
         let agent = test_agent_setup();
@@ -9414,12 +9437,6 @@ mod tests {
             "got: {output}"
         );
 
-        unsafe {
-            match original_auth {
-                Some(value) => std::env::set_var("OMEGON_AUTH_JSON_PATH", value),
-                None => std::env::remove_var("OMEGON_AUTH_JSON_PATH"),
-            }
-        }
     }
 
     #[test]

--- a/core/crates/omegon/src/main.rs
+++ b/core/crates/omegon/src/main.rs
@@ -9371,6 +9371,11 @@ mod tests {
 
     #[test]
     fn remote_slash_logout_accepts_openai_codex_provider() {
+        let dir = tempfile::tempdir().unwrap();
+        let auth_path = dir.path().join("auth.json");
+        let original_auth = std::env::var("OMEGON_AUTH_JSON_PATH").ok();
+        unsafe { std::env::set_var("OMEGON_AUTH_JSON_PATH", &auth_path) };
+
         let rt = tokio::runtime::Runtime::new().unwrap();
         let agent = test_agent_setup();
         let (events_tx, _) = broadcast::channel(16);
@@ -9408,6 +9413,13 @@ mod tests {
             output.contains("cleared this session's cached auth env"),
             "got: {output}"
         );
+
+        unsafe {
+            match original_auth {
+                Some(value) => std::env::set_var("OMEGON_AUTH_JSON_PATH", value),
+                None => std::env::remove_var("OMEGON_AUTH_JSON_PATH"),
+            }
+        }
     }
 
     #[test]

--- a/core/crates/omegon/src/tools/bash.rs
+++ b/core/crates/omegon/src/tools/bash.rs
@@ -94,33 +94,30 @@ pub async fn execute_streaming(
     }
 
     // ─── Workspace boundary heuristic scan ─────────────────────────
-    // Best-effort scan for filesystem write patterns targeting paths
-    // outside the workspace boundary. This is NOT a security boundary —
-    // shell variable expansion, subshells, and programmatic I/O bypass
-    // it trivially. It exists to catch the common accidental case.
-    // The Nex container sandbox is the real enforcement layer.
+    // Best-effort scan for filesystem write patterns targeting paths outside
+    // the workspace boundary. This is not a complete shell sandbox — shell
+    // variable expansion, subshells, and programmatic I/O require the Nex
+    // container boundary — but detected violations must flow through the same
+    // typed permission mediation path as read/write/edit instead of becoming
+    // ad hoc bash-local blocks that the agent can route around.
     if let Some(ref boundary) = boundary {
         let violations = scan_boundary_violations(trimmed, boundary, cwd);
-        if !violations.is_empty() {
-            return Ok(ToolResult {
-                content: vec![ContentBlock::Text {
-                    text: format!(
-                        "BLOCKED: command targets paths outside the workspace boundary:\n{}",
-                        violations
-                            .iter()
-                            .map(|v| format!("  - {v}"))
-                            .collect::<Vec<_>>()
-                            .join("\n"),
-                    ),
-                }],
-                details: serde_json::json!({
-                    "exitCode": -1,
-                    "durationMs": 0,
-                    "blocked": true,
-                    "reason": "workspace_boundary_violation",
-                    "paths": violations,
-                }),
-            });
+        if let Some(path) = violations.first() {
+            let resolved = if path.starts_with('/') || path.starts_with('~') {
+                super::expand_tilde(path)
+            } else {
+                cwd.join(path)
+            };
+            let directory = resolved
+                .parent()
+                .map(|p| p.display().to_string())
+                .unwrap_or_default();
+            return Err(super::PathPermissionError {
+                requested_path: path.clone(),
+                directory,
+                workspace: boundary.cwd().display().to_string(),
+            }
+            .into());
         }
     }
 
@@ -583,7 +580,8 @@ const ALLOWED_PATHS: &[&str] = &[
 ];
 
 /// Scan a bash command for filesystem write patterns targeting paths
-/// outside the workspace boundary. Returns a list of violating paths.
+/// outside the workspace boundary. Returns a list of paths that need
+/// permission mediation before bash may execute.
 pub(crate) fn scan_boundary_violations(
     command: &str,
     boundary: &super::WorkspaceBoundary,
@@ -1107,6 +1105,27 @@ mod tests {
         );
         assert!(!v.is_empty(), "should catch redirect to /etc/evil.txt");
         assert!(v.iter().any(|p| p.contains("/etc/evil.txt")));
+    }
+
+    #[tokio::test]
+    async fn bash_boundary_hit_returns_typed_permission_error() {
+        let b = test_boundary("/tmp/workspace");
+        let err = execute_streaming(
+            "echo secret > /etc/evil.txt",
+            Path::new("/tmp/workspace"),
+            Some(1),
+            CancellationToken::new(),
+            ToolProgressSink::noop(),
+            Some(b),
+        )
+        .await
+        .expect_err("outside-workspace bash writes should request permission");
+
+        let permission = err
+            .downcast_ref::<crate::tools::PathPermissionError>()
+            .expect("bash boundary hits must use PathPermissionError");
+        assert_eq!(permission.requested_path, "/etc/evil.txt");
+        assert_eq!(permission.directory, "/etc");
     }
 
     #[test]

--- a/docs/granular-permissions.md
+++ b/docs/granular-permissions.md
@@ -53,6 +53,8 @@ Patterns: glob matching on tool arguments.
 
 Runtime invariant: permission-required operations are not recoverable tool failures. They suspend the agent run until explicit operator allow, explicit deny, explicit run cancellation, or an upstream preapproval/bypass such as a trusted directory or `--dangerously-bypass-permissions`. A passive timeout must not convert a permission prompt into denial.
 
+Bash mediation is static and advisory for common shell forms (redirects, `tee`, `cp`/`mv`/`install`, `mkdir`, `rm`). It unifies detected bash boundary hits with the permission prompt surface, but hard filesystem containment for shell variable indirection, subprocesses, and programmatic I/O belongs to the sandbox layer.
+
 The key improvement over OpenCode: our permissions compose with personas. The tutor persona says "no bash" — that's a persona-level deny that the operator can't accidentally override with a session sticky. The Lex Imperialis could define absolute denies (e.g. never allow `rm -rf /`).
 
 ## Open Questions

--- a/docs/granular-permissions.md
+++ b/docs/granular-permissions.md
@@ -51,6 +51,8 @@ external_directory = { action = "deny", allow = ["/usr/local/include"] }
 Actions: `allow` (silent), `prompt` (ask operator), `deny` (block).
 Patterns: glob matching on tool arguments.
 
+Runtime invariant: permission-required operations are not recoverable tool failures. They suspend the agent run until explicit operator allow, explicit deny, explicit run cancellation, or an upstream preapproval/bypass such as a trusted directory or `--dangerously-bypass-permissions`. A passive timeout must not convert a permission prompt into denial.
+
 The key improvement over OpenCode: our permissions compose with personas. The tutor persona says "no bash" — that's a persona-level deny that the operator can't accidentally override with a session sticky. The Lex Imperialis could define absolute denies (e.g. never allow `rm -rf /`).
 
 ## Open Questions


### PR DESCRIPTION
## Summary

- Make outside-workspace permission prompts suspend execution until explicit operator allow/deny or run cancellation, instead of passively timing out as denial.
- Route detected bash outside-workspace writes through the same `PathPermissionError` mediation path as read/write/edit so approvals retry the original command.
- Guard auth credential mutations in tests so full-suite runs cannot mutate the operator’s real `~/.config/omegon/auth.json`.
- Isolate `/logout openai-codex` remote slash test with a panic-safe auth env guard.
- Document the permission runtime invariant and bash mediation limits.

## Validation

- `cargo test -p omegon`
- `cargo test -p omegon logout -- --nocapture`
- `cargo test -p omegon permission_wait_ -- --nocapture`
- `cargo test -p omegon bash_boundary_hit_returns_typed_permission_error -- --nocapture`
- `cargo check -p omegon --bin omegon`
- `git diff --check main..HEAD`

## Notes

Bash mediation remains static/advisory for common shell forms. Hard containment for shell indirection, subprocesses, and programmatic I/O remains a sandbox-layer responsibility.