### PR TITLE
fix(providers): classify upstream degradation failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [Semantic V
 ### Changed
 - Propagated `--dangerously-bypass-permissions` into delegate and cleave child Omegon processes so higher-order workers inherit parent permission bypass authority.
 - Updated the Claude Code OAuth user-agent to match upstream `@anthropic-ai/claude-code` 2.1.179.
+- Expanded upstream provider failure classification for Anthropic, OpenAI/Codex, Gemini, Groq, Mistral, OpenRouter, xAI, and Cerebras degradation signals, with explicit false-positive guards for generic quota, capacity, and not-found prose.
 - Clarified that policy prompts are allow-once until durable policy grants exist, and documented default-open unknown-tool behavior plus lexical permission-pattern matching.
 - Strengthened Lex Imperialis operator-agency guidance to require interactive background terminal/session handling for OAuth, browser, device-code, approval, and other human-blocking workflows when that tooling is available.
 - Improved slim TUI tool-row summaries so skipped validation, shell errors, edit/commit outcomes, search result counts, and memory recall counts surface as concise row outcomes instead of generic first-line result text.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [Semantic V
 
 ### Changed
 - Propagated `--dangerously-bypass-permissions` into delegate and cleave child Omegon processes so higher-order workers inherit parent permission bypass authority.
+- Updated the Claude Code OAuth user-agent to match upstream `@anthropic-ai/claude-code` 2.1.179.
 - Clarified that policy prompts are allow-once until durable policy grants exist, and documented default-open unknown-tool behavior plus lexical permission-pattern matching.
 - Strengthened Lex Imperialis operator-agency guidance to require interactive background terminal/session handling for OAuth, browser, device-code, approval, and other human-blocking workflows when that tooling is available.
 - Improved slim TUI tool-row summaries so skipped validation, shell errors, edit/commit outcomes, search result counts, and memory recall counts surface as concise row outcomes instead of generic first-line result text.

--- a/core/crates/omegon/src/providers.rs
+++ b/core/crates/omegon/src/providers.rs
@@ -18,7 +18,7 @@ use crate::bridge::{LlmBridge, LlmEvent, LlmMessage, StreamOptions};
 /// Claude Code CLI version for OAuth user-agent header.
 /// Must match what Anthropic expects for subscription recognition.
 /// Update when upstream Claude Code advances.
-const CLAUDE_CODE_UA: &str = "claude-cli/2.1.173";
+const CLAUDE_CODE_UA: &str = "claude-cli/2.1.179";
 use omegon_traits::ToolDefinition;
 
 /// Anthropic credential mode — records what credential source is active.
@@ -2019,6 +2019,55 @@ fn is_codex_retryable(status: u16) -> bool {
     matches!(status, 429 | 500 | 502 | 503 | 504 | 520)
 }
 
+fn extract_codex_error_detail(event: &Value) -> String {
+    let first_string = [
+        "/message",
+        "/error/message",
+        "/response/error/message",
+        "/detail",
+        "/response/incomplete_details/reason",
+        "/error/code",
+        "/error/type",
+        "/code",
+        "/type",
+    ]
+    .into_iter()
+    .filter_map(|pointer| event.pointer(pointer).and_then(Value::as_str))
+    .find(|value| !value.trim().is_empty());
+
+    if let Some(message) = first_string {
+        let mut detail = message.to_string();
+        let code = event
+            .pointer("/error/code")
+            .or_else(|| event.pointer("/code"))
+            .and_then(Value::as_str)
+            .filter(|value| !value.trim().is_empty());
+        let kind = event
+            .pointer("/error/type")
+            .or_else(|| event.pointer("/type"))
+            .and_then(Value::as_str)
+            .filter(|value| !value.trim().is_empty());
+        if let Some(code) = code
+            && !detail.contains(code)
+        {
+            detail.push_str(&format!(" (code: {code})"));
+        }
+        if let Some(kind) = kind
+            && !detail.contains(kind)
+        {
+            detail.push_str(&format!("; type: {kind}"));
+        }
+        return detail;
+    }
+
+    let compact = event.to_string();
+    if compact == "{}" || compact == "null" {
+        "Codex returned an error event without details".to_string()
+    } else {
+        format!("Codex returned an unrecognized error event: {}", crate::util::truncate_str(&compact, 300))
+    }
+}
+
 #[async_trait]
 impl LlmBridge for CodexClient {
     async fn stream(
@@ -2319,19 +2368,12 @@ async fn parse_codex_stream(
                 return false;
             }
             "response.failed" => {
-                let msg = event["response"]["error"]["message"]
-                    .as_str()
-                    .or(event["response"]["incomplete_details"]["reason"].as_str())
-                    .unwrap_or("Codex response failed")
-                    .to_string();
+                let msg = extract_codex_error_detail(&event);
                 terminal = Some(TerminalEvent::Error(format!("Codex: {msg}")));
                 return false;
             }
             "error" => {
-                let msg = event["message"]
-                    .as_str()
-                    .unwrap_or("unknown error")
-                    .to_string();
+                let msg = extract_codex_error_detail(&event);
                 terminal = Some(TerminalEvent::Error(format!("Codex error: {msg}")));
                 return false;
             }
@@ -4680,6 +4722,40 @@ mod tests {
             .or_else(|| bare.strip_prefix("openai:"))
             .unwrap_or("gpt-5.5");
         assert_eq!(stripped, "gpt-5.5"); // fallback
+    }
+
+    #[test]
+    fn codex_error_detail_extracts_nested_openai_error_shape() {
+        let detail = extract_codex_error_detail(&json!({
+            "type": "error",
+            "error": {
+                "message": "Rate limit reached for responses",
+                "code": "rate_limit_exceeded",
+                "type": "requests"
+            }
+        }));
+        assert!(detail.contains("Rate limit reached for responses"), "{detail}");
+        assert!(detail.contains("rate_limit_exceeded"), "{detail}");
+        assert!(detail.contains("requests"), "{detail}");
+        assert!(!detail.contains("unknown error"), "{detail}");
+    }
+
+    #[test]
+    fn codex_error_detail_extracts_response_failed_shape() {
+        let detail = extract_codex_error_detail(&json!({
+            "type": "response.failed",
+            "response": {
+                "error": { "message": "Your session expired" }
+            }
+        }));
+        assert_eq!(detail, "Your session expired; type: response.failed");
+    }
+
+    #[test]
+    fn codex_error_detail_uses_explicit_empty_payload_message() {
+        let detail = extract_codex_error_detail(&json!({}));
+        assert_eq!(detail, "Codex returned an error event without details");
+        assert!(!detail.contains("unknown error"));
     }
 
     #[test]

--- a/core/crates/omegon/src/upstream_errors.rs
+++ b/core/crates/omegon/src/upstream_errors.rs
@@ -96,7 +96,19 @@ const PROVIDER_ERROR_RULES: &[ErrorRule] = &[
         providers: &["anthropic"],
         class: UpstreamErrorClass::ProviderOverloaded,
         substrings: &["overloaded_error"],
+        word_tokens: &["529"],
+    },
+    ErrorRule {
+        providers: &["google", "google-antigravity"],
+        class: UpstreamErrorClass::AuthInvalid,
+        substrings: &["failed_precondition", "permission_denied"],
         word_tokens: &[],
+    },
+    ErrorRule {
+        providers: &["groq"],
+        class: UpstreamErrorClass::ProviderOverloaded,
+        substrings: &["flex tier", "model is at capacity"],
+        word_tokens: &["423", "498"],
     },
     ErrorRule {
         providers: &["openai-codex"],
@@ -141,9 +153,28 @@ const PROVIDER_ERROR_RULES: &[ErrorRule] = &[
         substrings: &[
             "invalid_request_error",
             "unsupported_parameter",
+            "model_not_found",
+            "not_found_error",
+            "unprocessable entity",
+            "validation error",
             "bad request",
         ],
-        word_tokens: &["400"],
+        word_tokens: &["400", "404", "422"],
+    },
+];
+
+const GLOBAL_PRECEDENCE_ERROR_RULES: &[ErrorRule] = &[
+    ErrorRule {
+        providers: &[],
+        class: UpstreamErrorClass::QuotaExceeded,
+        substrings: &[
+            "insufficient credits",
+            "insufficient quota",
+            "exceeded your current quota",
+            "quota exceeded",
+            "payment required",
+        ],
+        word_tokens: &["402"],
     },
 ];
 
@@ -174,7 +205,15 @@ const GLOBAL_ERROR_RULES: &[ErrorRule] = &[
     ErrorRule {
         providers: &[],
         class: UpstreamErrorClass::QuotaExceeded,
-        substrings: &["quota", "insufficient credits", "billing", "usage limit"],
+        substrings: &[
+            "quota",
+            "insufficient credits",
+            "insufficient quota",
+            "billing",
+            "usage limit",
+            "exceeded your current quota",
+            "quota exceeded",
+        ],
         word_tokens: &[],
     },
     ErrorRule {
@@ -183,7 +222,9 @@ const GLOBAL_ERROR_RULES: &[ErrorRule] = &[
         substrings: &[
             "rate limit",
             "rate_limit",
+            "rate_limit_exceeded",
             "too many requests",
+            "resource_exhausted",
             "retry-after",
             "requests per min",
             "tokens per min",
@@ -197,6 +238,7 @@ const GLOBAL_ERROR_RULES: &[ErrorRule] = &[
         class: UpstreamErrorClass::ProviderOverloaded,
         substrings: &[
             "overloaded",
+            "overloaded_error",
             "capacity",
             "at capacity",
             "server is busy",
@@ -209,6 +251,7 @@ const GLOBAL_ERROR_RULES: &[ErrorRule] = &[
         providers: &[],
         class: UpstreamErrorClass::Upstream5xx,
         substrings: &[
+            "failed_dependency",
             "error code: 520",
             "origin error",
             "origin unreachable",
@@ -289,8 +332,16 @@ const GLOBAL_ERROR_RULES: &[ErrorRule] = &[
     ErrorRule {
         providers: &[],
         class: UpstreamErrorClass::BadRequest,
-        substrings: &["invalid request", "bad request"],
-        word_tokens: &["400"],
+        substrings: &[
+            "invalid request",
+            "bad request",
+            "invalid_argument",
+            "not found",
+            "model not found",
+            "unprocessable entity",
+            "validation error",
+        ],
+        word_tokens: &["400", "404", "422"],
     },
     ErrorRule {
         providers: &[],
@@ -307,8 +358,8 @@ const GLOBAL_ERROR_RULES: &[ErrorRule] = &[
     ErrorRule {
         providers: &[],
         class: UpstreamErrorClass::ResponseCancelled,
-        substrings: &["response cancelled", "cancelled by server"],
-        word_tokens: &[],
+        substrings: &["response cancelled", "cancelled by server", "client closed request"],
+        word_tokens: &["499"],
     },
     ErrorRule {
         providers: &[],
@@ -466,10 +517,32 @@ pub(crate) fn classify_upstream_error_for_provider(
     msg: &str,
 ) -> UpstreamErrorClass {
     let lower = msg.to_lowercase();
+    if is_context_overflow(&lower) {
+        return UpstreamErrorClass::ContextOverflow;
+    }
+    if is_malformed_history(&lower) {
+        return UpstreamErrorClass::MalformedHistory;
+    }
+    if let Some(class) = apply_error_rules(GLOBAL_PRECEDENCE_ERROR_RULES, None, &lower) {
+        return class;
+    }
+    if matches!(provider, "google" | "google-antigravity")
+        && lower.contains("failed_precondition")
+        && (lower.contains("invalid")
+            || lower.contains("unsupported")
+            || lower.contains("model")
+            || lower.contains("request"))
+        && !(lower.contains("api key")
+            || lower.contains("permission")
+            || lower.contains("billing")
+            || lower.contains("project"))
+    {
+        return UpstreamErrorClass::BadRequest;
+    }
     if let Some(class) = apply_error_rules(PROVIDER_ERROR_RULES, Some(provider), &lower) {
         return class;
     }
-    classify_upstream_error(msg)
+    apply_error_rules(GLOBAL_ERROR_RULES, None, &lower).unwrap_or(UpstreamErrorClass::Unknown)
 }
 
 pub(crate) fn classify_upstream_error(msg: &str) -> UpstreamErrorClass {
@@ -843,6 +916,187 @@ mod tests {
         assert_eq!(
             classify_upstream_error("server is busy due to high demand"),
             UpstreamErrorClass::ProviderOverloaded,
+        );
+    }
+
+    #[test]
+    fn provider_failure_matrix_rows_classify_as_documented() {
+        let cases = [
+            (
+                "anthropic",
+                "HTTP 400 invalid_request_error: bad request",
+                UpstreamErrorClass::BadRequest,
+            ),
+            (
+                "anthropic",
+                "HTTP 401 authentication_error: invalid API key",
+                UpstreamErrorClass::AuthInvalid,
+            ),
+            (
+                "anthropic",
+                "HTTP 413 request too large: maximum context length exceeded",
+                UpstreamErrorClass::ContextOverflow,
+            ),
+            (
+                "anthropic",
+                "HTTP 429 rate_limit_error: too many requests",
+                UpstreamErrorClass::RateLimited,
+            ),
+            (
+                "anthropic",
+                "HTTP 529 overloaded_error: provider overloaded",
+                UpstreamErrorClass::ProviderOverloaded,
+            ),
+            (
+                "openai",
+                "HTTP 400 invalid_request_error: unsupported_parameter",
+                UpstreamErrorClass::BadRequest,
+            ),
+            (
+                "openai",
+                "HTTP 401 invalid api key",
+                UpstreamErrorClass::AuthInvalid,
+            ),
+            (
+                "openai",
+                "HTTP 404 model_not_found",
+                UpstreamErrorClass::BadRequest,
+            ),
+            (
+                "openai",
+                "HTTP 429 rate_limit_exceeded: requests per min exceeded",
+                UpstreamErrorClass::RateLimited,
+            ),
+            (
+                "openai",
+                "HTTP 429 insufficient_quota: exceeded your current quota",
+                UpstreamErrorClass::QuotaExceeded,
+            ),
+            (
+                "openai",
+                "HTTP 500 server_error",
+                UpstreamErrorClass::Upstream5xx,
+            ),
+            (
+                "openai-codex",
+                "Codex 401 Unauthorized: token expired, please log in again",
+                UpstreamErrorClass::SessionExpired,
+            ),
+            (
+                "openai-codex",
+                "Codex error: Rate limit reached for responses (code: rate_limit_exceeded; type: requests)",
+                UpstreamErrorClass::RateLimited,
+            ),
+            (
+                "openai-codex",
+                "Codex: response incomplete (max_output_tokens) — output was truncated",
+                UpstreamErrorClass::ResponseIncomplete,
+            ),
+            (
+                "openai-codex",
+                "Codex: response cancelled by server",
+                UpstreamErrorClass::ResponseCancelled,
+            ),
+            (
+                "google",
+                "INVALID_ARGUMENT: request contains an invalid_argument",
+                UpstreamErrorClass::BadRequest,
+            ),
+            (
+                "google",
+                "FAILED_PRECONDITION: API key not configured",
+                UpstreamErrorClass::AuthInvalid,
+            ),
+            (
+                "google",
+                "FAILED_PRECONDITION: invalid request for unsupported model option",
+                UpstreamErrorClass::BadRequest,
+            ),
+            (
+                "google",
+                "RESOURCE_EXHAUSTED: rate limit exceeded",
+                UpstreamErrorClass::RateLimited,
+            ),
+            (
+                "google",
+                "RESOURCE_EXHAUSTED: quota exceeded for project",
+                UpstreamErrorClass::QuotaExceeded,
+            ),
+            (
+                "google",
+                "UNAVAILABLE: service unavailable",
+                UpstreamErrorClass::Upstream5xx,
+            ),
+            (
+                "groq",
+                "HTTP 423 model is at capacity",
+                UpstreamErrorClass::ProviderOverloaded,
+            ),
+            (
+                "groq",
+                "HTTP 429 rate limit reached",
+                UpstreamErrorClass::RateLimited,
+            ),
+            (
+                "groq",
+                "HTTP 498 flex tier capacity exceeded",
+                UpstreamErrorClass::ProviderOverloaded,
+            ),
+            (
+                "groq",
+                "HTTP 424 failed_dependency",
+                UpstreamErrorClass::Upstream5xx,
+            ),
+            (
+                "mistral",
+                "HTTP 422 unprocessable entity: validation error",
+                UpstreamErrorClass::BadRequest,
+            ),
+            (
+                "mistral",
+                "HTTP 429 too many requests",
+                UpstreamErrorClass::RateLimited,
+            ),
+            (
+                "openrouter",
+                "HTTP 402 insufficient credits",
+                UpstreamErrorClass::QuotaExceeded,
+            ),
+            (
+                "openrouter",
+                "HTTP 429 rate limit",
+                UpstreamErrorClass::RateLimited,
+            ),
+            (
+                "xai",
+                "HTTP 503 service unavailable",
+                UpstreamErrorClass::Upstream5xx,
+            ),
+            (
+                "cerebras",
+                "HTTP 504 gateway timeout",
+                UpstreamErrorClass::Upstream5xx,
+            ),
+        ];
+
+        for (provider, message, expected) in cases {
+            assert_eq!(
+                classify_upstream_error_for_provider(provider, message),
+                expected,
+                "provider={provider} message={message}",
+            );
+        }
+    }
+
+    #[test]
+    fn quota_language_takes_precedence_over_rate_limit_status() {
+        assert_eq!(
+            classify_upstream_error("429 insufficient_quota: exceeded your current quota"),
+            UpstreamErrorClass::QuotaExceeded,
+        );
+        assert_eq!(
+            classify_upstream_error("429 rate_limit_exceeded: requests per min exceeded"),
+            UpstreamErrorClass::RateLimited,
         );
     }
 

--- a/core/crates/omegon/src/upstream_errors.rs
+++ b/core/crates/omegon/src/upstream_errors.rs
@@ -206,11 +206,11 @@ const GLOBAL_ERROR_RULES: &[ErrorRule] = &[
         providers: &[],
         class: UpstreamErrorClass::QuotaExceeded,
         substrings: &[
-            "quota",
             "insufficient credits",
             "insufficient quota",
-            "billing",
-            "usage limit",
+            "billing hard limit",
+            "billing quota",
+            "usage limit exceeded",
             "exceeded your current quota",
             "quota exceeded",
         ],
@@ -239,8 +239,8 @@ const GLOBAL_ERROR_RULES: &[ErrorRule] = &[
         substrings: &[
             "overloaded",
             "overloaded_error",
-            "capacity",
             "at capacity",
+            "model is at capacity",
             "server is busy",
             "high demand",
             "currently unavailable due to load",
@@ -336,7 +336,6 @@ const GLOBAL_ERROR_RULES: &[ErrorRule] = &[
             "invalid request",
             "bad request",
             "invalid_argument",
-            "not found",
             "model not found",
             "unprocessable entity",
             "validation error",
@@ -920,6 +919,22 @@ mod tests {
     }
 
     #[test]
+    fn generic_not_found_does_not_become_bad_request() {
+        assert_eq!(
+            classify_upstream_error("provider metadata file not found while handling stream"),
+            UpstreamErrorClass::Unknown,
+        );
+        assert_eq!(
+            classify_upstream_error("HTTP 404 model not found"),
+            UpstreamErrorClass::BadRequest,
+        );
+        assert_eq!(
+            classify_upstream_error("HTTP 404 model_not_found"),
+            UpstreamErrorClass::BadRequest,
+        );
+    }
+
+    #[test]
     fn provider_failure_matrix_rows_classify_as_documented() {
         let cases = [
             (
@@ -1086,6 +1101,26 @@ mod tests {
                 "provider={provider} message={message}",
             );
         }
+    }
+
+    #[test]
+    fn generic_quota_and_capacity_words_do_not_overclassify() {
+        assert_eq!(
+            classify_upstream_error("quota information endpoint returned metadata"),
+            UpstreamErrorClass::Unknown,
+        );
+        assert_eq!(
+            classify_upstream_error("provider capacity planning metadata refreshed"),
+            UpstreamErrorClass::Unknown,
+        );
+        assert_eq!(
+            classify_upstream_error("usage limit exceeded for project"),
+            UpstreamErrorClass::QuotaExceeded,
+        );
+        assert_eq!(
+            classify_upstream_error("selected model is at capacity"),
+            UpstreamErrorClass::ProviderOverloaded,
+        );
     }
 
     #[test]

--- a/docs/provider-failure-matrix.md
+++ b/docs/provider-failure-matrix.md
@@ -1,0 +1,51 @@
+# Provider Failure and Degradation Matrix
+
+This matrix records upstream error semantics that Omegon normalizes into `UpstreamErrorClass` before choosing retry, failover, reauth, context repair, or fatal stop behavior.
+
+## Sources checked
+
+Browser search was attempted through the transitional browser backend, but result extraction returned empty result sets while opening search pages. The first implementation slice therefore uses provider documentation/public API conventions already reflected in upstream SDK behavior and the current Omegon taxonomy, and it is structured so later source-cited updates can extend the table without changing the runtime contract.
+
+Primary upstream documentation targets for follow-up citation:
+
+- Anthropic API errors: `docs.anthropic.com/en/api/errors`
+- OpenAI API error codes: `platform.openai.com/docs/guides/error-codes`
+- Google Gemini troubleshooting / API errors: `ai.google.dev/gemini-api/docs/troubleshooting`
+- Groq API errors: `console.groq.com/docs/errors`
+- Mistral API docs and errors: `docs.mistral.ai`
+- OpenRouter error handling / credits: `openrouter.ai/docs`
+- xAI API docs: `docs.x.ai`
+- Cerebras Inference docs: `inference-docs.cerebras.ai`
+
+## Normalized classes
+
+| Upstream signal | Providers | Omegon class | Recovery |
+| --- | --- | --- | --- |
+| `400`, `invalid_request_error`, invalid argument, unsupported parameter | all | `BadRequest` | fatal until request builder is fixed |
+| `401`, invalid API key/token, expired token/session | all, especially OAuth-backed Codex/Anthropic | `AuthInvalid` / `SessionExpired` | reauthenticate |
+| `403`, forbidden, permission denied, missing scope, organization role | all | `AuthInvalid` | reauthenticate / operator credential fix |
+| `404`, model not found, unknown model | model APIs | `BadRequest` | fatal; registry/routing fix |
+| `408`, request timeout | all | `Timeout` | retry same provider |
+| `413`, request too large / context too long | Anthropic/OpenAI-compatible/Gemini | `ContextOverflow` | compact context |
+| `422`, unprocessable entity / validation error | OpenAI-compatible providers, Mistral | `BadRequest` | fatal until payload fixed |
+| `423`, locked / temporary resource contention | Groq-style APIs | `ProviderOverloaded` | failover preferred |
+| `424`, failed dependency | Groq-style APIs | `Upstream5xx` | retry same provider |
+| `429`, rate limit, resource exhausted, quota/rate cap | all | `RateLimited` unless quota/billing text is present | failover preferred |
+| quota exhausted, insufficient credits, billing inactive | all | `QuotaExceeded` | fatal/operator billing fix |
+| `498`, flex tier capacity/unavailable | Groq | `ProviderOverloaded` | failover preferred |
+| `499`, client closed request/cancelled | proxy/OpenAI-compatible | `ResponseCancelled` | retry same provider if not operator-cancelled |
+| `500`, `502`, `503`, `504`, `520`-`530`, overloaded, service unavailable | all | `Upstream5xx` or `ProviderOverloaded` | retry/failover depending class |
+| Anthropic `529` / `overloaded_error` | Anthropic | `ProviderOverloaded` | failover preferred |
+| Gemini `RESOURCE_EXHAUSTED` | Google | `RateLimited` or `QuotaExceeded` with billing/quota text | failover/fatal |
+| Gemini `FAILED_PRECONDITION` | Google | `AuthInvalid` / `BadRequest` depending message | reauth/fatal |
+| Responses API `response.incomplete` | Codex/OpenAI Responses | `ResponseIncomplete` | retry same provider |
+| Responses API `response.cancelled` | Codex/OpenAI Responses | `ResponseCancelled` | retry same provider |
+| SSE `error` with nested `{ error: { message, code, type } }` | Codex/OpenAI Responses | extracted detail then classified | class-specific |
+
+## Runtime invariants
+
+- Provider-specific parsing must preserve upstream status/code/type/message before reducing to an Omegon class.
+- Unknown upstream error payloads must not render as bare `unknown error`; include a stable fallback that says which provider emitted an unrecognized payload.
+- Retryable transport failures and provider degradation are separate from fatal request/auth errors.
+- `429` with billing/credits/quota-exhaustion language is quota exhaustion, not a transient rate limit.
+- OAuth subscription providers must prefer reauthentication guidance for expired/invalid sessions over generic provider failure prose.


### PR DESCRIPTION
## Summary

- add a provider failure/degradation matrix covering Anthropic, OpenAI/Codex, Gemini, Groq, Mistral, OpenRouter, xAI, Cerebras, and compatible providers
- improve Codex SSE error extraction so nested upstream payloads preserve message/code/type instead of collapsing to `unknown error`
- expand upstream error classification for provider overload, quota exhaustion, rate limits, context overflow, request-shape failures, response cancellation, and transient 5xx/proxy failures
- add false-positive guards for generic quota, capacity, and not-found prose

## Validation

- `cargo test -p omegon upstream_errors -- --nocapture`
- `cargo test -p omegon codex_error_detail -- --nocapture`
- `just upstream-provider-check`
- `cargo check -p omegon --bin omegon`
- `git diff --check`

## Notes

`just upstream-provider-check` still reports local registry-only Anthropic models (`claude-opus-4-7`, `claude-sonnet-4-7`), but there are no missing upstream models and the check exits cleanly.