### PR TITLE
feat(providers): add local DwarfStar launcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [Semantic V
 
 ### Added
 
+
 - Added guided CRUD affordances to `/variables` and `/secrets` structured menus, including variable update actions, common variable templates, recipe-specific secret rows, and per-secret clear/replace actions that never display secret values.
 - Added `/variables` and `/vars` as the MVP non-secret session configuration surface, with list/status, set, get, and delete/remove/rm command plumbing plus plain-value control readouts; secret-like names are flagged with `/secrets` guidance without blocking operator-defined variables.
 - Added design notes for the `/variables` non-secret runtime configuration surface, including second- and third-order effects around OCI deployment, process injection, trust boundaries, and project portability.
@@ -37,6 +38,8 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [Semantic V
 - Hardened `validate`'s built-in process execution to run validator programs directly with fixed argument vectors instead of shell interpolation.
 - Split the built-in `validate` tool checks into bounded Rust, TypeScript, and Python validator implementations behind a shared validator trait, preparing the surface for extension-backed validators.
 - Added Anthropic Claude Sonnet 5 to the model registry and promoted it as the Anthropic B-grade balanced route while keeping Claude Fable 5 as the S-grade/default route.
+- Added `scripts/setup-dwarfstar.sh` and `scripts/start-dwarfstar.sh`, opt-in happy-path helpers for cloning/building/downloading and launching a local DwarfStar/ds4 OpenAI-compatible server with RAM guard defaults and Omegon consumption hints.
+
 - Added an Actions tab to the shared `/memory` menu with recall/list/focus/release/compact rows; argument-taking actions prime the editor and memory compaction requires confirmation.
 - Added refreshable menu action close policies and menu-level action hotkeys so `/ui` toggles and lean/full shortcuts update the active menu in place.
 - Added typed menu action dispositions for run-command versus focus-row actions, and routed TUI menu dispatch through the typed action substrate while retaining compatibility helpers.

--- a/core/crates/omegon/src/providers.rs
+++ b/core/crates/omegon/src/providers.rs
@@ -311,6 +311,9 @@ pub fn infer_provider_id(model_spec: &str) -> String {
     if lower == "local" {
         return "ollama".to_string();
     }
+    if lower == "deepseek-local" {
+        return "dwarfstar".to_string();
+    }
     if lower.starts_with("claude") || matches!(lower.as_str(), "haiku" | "sonnet" | "opus") {
         return "anthropic".to_string();
     }
@@ -388,6 +391,9 @@ pub fn explicit_provider_id(model_spec: &str) -> Option<String> {
 
 fn model_id_from_spec(model_spec: &str) -> &str {
     let trimmed = model_spec.trim();
+    if trimmed.eq_ignore_ascii_case("deepseek-local") {
+        return "deepseek-v4-flash";
+    }
     if let Some((head, tail)) = trimmed.split_once(':')
         && is_known_provider_id(head)
     {
@@ -2839,7 +2845,9 @@ pub fn compat_base_url(provider_id: &str) -> Option<&'static str> {
         "google-antigravity" => Some("https://generativelanguage.googleapis.com/v1beta/openai"),
         "huggingface" => Some("https://router.huggingface.co"),
         "ollama" => Some("http://localhost:11434"),
-        "dwarfstar" => Some("http://127.0.0.1:8000/v1"),
+        // OpenAIClient appends the /v1 chat-completions path itself; keep the
+        // DwarfStar base at the server root to avoid double-/v1 endpoints.
+        "dwarfstar" => Some("http://127.0.0.1:8000"),
         _ => None,
     }
 }
@@ -4101,6 +4109,7 @@ mod tests {
         assert_eq!(infer_provider_id("qwen3:30b"), "ollama");
         assert_eq!(infer_provider_id("local:qwen3:30b"), "ollama");
         assert_eq!(infer_provider_id("local"), "ollama");
+        assert_eq!(infer_provider_id("deepseek-local"), "dwarfstar");
         assert_eq!(
             infer_provider_id("ollama-cloud:gpt-oss:120b-cloud"),
             "ollama-cloud"
@@ -5461,6 +5470,11 @@ mod tests {
             "gpt-5.4-mini"
         );
         assert_eq!(model_id_from_spec("ollama:qwen3:32b"), "qwen3:32b");
+        assert_eq!(
+            model_id_from_spec("dwarfstar:deepseek-v4-flash"),
+            "deepseek-v4-flash"
+        );
+        assert_eq!(model_id_from_spec("deepseek-local"), "deepseek-v4-flash");
 
         // Bare model IDs (no known provider prefix) — returned as-is
         assert_eq!(model_id_from_spec("claude-sonnet-4-6"), "claude-sonnet-4-6");

--- a/scripts/setup-dwarfstar.sh
+++ b/scripts/setup-dwarfstar.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# One-command happy-path setup for Omegon's experimental local DwarfStar/ds4
+# provider. This intentionally does not vendor ds4 or model weights into Omegon;
+# it clones/builds/downloads under DS4_ROOT and prints the single run command.
+
+ROOT="${DS4_ROOT:-$HOME/models/ds4}"
+REPO_URL="${DS4_REPO_URL:-https://github.com/antirez/ds4.git}"
+REF="${DS4_REF:-main}"
+QUANT="${DS4_QUANT:-q2-imatrix}"
+MIN_RAM_GB="${OMEGON_DWARFSTAR_MIN_RAM_GB:-96}"
+SKIP_DOWNLOAD="${DS4_SKIP_DOWNLOAD:-0}"
+START_SCRIPT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/start-dwarfstar.sh"
+
+fail() {
+  echo "setup-dwarfstar: $*" >&2
+  exit 1
+}
+
+need_cmd() {
+  command -v "$1" >/dev/null 2>&1 || fail "required command not found: $1"
+}
+
+ram_bytes() {
+  if command -v sysctl >/dev/null 2>&1; then
+    sysctl -n hw.memsize 2>/dev/null || true
+    return
+  fi
+  if [ -r /proc/meminfo ]; then
+    awk '/^MemTotal:/ {print $2 * 1024}' /proc/meminfo
+  fi
+}
+
+mem_bytes="$(ram_bytes)"
+if [ -z "$mem_bytes" ]; then
+  fail "could not detect host RAM; set OMEGON_DWARFSTAR_MIN_RAM_GB=0 to bypass the guard explicitly"
+fi
+mem_gb="$((mem_bytes / 1024 / 1024 / 1024))"
+if [ "$mem_gb" -lt "$MIN_RAM_GB" ]; then
+  fail "requires at least ${MIN_RAM_GB}GiB RAM for this experimental local provider; detected ${mem_gb}GiB"
+fi
+
+need_cmd git
+need_cmd make
+need_cmd curl
+
+mkdir -p "$(dirname "$ROOT")"
+
+if [ ! -d "$ROOT/.git" ]; then
+  git clone "$REPO_URL" "$ROOT"
+fi
+
+cd "$ROOT"
+git fetch --tags origin
+if [ "$REF" = "main" ]; then
+  git checkout main
+  git pull --ff-only origin main
+else
+  git checkout "$REF"
+fi
+
+make
+
+if [ "$SKIP_DOWNLOAD" != "1" ]; then
+  [ -x ./download_model.sh ] || fail "download_model.sh not found or not executable in $ROOT"
+  ./download_model.sh "$QUANT"
+else
+  echo "Skipping model download because DS4_SKIP_DOWNLOAD=1"
+fi
+
+[ -x ./ds4-server ] || fail "build did not produce executable ds4-server"
+[ -f ./ds4flash.gguf ] || fail "model symlink/file ds4flash.gguf was not found after setup"
+
+cat <<EOF
+DwarfStar setup complete.
+
+Start server:
+  DS4_CTX=100000 DS4_TOKENS=1024 "$START_SCRIPT"
+
+Use from Omegon:
+  om -m deepseek-local
+
+Installed at:
+  $ROOT
+EOF

--- a/scripts/start-dwarfstar.sh
+++ b/scripts/start-dwarfstar.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Happy-path launcher for a local DwarfStar/ds4 OpenAI-compatible server.
+# After this is running, Omegon can consume it with: om -m deepseek-local
+
+ROOT="${DS4_ROOT:-$HOME/models/ds4}"
+HOST="${DS4_HOST:-127.0.0.1}"
+PORT="${DS4_PORT:-8000}"
+CTX="${DS4_CTX:-32768}"
+TOKENS="${DS4_TOKENS:-1024}"
+KV_DIR="${DS4_KV_DIR:-/tmp/ds4-kv}"
+KV_MB="${DS4_KV_MB:-8192}"
+MODEL="${DS4_MODEL:-$ROOT/ds4flash.gguf}"
+MIN_RAM_GB="${OMEGON_DWARFSTAR_MIN_RAM_GB:-96}"
+
+fail() {
+  echo "start-dwarfstar: $*" >&2
+  exit 1
+}
+
+if command -v sysctl >/dev/null 2>&1; then
+  mem_bytes="$(sysctl -n hw.memsize 2>/dev/null || true)"
+else
+  mem_bytes=""
+fi
+
+if [ -z "$mem_bytes" ] && [ -r /proc/meminfo ]; then
+  mem_kb="$(awk '/^MemTotal:/ {print $2}' /proc/meminfo)"
+  mem_bytes="$((mem_kb * 1024))"
+fi
+
+if [ -z "$mem_bytes" ]; then
+  fail "could not detect host RAM; set OMEGON_DWARFSTAR_MIN_RAM_GB=0 to bypass the guard explicitly"
+fi
+
+mem_gb="$((mem_bytes / 1024 / 1024 / 1024))"
+if [ "$mem_gb" -lt "$MIN_RAM_GB" ]; then
+  fail "requires at least ${MIN_RAM_GB}GiB RAM for this experimental local provider; detected ${mem_gb}GiB"
+fi
+
+[ -d "$ROOT" ] || fail "ds4 root not found: $ROOT"
+[ -x "$ROOT/ds4-server" ] || fail "ds4-server not executable: $ROOT/ds4-server"
+[ -f "$MODEL" ] || fail "model file not found: $MODEL"
+
+mkdir -p "$KV_DIR"
+
+if curl -fsS "http://${HOST}:${PORT}/v1/models" >/dev/null 2>&1; then
+  echo "DwarfStar already reachable at http://${HOST}:${PORT}/v1"
+  echo "Use: om -m deepseek-local"
+  exit 0
+fi
+
+cat >&2 <<EOF
+Starting DwarfStar/ds4 server:
+  root:   $ROOT
+  model:  $MODEL
+  url:    http://${HOST}:${PORT}/v1
+  ctx:    $CTX
+  tokens: $TOKENS
+  kv:     $KV_DIR (${KV_MB}MiB)
+
+Consume from Omegon with:
+  om -m deepseek-local
+EOF
+
+cd "$ROOT"
+exec "$ROOT/ds4-server" \
+  --host "$HOST" \
+  --port "$PORT" \
+  --model "$MODEL" \
+  --ctx "$CTX" \
+  --tokens "$TOKENS" \
+  --kv-disk-dir "$KV_DIR" \
+  --kv-disk-space-mb "$KV_MB"


### PR DESCRIPTION
## Summary
- add `deepseek-local` as a DwarfStar-backed local provider alias
- wire DwarfStar as an OpenAI-compatible local endpoint with server-root default URL
- add opt-in setup/start helper scripts with RAM guard defaults instead of vendoring DS4 or model weights

## Validation
- `bash -n scripts/setup-dwarfstar.sh scripts/start-dwarfstar.sh`
- `git diff --check origin/main...HEAD -- CHANGELOG.md core/crates/omegon/src/providers.rs scripts/setup-dwarfstar.sh scripts/start-dwarfstar.sh`
- `cargo test -p omegon providers::tests -- --nocapture`
- live smoke against local DS4: `OMEGON_DWARFSTAR_ENABLE=1 OMEGON_DWARFSTAR_BASE_URL=http://127.0.0.1:8000 target/debug/omegon --log-level error -m deepseek-local --no-session --fresh --max-turns 1 -p "Return exactly: main rebase dwarfstar ok"` → `main rebase dwarfstar ok`

## Notes
This is intentionally a happy-path experimental slice. It does not auto-start DwarfStar, does not touch menu/slash-surface work, and does not package DS4 or GGUF weights into Omegon.