### PR TITLE
feat: observation-driven harness guidance (task modes, unified observations, evidence ledger)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [Semantic V
 - Added additive conceptual model IDs to the model registry so multiple provider routes can map to the same semantic model class ahead of first-class GitHub Copilot routing.
 
 ### Fixed
+- Routed StuckDetector file/churn tracking through normalized observation events so bash/view/search evidence shares the same validation and mutation reset semantics as structured tool calls.
 - Gated live OpenAI-compatible provider endpoint probes behind `OMEGON_LIVE_ENDPOINT_PROBES=1` so default test runs do not fail or stall on external network availability.
 - Serialized current-directory-mutating tests on a shared CWD test lock so the default parallel `cargo test -p omegon` run no longer observes deleted temporary working directories.
 - Coalesced duplicate tool results after provider-compatible ID sanitization so wrapper-tool rollback/no-op paths cannot poison Anthropic history with multiple `tool_result` blocks.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [Semantic V
 - Added additive conceptual model IDs to the model registry so multiple provider routes can map to the same semantic model class ahead of first-class GitHub Copilot routing.
 
 ### Fixed
+- Coalesced duplicate tool results after provider-compatible ID sanitization so wrapper-tool rollback/no-op paths cannot poison Anthropic history with multiple `tool_result` blocks.
 - Routed GitHub Copilot `gpt-5.5` through Copilot's `/responses` endpoint instead of the unsupported `/chat/completions` path and made Copilot runtime errors name the failing endpoint.
 - Prevented GitHub Copilot routes with an empty effective model from sending blank `model` values to the Copilot API and reject explicit empty model switches such as `github-copilot:`.
 - Added `github-copilot` to `/auth` command suggestions so Copilot login is discoverable from the TUI command picker.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [Semantic V
 - Added first-class operator copy blocks for auth/device-code flows, including best-effort host clipboard copy for GitHub Copilot device codes and exact copy/export payloads in conversation surfaces.
 
 ### Added
+- Added an A3 evidence ledger for harness guidance so discovery novelty and low-novelty revisits, not scalar file counts alone, drive evidence convergence pressure.
 - Added a guidance task-mode channel (implementation vs research) inferred from the operator prompt, with explicit `/mode ...` / `[mode: ...]` markers, so research/Q&A sessions relax execution and orientation-churn pressure while failure-driven pressure stays active.
 - Added a unified observation normalizer for harness guidance so capability-catalog tools and conservative bash read/search/validation/commit/minimal-mutation commands feed intent evidence consistently.
 - Made git guidance and validation recommendations document-aware so Markdown-only human documents/knowledge notes are not framed as code changes.
@@ -33,6 +34,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [Semantic V
 - Added additive conceptual model IDs to the model registry so multiple provider routes can map to the same semantic model class ahead of first-class GitHub Copilot routing.
 
 ### Fixed
+- Replaced the `files_read <= 2` actionability shortcut with novelty-decay-based local evidence sufficiency, preventing first targeted reads from forcing premature convergence.
 - Suppressed anti-orientation drift and read-only evidence convergence in research mode unless validation or mutation evidence makes the target actionable.
 - Required matching successful tool results before normalized observations create positive guidance evidence, so orphaned/missing tool results no longer look like successful reads or mutations.
 - Routed StuckDetector file/churn tracking through normalized observation events so bash/view/search evidence shares the same validation and mutation reset semantics as structured tool calls.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [Semantic V
 - Added additive conceptual model IDs to the model registry so multiple provider routes can map to the same semantic model class ahead of first-class GitHub Copilot routing.
 
 ### Fixed
+- Gated live OpenAI-compatible provider endpoint probes behind `OMEGON_LIVE_ENDPOINT_PROBES=1` so default test runs do not fail or stall on external network availability.
+- Serialized current-directory-mutating tests on a shared CWD test lock so the default parallel `cargo test -p omegon` run no longer observes deleted temporary working directories.
 - Coalesced duplicate tool results after provider-compatible ID sanitization so wrapper-tool rollback/no-op paths cannot poison Anthropic history with multiple `tool_result` blocks.
 - Routed GitHub Copilot `gpt-5.5` through Copilot's `/responses` endpoint instead of the unsupported `/chat/completions` path and made Copilot runtime errors name the failing endpoint.
 - Prevented GitHub Copilot routes with an empty effective model from sending blank `model` values to the Copilot API and reject explicit empty model switches such as `github-copilot:`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [Semantic V
 - Added first-class operator copy blocks for auth/device-code flows, including best-effort host clipboard copy for GitHub Copilot device codes and exact copy/export payloads in conversation surfaces.
 
 ### Added
+- Added a unified observation normalizer for harness guidance so capability-catalog tools and conservative bash read/search/validation/commit commands feed intent evidence consistently.
 - Made git guidance and validation recommendations document-aware so Markdown-only human documents/knowledge notes are not framed as code changes.
 - Added a redacted GitHub Copilot tools contract probe that verifies OpenAI-style `tools`, returned `tool_calls`, and tool-result continuation against the live Copilot endpoint.
 - Added GitHub Copilot device OAuth login plus a redacted inventory probe that verifies Copilot token exchange and `/models` access using VS Code-compatible integration headers.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,8 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [Semantic V
 - Added first-class operator copy blocks for auth/device-code flows, including best-effort host clipboard copy for GitHub Copilot device codes and exact copy/export payloads in conversation surfaces.
 
 ### Added
-- Added a guidance task-mode channel (implementation vs research) inferred from the operator prompt, so research/Q&A sessions relax execution and orientation-churn pressure while failure-driven pressure stays active.
-- Added a unified observation normalizer for harness guidance so capability-catalog tools and conservative bash read/search/validation/commit commands feed intent evidence consistently.
+- Added a guidance task-mode channel (implementation vs research) inferred from the operator prompt, with explicit `/mode ...` / `[mode: ...]` markers, so research/Q&A sessions relax execution and orientation-churn pressure while failure-driven pressure stays active.
+- Added a unified observation normalizer for harness guidance so capability-catalog tools and conservative bash read/search/validation/commit/minimal-mutation commands feed intent evidence consistently.
 - Made git guidance and validation recommendations document-aware so Markdown-only human documents/knowledge notes are not framed as code changes.
 - Added a redacted GitHub Copilot tools contract probe that verifies OpenAI-style `tools`, returned `tool_calls`, and tool-result continuation against the live Copilot endpoint.
 - Added GitHub Copilot device OAuth login plus a redacted inventory probe that verifies Copilot token exchange and `/models` access using VS Code-compatible integration headers.
@@ -33,6 +33,8 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [Semantic V
 - Added additive conceptual model IDs to the model registry so multiple provider routes can map to the same semantic model class ahead of first-class GitHub Copilot routing.
 
 ### Fixed
+- Suppressed anti-orientation drift and read-only evidence convergence in research mode unless validation or mutation evidence makes the target actionable.
+- Required matching successful tool results before normalized observations create positive guidance evidence, so orphaned/missing tool results no longer look like successful reads or mutations.
 - Routed StuckDetector file/churn tracking through normalized observation events so bash/view/search evidence shares the same validation and mutation reset semantics as structured tool calls.
 - Gated live OpenAI-compatible provider endpoint probes behind `OMEGON_LIVE_ENDPOINT_PROBES=1` so default test runs do not fail or stall on external network availability.
 - Serialized current-directory-mutating tests on a shared CWD test lock so the default parallel `cargo test -p omegon` run no longer observes deleted temporary working directories.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [Semantic V
 - Added first-class operator copy blocks for auth/device-code flows, including best-effort host clipboard copy for GitHub Copilot device codes and exact copy/export payloads in conversation surfaces.
 
 ### Added
+- Added a guidance task-mode channel (implementation vs research) inferred from the operator prompt, so research/Q&A sessions relax execution and orientation-churn pressure while failure-driven pressure stays active.
 - Added a unified observation normalizer for harness guidance so capability-catalog tools and conservative bash read/search/validation/commit commands feed intent evidence consistently.
 - Made git guidance and validation recommendations document-aware so Markdown-only human documents/knowledge notes are not framed as code changes.
 - Added a redacted GitHub Copilot tools contract probe that verifies OpenAI-style `tools`, returned `tool_calls`, and tool-result continuation against the live Copilot endpoint.

--- a/core/crates/omegon/src/acp.rs
+++ b/core/crates/omegon/src/acp.rs
@@ -5191,26 +5191,21 @@ auto_disabled = true
 
     #[tokio::test]
     async fn assistant_runs_list_reports_empty_runtime_projection() {
-        let _guard = crate::GLOBAL_TEST_ENV_LOCK.lock().await;
-        let cwd = std::env::current_dir().unwrap();
         let home = tempfile::tempdir().unwrap();
-        std::env::set_current_dir(home.path()).unwrap();
+        let _cwd = crate::test_support::cwd::CurrentDirGuard::enter_async(home.path()).await;
         let agent = Rc::new(OmegonAcpAgent::new("test-model"));
         let response =
             handle_acp_request_result(agent, "_assistant_runs/list", &serde_json::json!({}))
                 .await
                 .unwrap();
-        std::env::set_current_dir(cwd).unwrap();
 
         assert!(response["runs"].as_array().unwrap().is_empty());
     }
 
     #[tokio::test]
     async fn assistant_runs_show_reports_missing_runtime_run() {
-        let _guard = crate::GLOBAL_TEST_ENV_LOCK.lock().await;
-        let cwd = std::env::current_dir().unwrap();
         let home = tempfile::tempdir().unwrap();
-        std::env::set_current_dir(home.path()).unwrap();
+        let _cwd = crate::test_support::cwd::CurrentDirGuard::enter_async(home.path()).await;
         let agent = Rc::new(OmegonAcpAgent::new("test-model"));
         let response = handle_acp_request_result(
             agent,
@@ -5219,7 +5214,6 @@ auto_disabled = true
         )
         .await
         .unwrap();
-        std::env::set_current_dir(cwd).unwrap();
 
         assert_eq!(response["error"], "assistant_run_not_found");
     }

--- a/core/crates/omegon/src/auth.rs
+++ b/core/crates/omegon/src/auth.rs
@@ -1492,8 +1492,12 @@ fn parse_callback_url(url: &str) -> anyhow::Result<(String, String)> {
 pub type LoginProgress = Box<dyn Fn(&str) + Send + Sync>;
 
 pub type LoginCopyBlock = Box<
-    dyn Fn(String, String, omegon_traits::OperatorCopyKind, Option<omegon_traits::ClipboardCopyStatus>)
-        + Send
+    dyn Fn(
+            String,
+            String,
+            omegon_traits::OperatorCopyKind,
+            Option<omegon_traits::ClipboardCopyStatus>,
+        ) + Send
         + Sync,
 >;
 
@@ -2811,8 +2815,8 @@ mod tests {
             "should probe chatgpt/codex"
         );
         assert!(
-            status.providers.iter().any(|p| p.name == "ollama-cloud"),
-            "should probe ollama cloud"
+            !status.providers.iter().any(|p| p.name == "ollama-cloud"),
+            "operator auth status should not include obsolete hardcoded ollama-cloud rows"
         );
     }
 

--- a/core/crates/omegon/src/behavior.rs
+++ b/core/crates/omegon/src/behavior.rs
@@ -785,7 +785,10 @@ pub(crate) fn assess_evidence(
                 .iter()
                 .any(|read| read == std::path::Path::new(path))
         });
-    let local_target_count = conversation.intent.files_read.len();
+    let low_novelty_revisit_streak = conversation
+        .intent
+        .evidence_ledger
+        .low_novelty_revisit_streak();
     let global = if targeted_validation
         || failed_mutation_on_known_target
         || inspection_backed_by_validation_failure
@@ -807,9 +810,9 @@ pub(crate) fn assess_evidence(
         };
     }
 
-    let local = if targeted_paths_known && local_target_count <= 2 {
+    let local = if targeted_paths_known && low_novelty_revisit_streak >= 2 {
         EvidenceSufficiency::Actionable
-    } else if targeted_paths_known || local_target_count <= 2 {
+    } else if targeted_paths_known || !conversation.intent.files_read.is_empty() {
         EvidenceSufficiency::Targeted
     } else {
         EvidenceSufficiency::None
@@ -1124,6 +1127,78 @@ mod tests {
                 "prompt should infer Implementation: {prompt}"
             );
         }
+    }
+
+    #[test]
+    fn first_targeted_read_is_targeted_not_actionable() {
+        let catalog = ToolCapabilityCatalog::from_tool_defs(&[omegon_traits::ToolDefinition {
+            name: "read".into(),
+            label: String::new(),
+            description: String::new(),
+            parameters: serde_json::json!({}),
+            capabilities: vec![omegon_traits::ToolCapability::RepoInspection],
+        }]);
+        let mut conversation = ConversationState::new();
+        conversation
+            .intent
+            .files_read
+            .insert("core/crates/omegon/src/behavior.rs".into());
+        let call = ToolCall {
+            id: "1".into(),
+            name: "read".into(),
+            arguments: serde_json::json!({"path": "core/crates/omegon/src/behavior.rs"}),
+        };
+        let evidence = assess_evidence(&conversation, &catalog, &[call], &[]);
+        assert_eq!(evidence.local, EvidenceSufficiency::Targeted);
+        assert_eq!(evidence.global, EvidenceSufficiency::None);
+    }
+
+    #[test]
+    fn repeated_low_novelty_revisits_make_known_target_actionable() {
+        let catalog = ToolCapabilityCatalog::from_tool_defs(&[omegon_traits::ToolDefinition {
+            name: "read".into(),
+            label: String::new(),
+            description: String::new(),
+            parameters: serde_json::json!({}),
+            capabilities: vec![
+                omegon_traits::ToolCapability::RepoInspection,
+                omegon_traits::ToolCapability::TargetedRepoInspection,
+            ],
+        }]);
+        let mut conversation = ConversationState::new();
+        conversation
+            .intent
+            .files_read
+            .insert("core/crates/omegon/src/behavior.rs".into());
+        conversation
+            .intent
+            .evidence_ledger
+            .turns
+            .push(crate::conversation::EvidenceTurn {
+                observations: 1,
+                novel_paths: 0,
+                revisits: 1,
+                searches: 0,
+                mutation_or_validation: false,
+            });
+        conversation
+            .intent
+            .evidence_ledger
+            .turns
+            .push(crate::conversation::EvidenceTurn {
+                observations: 1,
+                novel_paths: 0,
+                revisits: 1,
+                searches: 0,
+                mutation_or_validation: false,
+            });
+        let call = ToolCall {
+            id: "1".into(),
+            name: "read".into(),
+            arguments: serde_json::json!({"path": "core/crates/omegon/src/behavior.rs"}),
+        };
+        let evidence = assess_evidence(&conversation, &catalog, &[call], &[]);
+        assert_eq!(evidence.local, EvidenceSufficiency::Actionable);
     }
 
     #[test]

--- a/core/crates/omegon/src/behavior.rs
+++ b/core/crates/omegon/src/behavior.rs
@@ -20,7 +20,22 @@ use std::collections::{BTreeSet, HashMap};
 /// errs strongly toward `Research`: a false `Implementation` classification
 /// pushes the model to invent file-writing work the user never requested,
 /// which is the worse failure mode.
+pub(crate) fn explicit_task_mode_from_prompt(prompt: &str) -> Option<TaskMode> {
+    let normalized = prompt.trim_start().to_lowercase();
+    let first_line = normalized.lines().next().unwrap_or("").trim();
+    match first_line {
+        "/mode research" | "/mode: research" | "[mode: research]" => Some(TaskMode::Research),
+        "/mode implementation" | "/mode: implementation" | "[mode: implementation]" => {
+            Some(TaskMode::Implementation)
+        }
+        _ => None,
+    }
+}
+
 pub(crate) fn infer_task_mode_from_prompt(prompt: &str) -> TaskMode {
+    if let Some(mode) = explicit_task_mode_from_prompt(prompt) {
+        return mode;
+    }
     let prompt = prompt.to_lowercase();
     let starts = |w: &str| prompt.trim_start().starts_with(w);
     let research = prompt.contains('?')
@@ -265,7 +280,10 @@ pub(crate) fn classify_drift_kind(
         .filter(|call| is_targeted_repo_inspection_tool(catalog, &call.name))
         .count();
 
-    if conversation.intent.files_modified.is_empty()
+    let research_mode = conversation.intent.task_mode == TaskMode::Research;
+
+    if !research_mode
+        && conversation.intent.files_modified.is_empty()
         && !conversation.intent.files_read.is_empty()
         && tool_calls
             .iter()
@@ -277,7 +295,8 @@ pub(crate) fn classify_drift_kind(
         return Some(DriftKind::OrientationChurn);
     }
 
-    if conversation.intent.files_modified.is_empty()
+    if !research_mode
+        && conversation.intent.files_modified.is_empty()
         && conversation.intent.files_read.is_empty()
         && turn >= 3
         && broad_orientation_calls == tool_calls.len()
@@ -767,18 +786,31 @@ pub(crate) fn assess_evidence(
                 .any(|read| read == std::path::Path::new(path))
         });
     let local_target_count = conversation.intent.files_read.len();
-    let local = if targeted_paths_known && local_target_count <= 2 {
-        EvidenceSufficiency::Actionable
-    } else if targeted_paths_known || local_target_count <= 2 {
-        EvidenceSufficiency::Targeted
-    } else {
-        EvidenceSufficiency::None
-    };
     let global = if targeted_validation
         || failed_mutation_on_known_target
         || inspection_backed_by_validation_failure
     {
         EvidenceSufficiency::Actionable
+    } else {
+        EvidenceSufficiency::None
+    };
+    if conversation.intent.task_mode == TaskMode::Research
+        && global != EvidenceSufficiency::Actionable
+    {
+        return EvidenceAssessment {
+            local: if targeted_paths_known {
+                EvidenceSufficiency::Targeted
+            } else {
+                EvidenceSufficiency::None
+            },
+            global,
+        };
+    }
+
+    let local = if targeted_paths_known && local_target_count <= 2 {
+        EvidenceSufficiency::Actionable
+    } else if targeted_paths_known || local_target_count <= 2 {
+        EvidenceSufficiency::Targeted
     } else {
         EvidenceSufficiency::None
     };
@@ -1092,6 +1124,51 @@ mod tests {
                 "prompt should infer Implementation: {prompt}"
             );
         }
+    }
+
+    #[test]
+    fn explicit_task_mode_marker_is_recognized() {
+        assert_eq!(
+            explicit_task_mode_from_prompt("/mode research\nreview the loop"),
+            Some(TaskMode::Research)
+        );
+        assert_eq!(
+            infer_task_mode_from_prompt("[mode: implementation]\nwhat file should change?"),
+            TaskMode::Implementation
+        );
+    }
+
+    #[test]
+    fn research_mode_suppresses_orientation_churn_drift() {
+        let catalog = ToolCapabilityCatalog::from_tool_defs(&[omegon_traits::ToolDefinition {
+            name: "codebase_search".into(),
+            label: String::new(),
+            description: String::new(),
+            parameters: serde_json::json!({}),
+            capabilities: vec![
+                omegon_traits::ToolCapability::RepoInspection,
+                omegon_traits::ToolCapability::BroadRepoInspection,
+            ],
+        }]);
+        let call = ToolCall {
+            id: "1".into(),
+            name: "codebase_search".into(),
+            arguments: serde_json::json!({"query": "loop"}),
+        };
+        let mut conversation = ConversationState::new();
+        conversation
+            .intent
+            .files_read
+            .insert("core/crates/omegon/src/loop.rs".into());
+        assert_eq!(
+            classify_drift_kind(&catalog, 4, &conversation, std::slice::from_ref(&call), &[]),
+            Some(DriftKind::OrientationChurn)
+        );
+        conversation.intent.pin_task_mode(TaskMode::Research);
+        assert_eq!(
+            classify_drift_kind(&catalog, 4, &conversation, &[call], &[]),
+            None
+        );
     }
 
     #[test]

--- a/core/crates/omegon/src/behavior.rs
+++ b/core/crates/omegon/src/behavior.rs
@@ -1130,6 +1130,50 @@ mod tests {
     }
 
     #[test]
+    fn repeated_observation_flow_makes_target_actionable_after_revisits() {
+        let catalog = ToolCapabilityCatalog::from_tool_defs(&[omegon_traits::ToolDefinition {
+            name: "read".into(),
+            label: String::new(),
+            description: String::new(),
+            parameters: serde_json::json!({}),
+            capabilities: vec![
+                omegon_traits::ToolCapability::RepoInspection,
+                omegon_traits::ToolCapability::TargetedRepoInspection,
+            ],
+        }]);
+        let mut conversation = ConversationState::new();
+        let call = ToolCall {
+            id: "1".into(),
+            name: "read".into(),
+            arguments: serde_json::json!({"path": "core/crates/omegon/src/behavior.rs"}),
+        };
+        let result = ToolResultEntry {
+            call_id: "1".into(),
+            tool_name: "read".into(),
+            content: vec![],
+            is_error: false,
+            args_summary: None,
+        };
+        conversation.intent.update_from_tools(
+            &catalog,
+            std::slice::from_ref(&call),
+            std::slice::from_ref(&result),
+        );
+        conversation.intent.update_from_tools(
+            &catalog,
+            std::slice::from_ref(&call),
+            std::slice::from_ref(&result),
+        );
+        conversation.intent.update_from_tools(
+            &catalog,
+            std::slice::from_ref(&call),
+            std::slice::from_ref(&result),
+        );
+        let evidence = assess_evidence(&conversation, &catalog, &[call], &[result]);
+        assert_eq!(evidence.local, EvidenceSufficiency::Actionable);
+    }
+
+    #[test]
     fn first_targeted_read_is_targeted_not_actionable() {
         let catalog = ToolCapabilityCatalog::from_tool_defs(&[omegon_traits::ToolDefinition {
             name: "read".into(),
@@ -1179,6 +1223,7 @@ mod tests {
                 novel_paths: 0,
                 revisits: 1,
                 searches: 0,
+                search_roots: Vec::new(),
                 mutation_or_validation: false,
             });
         conversation
@@ -1190,6 +1235,7 @@ mod tests {
                 novel_paths: 0,
                 revisits: 1,
                 searches: 0,
+                search_roots: Vec::new(),
                 mutation_or_validation: false,
             });
         let call = ToolCall {

--- a/core/crates/omegon/src/behavior.rs
+++ b/core/crates/omegon/src/behavior.rs
@@ -5,10 +5,72 @@
 //! `ControllerState` streak tracker. Extracted from `loop.rs` to keep
 //! the core state machine focused on turn orchestration.
 
-use crate::conversation::{ConversationState, ToolCall, ToolResultEntry};
+use crate::conversation::{ConversationState, TaskMode, ToolCall, ToolResultEntry};
 pub(crate) use omegon_traits::ProgressSignal;
 use omegon_traits::{DriftKind, OodaPhase, ProgressNudgeReason, ToolCapability, ToolDefinition};
 use std::collections::{BTreeSet, HashMap};
+
+// ─── Task-mode inference ────────────────────────────────────────────────────
+
+/// Infer the guidance task mode from the operator's prompt.
+///
+/// Research-style prompts (questions, explain/summarize/review requests, any
+/// read-oriented ask) legitimately spend many turns in read/search without
+/// mutating files, so convergence pressure must relax for them. The heuristic
+/// errs strongly toward `Research`: a false `Implementation` classification
+/// pushes the model to invent file-writing work the user never requested,
+/// which is the worse failure mode.
+pub(crate) fn infer_task_mode_from_prompt(prompt: &str) -> TaskMode {
+    let prompt = prompt.to_lowercase();
+    let starts = |w: &str| prompt.trim_start().starts_with(w);
+    let research = prompt.contains('?')
+        || starts("explain")
+        || starts("what")
+        || starts("why")
+        || starts("how")
+        || starts("when")
+        || starts("where")
+        || starts("which")
+        || starts("who")
+        || starts("describe")
+        || starts("summarize")
+        || starts("summary")
+        || starts("rundown")
+        || starts("overview")
+        || starts("review")
+        || starts("assess")
+        || starts("analyze")
+        || starts("compare")
+        || starts("contrast")
+        || starts("outline")
+        || starts("discuss")
+        || starts("tell me")
+        || starts("show me")
+        || starts("give me")
+        || starts("list")
+        || starts("can you")
+        || starts("could you")
+        || starts("do you")
+        || starts("is ")
+        || starts("are ")
+        || starts("does")
+        || starts("did")
+        || starts("read")
+        || starts("look")
+        || starts("check")
+        || starts("find")
+        || starts("search")
+        || starts("investigate")
+        || starts("research")
+        || prompt.contains(" rundown")
+        || prompt.contains(" summary")
+        || prompt.contains(" overview");
+    if research {
+        TaskMode::Research
+    } else {
+        TaskMode::Implementation
+    }
+}
 
 // ─── Tool classification predicates ────────────────────────────────────────
 
@@ -314,6 +376,11 @@ pub(crate) fn should_inject_execution_pressure(
     tool_calls: &[ToolCall],
     behavior: BehavioralTier,
 ) -> bool {
+    // Research turns legitimately read/search without mutating files; do not
+    // pressure them toward edits they were never asked to make.
+    if conversation.intent.task_mode == TaskMode::Research {
+        return false;
+    }
     if tool_calls.is_empty()
         || !conversation.intent.files_modified.is_empty()
         || conversation.intent.files_read.is_empty()
@@ -749,11 +816,21 @@ pub(crate) fn continuation_pressure_tier(
 
     let local_evidence_sufficient = controller.local_evidence_sufficient_streak > 0;
     let evidence_sufficient = controller.evidence_sufficient_streak > 0;
-    let om_local_first_lock = is_slim_execution_bias(config)
+    let research_mode = conversation.intent.task_mode == TaskMode::Research;
+    let om_local_first_lock = !research_mode
+        && is_slim_execution_bias(config)
         && local_evidence_sufficient
         && has_local_target_hypothesis(conversation);
     let constrained = behavior == BehavioralTier::Constrained;
-    let (tier1, tier2, tier3) = if om_local_first_lock {
+    let (tier1, tier2, tier3) = if research_mode {
+        // Research turns legitimately spend many turns in read/search.
+        // Keep only a late safety net against genuinely unbounded exploration.
+        if constrained {
+            (8, 12, 16)
+        } else {
+            (16, 24, 32)
+        }
+    } else if om_local_first_lock {
         if constrained { (2, 3, 5) } else { (4, 6, 8) }
     } else if evidence_sufficient {
         if constrained { (3, 4, 6) } else { (6, 8, 10) }
@@ -779,7 +856,7 @@ pub(crate) fn continuation_pressure_tier(
         return Some(3);
     }
 
-    if discoveries >= 2 {
+    if discoveries >= 2 && !research_mode {
         return Some(2);
     }
 
@@ -978,6 +1055,59 @@ mod tests {
                 assert_recovery_directive(&message);
             }
         }
+    }
+
+    #[test]
+    fn task_mode_inference_classifies_research_prompts() {
+        for prompt in [
+            "what does the observation layer do?",
+            "Explain the OODA loop wiring",
+            "summarize the recent changes",
+            "give me a rundown of loop.rs",
+            "review the pressure heuristics",
+            "How does compaction work",
+            "investigate the flaky test",
+            "can you check whether the tests pass",
+        ] {
+            assert_eq!(
+                infer_task_mode_from_prompt(prompt),
+                TaskMode::Research,
+                "prompt should infer Research: {prompt}"
+            );
+        }
+    }
+
+    #[test]
+    fn task_mode_inference_classifies_implementation_prompts() {
+        for prompt in [
+            "fix the bug in conversation.rs",
+            "implement the observation normalizer",
+            "add a regression test for orphaned tool results",
+            "refactor the pressure tiers into policy rows",
+            "commit the changes",
+        ] {
+            assert_eq!(
+                infer_task_mode_from_prompt(prompt),
+                TaskMode::Implementation,
+                "prompt should infer Implementation: {prompt}"
+            );
+        }
+    }
+
+    #[test]
+    fn observed_task_mode_does_not_override_pinned_mode() {
+        let mut conversation = ConversationState::new();
+        conversation.intent.pin_task_mode(TaskMode::Research);
+        conversation
+            .intent
+            .observe_task_mode(TaskMode::Implementation);
+        assert_eq!(conversation.intent.task_mode, TaskMode::Research);
+
+        let mut unpinned = ConversationState::new();
+        unpinned.intent.observe_task_mode(TaskMode::Research);
+        assert_eq!(unpinned.intent.task_mode, TaskMode::Research);
+        unpinned.intent.observe_task_mode(TaskMode::Implementation);
+        assert_eq!(unpinned.intent.task_mode, TaskMode::Implementation);
     }
 
     #[test]

--- a/core/crates/omegon/src/command_registry.rs
+++ b/core/crates/omegon/src/command_registry.rs
@@ -651,6 +651,10 @@ mod tests {
         assert!(auth.availability.tui);
         assert!(auth.availability.acp);
         assert!(auth.availability.cli);
-        assert!(auth.subcommands.iter().any(|subcommand| subcommand == "github-copilot"));
+        assert!(
+            auth.subcommands
+                .iter()
+                .any(|subcommand| subcommand == "github-copilot")
+        );
     }
 }

--- a/core/crates/omegon/src/control_runtime.rs
+++ b/core/crates/omegon/src/control_runtime.rs
@@ -2653,14 +2653,15 @@ pub async fn auth_login_response(
             }
             "github-copilot" | "copilot" => {
                 let copy_tx = events_tx_clone.clone();
-                let copy_block: auth::LoginCopyBlock = Box::new(move |label, text, kind, copy_attempt| {
-                    let _ = copy_tx.send(AgentEvent::OperatorCopyBlock {
-                        label,
-                        text,
-                        kind,
-                        copy_attempt,
+                let copy_block: auth::LoginCopyBlock =
+                    Box::new(move |label, text, kind, copy_attempt| {
+                        let _ = copy_tx.send(AgentEvent::OperatorCopyBlock {
+                            label,
+                            text,
+                            kind,
+                            copy_attempt,
+                        });
                     });
-                });
                 auth::login_github_copilot_with_copy_callback(progress, prompt, copy_block).await
             }
             "openai" => Err(anyhow::anyhow!(auth::operator_api_key_login_guidance(

--- a/core/crates/omegon/src/conversation.rs
+++ b/core/crates/omegon/src/conversation.rs
@@ -1053,6 +1053,11 @@ impl ConversationState {
             }
         }
 
+        // Collapse duplicate tool results before provider-shape repair. Wrapper
+        // tools can emit multiple local result events for one upstream tool_use;
+        // Anthropic requires those to be represented as one tool_result block.
+        coalesce_duplicate_tool_results(&mut messages);
+
         // Strip orphaned tool_use assistant calls whose matching tool_result
         // message was evicted or dropped during compaction/decay. Anthropic
         // rejects these with "tool_use ids were found without tool_result
@@ -1616,6 +1621,69 @@ fn tool_result_text_and_images(result: &ToolResultEntry) -> (String, Vec<ImageAt
     (text_blocks.join("\n"), images)
 }
 
+fn coalesce_duplicate_tool_results(messages: &mut Vec<LlmMessage>) {
+    let mut idx = 0;
+    while idx < messages.len() {
+        let LlmMessage::ToolResult { call_id, .. } = &messages[idx] else {
+            idx += 1;
+            continue;
+        };
+        let sanitized = sanitize_tool_like_id(call_id);
+        let mut merge_idx = idx + 1;
+        while merge_idx < messages.len() {
+            let LlmMessage::ToolResult {
+                call_id: next_call_id,
+                ..
+            } = &messages[merge_idx]
+            else {
+                break;
+            };
+            if sanitize_tool_like_id(next_call_id) != sanitized {
+                merge_idx += 1;
+                continue;
+            }
+            let duplicate = messages.remove(merge_idx);
+            merge_tool_result_message(&mut messages[idx], duplicate);
+        }
+        idx += 1;
+    }
+}
+
+fn merge_tool_result_message(target: &mut LlmMessage, duplicate: LlmMessage) {
+    let LlmMessage::ToolResult {
+        content: duplicate_content,
+        images: duplicate_images,
+        is_error: duplicate_is_error,
+        args_summary: duplicate_args_summary,
+        ..
+    } = duplicate
+    else {
+        return;
+    };
+    let LlmMessage::ToolResult {
+        content,
+        images,
+        is_error,
+        args_summary,
+        ..
+    } = target
+    else {
+        return;
+    };
+
+    if !duplicate_content.is_empty() {
+        if !content.is_empty() {
+            content.push_str("\n\n");
+        }
+        content.push_str(&duplicate_content);
+    }
+    images.extend(duplicate_images);
+    *is_error |= duplicate_is_error;
+    if args_summary.is_none() {
+        *args_summary = duplicate_args_summary;
+    }
+}
+
 fn bash_command_committed_successfully(call: &ToolCall, results: &[ToolResultEntry]) -> bool {
     let Some(command) = call.arguments.get("command").and_then(|v| v.as_str()) else {
         return false;
@@ -1827,7 +1895,18 @@ fn strip_orphaned_tool_results(messages: &mut Vec<LlmMessage>) {
 }
 
 fn sanitize_tool_like_id(id: &str) -> String {
-    id.split('|').next().unwrap_or(id).to_string()
+    id.split('|')
+        .next()
+        .unwrap_or(id)
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '_' || c == '-' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect()
 }
 
 /// Returns sequences of `[a-zA-Z0-9_]` that are at least 8 chars long.
@@ -3478,6 +3557,112 @@ mod tests {
         assert!(matches!(&view[0], LlmMessage::User { .. }));
         assert!(matches!(&view[1], LlmMessage::Assistant { .. }));
         assert!(matches!(&view[2], LlmMessage::ToolResult { .. }));
+    }
+
+    #[test]
+    fn coalesces_duplicate_tool_results_before_provider_replay() {
+        let mut conv = ConversationState::new();
+        conv.push_user("run tools".into());
+        push_matching_assistant(&mut conv, "toolu_abc");
+        conv.push_tool_result(ToolResultEntry {
+            call_id: "toolu_abc".into(),
+            tool_name: "multi_tool_use.parallel".into(),
+            content: vec![omegon_traits::ContentBlock::Text {
+                text: "first child result".into(),
+            }],
+            is_error: false,
+            args_summary: Some("batch".into()),
+        });
+        conv.push_tool_result(ToolResultEntry {
+            call_id: "toolu_abc".into(),
+            tool_name: "multi_tool_use.parallel".into(),
+            content: vec![omegon_traits::ContentBlock::Text {
+                text: "rollback notice".into(),
+            }],
+            is_error: true,
+            args_summary: None,
+        });
+
+        let view = conv.build_llm_view();
+        let results: Vec<_> = view
+            .iter()
+            .filter_map(|msg| match msg {
+                LlmMessage::ToolResult {
+                    call_id,
+                    content,
+                    is_error,
+                    args_summary,
+                    ..
+                } => Some((call_id, content, is_error, args_summary)),
+                _ => None,
+            })
+            .collect();
+
+        assert_eq!(
+            results.len(),
+            1,
+            "duplicate tool results survived: {view:?}"
+        );
+        assert_eq!(results[0].0, "toolu_abc");
+        assert!(results[0].1.contains("first child result"));
+        assert!(results[0].1.contains("rollback notice"));
+        assert!(*results[0].2);
+        assert_eq!(results[0].3.as_deref(), Some("batch"));
+    }
+
+    #[test]
+    fn provider_sanitized_duplicate_tool_results_do_not_orphan_assistant_tool_use() {
+        let mut conv = ConversationState::new();
+        conv.push_user("run tools".into());
+        push_matching_assistant(&mut conv, "toolu_abc.bad|fc_1");
+        conv.push_tool_result(ToolResultEntry {
+            call_id: "toolu_abc.bad|result_1".into(),
+            tool_name: "multi_tool_use.parallel".into(),
+            content: vec![omegon_traits::ContentBlock::Text {
+                text: "first child result".into(),
+            }],
+            is_error: false,
+            args_summary: None,
+        });
+        conv.push_tool_result(ToolResultEntry {
+            call_id: "toolu_abc_bad|result_2".into(),
+            tool_name: "multi_tool_use.parallel".into(),
+            content: vec![omegon_traits::ContentBlock::Text {
+                text: "second child result".into(),
+            }],
+            is_error: false,
+            args_summary: None,
+        });
+
+        let view = conv.build_llm_view();
+        let assistant_calls: Vec<_> = view
+            .iter()
+            .filter_map(|msg| match msg {
+                LlmMessage::Assistant { tool_calls, .. } => Some(tool_calls),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(assistant_calls.len(), 1, "assistant was stripped: {view:?}");
+        assert_eq!(
+            assistant_calls[0].len(),
+            1,
+            "tool call was stripped: {view:?}"
+        );
+
+        let results: Vec<_> = view
+            .iter()
+            .filter_map(|msg| match msg {
+                LlmMessage::ToolResult { content, .. } => Some(content),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            results.len(),
+            1,
+            "duplicate tool results survived: {view:?}"
+        );
+        assert!(results[0].contains("first child result"));
+        assert!(results[0].contains("second child result"));
     }
 
     #[test]

--- a/core/crates/omegon/src/conversation.rs
+++ b/core/crates/omegon/src/conversation.rs
@@ -219,6 +219,8 @@ pub struct IntentDocument {
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
 #[serde(default)]
 pub struct EvidenceLedger {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub task_scope: Option<String>,
     #[serde(default)]
     pub seen_paths: IndexSet<PathBuf>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -233,6 +235,8 @@ pub struct EvidenceTurn {
     pub revisits: u32,
     pub searches: u32,
     pub mutation_or_validation: bool,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub search_roots: Vec<PathBuf>,
 }
 
 impl EvidenceTurn {
@@ -255,6 +259,25 @@ impl EvidenceTurn {
 
 impl EvidenceLedger {
     const MAX_TURNS: usize = 32;
+    const ACTIONABLE_REVISIT_STREAK: u32 = 2;
+    const LOW_NOVELTY_THRESHOLD: f32 = 0.34;
+    const REVISIT_RATE_THRESHOLD: f32 = 0.5;
+
+    pub fn set_task_scope(&mut self, task_scope: Option<&str>) {
+        let normalized = task_scope
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(str::to_string);
+        if self.task_scope != normalized {
+            self.task_scope = normalized;
+            self.seen_paths.clear();
+            self.turns.clear();
+        }
+    }
+
+    pub fn actionable_revisit_streak(&self) -> bool {
+        self.low_novelty_revisit_streak() >= Self::ACTIONABLE_REVISIT_STREAK
+    }
 
     pub fn record_turn(&mut self, events: &[ObservationEvent]) {
         let mut turn = EvidenceTurn::default();
@@ -268,9 +291,10 @@ impl EvidenceLedger {
                         turn.revisits = turn.revisits.saturating_add(1);
                     }
                 }
-                ObservationEvent::SearchPerformed { .. } => {
+                ObservationEvent::SearchPerformed { roots, .. } => {
                     turn.observations = turn.observations.saturating_add(1);
                     turn.searches = turn.searches.saturating_add(1);
+                    turn.search_roots.extend(roots.iter().cloned());
                 }
                 ObservationEvent::FileMutated { path, .. } => {
                     turn.observations = turn.observations.saturating_add(1);
@@ -302,7 +326,10 @@ impl EvidenceLedger {
             if turn.mutation_or_validation {
                 break;
             }
-            if turn.observations > 0 && turn.novelty_rate() < 0.34 && turn.revisit_rate() >= 0.5 {
+            if turn.observations > 0
+                && turn.novelty_rate() < Self::LOW_NOVELTY_THRESHOLD
+                && turn.revisit_rate() >= Self::REVISIT_RATE_THRESHOLD
+            {
                 streak = streak.saturating_add(1);
             } else {
                 break;
@@ -598,6 +625,9 @@ impl IntentDocument {
             first_line.to_string()
         };
         if !task.trim().is_empty() {
+            if self.current_task.as_deref() != Some(task.as_str()) {
+                self.evidence_ledger.set_task_scope(Some(&task));
+            }
             self.current_task = Some(task);
         }
     }
@@ -2918,6 +2948,65 @@ mod tests {
         assert!(block.contains("30-minute TTL"));
         assert!(block.contains("Direct replacement"));
         assert!(block.contains("Cache holds stale refs"));
+    }
+
+    #[test]
+    fn evidence_ledger_resets_when_task_changes() {
+        let mut intent = IntentDocument::default();
+        intent.set_task_from_prompt("inspect foo");
+        let read_call = ToolCall {
+            id: "1".into(),
+            name: "read".into(),
+            arguments: serde_json::json!({"path": "src/foo.rs"}),
+        };
+        let read_result = ToolResultEntry {
+            call_id: "1".into(),
+            tool_name: "read".into(),
+            content: vec![],
+            is_error: false,
+            args_summary: None,
+        };
+        intent.update_from_tools(
+            &test_tool_catalog(),
+            std::slice::from_ref(&read_call),
+            std::slice::from_ref(&read_result),
+        );
+        assert!(
+            intent
+                .evidence_ledger
+                .seen_paths
+                .contains(&PathBuf::from("src/foo.rs"))
+        );
+
+        intent.set_task_from_prompt("inspect bar");
+        assert!(intent.evidence_ledger.seen_paths.is_empty());
+        assert!(intent.evidence_ledger.turns.is_empty());
+        intent.update_from_tools(&test_tool_catalog(), &[read_call], &[read_result]);
+        assert_eq!(intent.evidence_ledger.turns.last().unwrap().novel_paths, 1);
+    }
+
+    #[test]
+    fn evidence_ledger_records_search_roots() {
+        let mut intent = IntentDocument::default();
+        let call = ToolCall {
+            id: "1".into(),
+            name: "codebase_search".into(),
+            arguments: serde_json::json!({"query": "EvidenceLedger", "within": "core/crates/omegon/src"}),
+        };
+        let result = ToolResultEntry {
+            call_id: "1".into(),
+            tool_name: "codebase_search".into(),
+            content: vec![],
+            is_error: false,
+            args_summary: None,
+        };
+        intent.update_from_tools(&test_tool_catalog(), &[call], &[result]);
+        let turn = intent.evidence_ledger.turns.last().unwrap();
+        assert_eq!(turn.searches, 1);
+        assert_eq!(
+            turn.search_roots,
+            vec![PathBuf::from("core/crates/omegon/src")]
+        );
     }
 
     #[test]

--- a/core/crates/omegon/src/conversation.rs
+++ b/core/crates/omegon/src/conversation.rs
@@ -112,6 +112,27 @@ impl AgentMessage {
     }
 }
 
+/// Operator/task intent mode for the guidance policy (A1 in the harness
+/// guidance affordances). Research-style turns legitimately spend many turns
+/// in read/search without mutating files, so anti-orientation and forced-
+/// convergence pressure must relax. Implementation turns keep full pressure.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum TaskMode {
+    #[default]
+    Implementation,
+    Research,
+}
+
+impl TaskMode {
+    pub fn label(&self) -> &'static str {
+        match self {
+            Self::Implementation => "implementation",
+            Self::Research => "research",
+        }
+    }
+}
+
 /// Structured intent tracking — auto-populated, survives compaction verbatim.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(default)]
@@ -119,6 +140,16 @@ pub struct IntentDocument {
     pub current_task: Option<String>,
     pub approach: Option<String>,
     pub lifecycle_phase: LifecyclePhase,
+
+    /// Guidance-policy mode for the current operator task. Inferred from the
+    /// operator prompt at the start of each run unless pinned by an explicit
+    /// operator declaration.
+    #[serde(default)]
+    pub task_mode: TaskMode,
+    /// True when the operator explicitly declared the mode. Pinned mode is
+    /// not overwritten by per-prompt inference.
+    #[serde(default)]
+    pub task_mode_pinned: bool,
 
     pub files_read: IndexSet<PathBuf>,
     pub files_modified: IndexSet<PathBuf>,
@@ -346,6 +377,20 @@ pub struct SessionStatsAccumulator {
 }
 
 impl IntentDocument {
+    /// Observe an inferred task mode for the current operator prompt.
+    /// Inference never overrides an explicit operator declaration.
+    pub fn observe_task_mode(&mut self, inferred: TaskMode) {
+        if !self.task_mode_pinned {
+            self.task_mode = inferred;
+        }
+    }
+
+    /// Pin the task mode from an explicit operator declaration.
+    pub fn pin_task_mode(&mut self, mode: TaskMode) {
+        self.task_mode = mode;
+        self.task_mode_pinned = true;
+    }
+
     /// Update from tool call activity — automatic population.
     pub fn update_from_tools(
         &mut self,

--- a/core/crates/omegon/src/conversation.rs
+++ b/core/crates/omegon/src/conversation.rs
@@ -402,14 +402,15 @@ impl IntentDocument {
 
         for event in ObservationNormalizer::new(catalog).normalize(calls, results) {
             match event {
-                ObservationEvent::FileRead { path } => {
+                ObservationEvent::FileRead { path, .. } => {
                     self.files_read.insert(path);
                 }
-                ObservationEvent::FileMutated { path } => {
+                ObservationEvent::FileMutated { path, .. } => {
                     self.files_modified.insert(path);
                 }
                 ObservationEvent::ProgressBoundary {
                     clears_mutation_state,
+                    ..
                 } => {
                     if clears_mutation_state {
                         // A progress boundary such as commit clears the mutation set —
@@ -419,7 +420,8 @@ impl IntentDocument {
                         self.commit_nudged = false;
                     }
                 }
-                ObservationEvent::SearchPerformed | ObservationEvent::ValidationRun => {}
+                ObservationEvent::SearchPerformed { .. }
+                | ObservationEvent::ValidationRun { .. } => {}
             }
         }
 

--- a/core/crates/omegon/src/conversation.rs
+++ b/core/crates/omegon/src/conversation.rs
@@ -4,6 +4,7 @@
 //! and the LLM-facing view with decay applied for context efficiency.
 
 use crate::bridge::{ImageAttachment, LlmMessage, WireToolCall};
+use crate::observation::{ObservationEvent, ObservationNormalizer};
 pub use crate::plan::*;
 use indexmap::IndexSet;
 use omegon_traits::LifecyclePhase;
@@ -346,79 +347,76 @@ pub struct SessionStatsAccumulator {
 
 impl IntentDocument {
     /// Update from tool call activity — automatic population.
-    pub fn update_from_tools(&mut self, calls: &[ToolCall], results: &[ToolResultEntry]) {
+    pub fn update_from_tools(
+        &mut self,
+        catalog: &crate::behavior::ToolCapabilityCatalog,
+        calls: &[ToolCall],
+        results: &[ToolResultEntry],
+    ) {
         self.stats.tool_calls += calls.len() as u32;
 
+        for event in ObservationNormalizer::new(catalog).normalize(calls, results) {
+            match event {
+                ObservationEvent::FileRead { path } => {
+                    self.files_read.insert(path);
+                }
+                ObservationEvent::FileMutated { path } => {
+                    self.files_modified.insert(path);
+                }
+                ObservationEvent::ProgressBoundary {
+                    clears_mutation_state,
+                } => {
+                    if clears_mutation_state {
+                        // A progress boundary such as commit clears the mutation set —
+                        // after a commit the working tree is clean. Also reset
+                        // commit_nudged so future changes can be nudged again.
+                        self.files_modified.clear();
+                        self.commit_nudged = false;
+                    }
+                }
+                ObservationEvent::SearchPerformed | ObservationEvent::ValidationRun => {}
+            }
+        }
+
         for call in calls {
-            match call.name.as_str() {
-                "read" | "understand" => {
-                    if let Some(path) = call.arguments.get("path").and_then(|v| v.as_str()) {
-                        self.files_read.insert(PathBuf::from(path));
-                    }
-                }
-                "change" | "write" | "edit" => {
-                    if let Some(path) = call.arguments.get("path").and_then(|v| v.as_str()) {
-                        self.files_modified.insert(PathBuf::from(path));
-                    }
-                    // change tool may include multiple file paths in an edits array
-                    if let Some(edits) = call.arguments.get("edits").and_then(|v| v.as_array()) {
-                        for edit in edits {
-                            if let Some(path) = edit.get("file").and_then(|v| v.as_str()) {
-                                self.files_modified.insert(PathBuf::from(path));
-                            }
-                        }
-                    }
-                }
-                // commit clears the mutation set — after a commit the working tree is clean.
-                // Also resets commit_nudged so the agent can be nudged again if it makes
-                // further changes after committing.
-                "commit" => {
-                    self.files_modified.clear();
-                    self.commit_nudged = false;
-                }
-                "bash" if bash_command_committed_successfully(call, results) => {
-                    self.files_modified.clear();
-                    self.commit_nudged = false;
-                }
-                "plan" => {
-                    let action = call
+            if call.name != "plan" {
+                continue;
+            }
+            let action = call
+                .arguments
+                .get("action")
+                .and_then(|v| v.as_str())
+                .unwrap_or("status");
+            match action {
+                "set" => {
+                    let items: Vec<String> = call
                         .arguments
-                        .get("action")
-                        .and_then(|v| v.as_str())
-                        .unwrap_or("status");
-                    match action {
-                        "set" => {
-                            let items: Vec<String> = call
-                                .arguments
-                                .get("items")
-                                .and_then(|v| v.as_array())
-                                .map(|arr| {
-                                    arr.iter()
-                                        .filter_map(|v| v.as_str().map(String::from))
-                                        .collect()
-                                })
-                                .unwrap_or_default();
-                            if !items.is_empty() {
-                                self.apply_plan_action(PlanAction::Set { items });
-                            }
-                        }
-                        "advance" => self.apply_plan_action(PlanAction::Advance),
-                        "approve" => self.apply_plan_action(PlanAction::Approve),
-                        "execute" => self.apply_plan_action(PlanAction::Execute),
-                        "complete" => {
-                            let index = call
-                                .arguments
-                                .get("index")
-                                .and_then(|v| v.as_u64())
-                                .unwrap_or(0) as usize;
-                            self.apply_plan_action(PlanAction::Complete { index });
-                        }
-                        "skip" => self.apply_plan_action(PlanAction::Skip),
-                        "clear" => self.apply_plan_action(PlanAction::Clear),
-                        "list" | "status" => self.apply_plan_action(PlanAction::View),
-                        _ => {}
+                        .get("items")
+                        .and_then(|v| v.as_array())
+                        .map(|arr| {
+                            arr.iter()
+                                .filter_map(|v| v.as_str().map(String::from))
+                                .collect()
+                        })
+                        .unwrap_or_default();
+                    if !items.is_empty() {
+                        self.apply_plan_action(PlanAction::Set { items });
                     }
                 }
+                "advance" => self.apply_plan_action(PlanAction::Advance),
+                "approve" => self.apply_plan_action(PlanAction::Approve),
+                "execute" => self.apply_plan_action(PlanAction::Execute),
+                "complete" => {
+                    let index = call
+                        .arguments
+                        .get("index")
+                        .and_then(|v| v.as_u64())
+                        .unwrap_or(0) as usize;
+                    self.apply_plan_action(PlanAction::Complete { index });
+                }
+                "skip" => self.apply_plan_action(PlanAction::Skip),
+                "clear" => self.apply_plan_action(PlanAction::Clear),
+                "list" | "status" => self.apply_plan_action(PlanAction::View),
                 _ => {}
             }
         }
@@ -2205,6 +2203,67 @@ pub fn normalize_leet_speak(text: &str) -> String {
 mod tests {
     use super::*;
 
+    fn test_tool_catalog() -> crate::behavior::ToolCapabilityCatalog {
+        crate::behavior::ToolCapabilityCatalog::from_tool_defs(&[
+            omegon_traits::ToolDefinition {
+                name: "read".into(),
+                label: String::new(),
+                description: String::new(),
+                parameters: serde_json::json!({}),
+                capabilities: vec![omegon_traits::ToolCapability::TargetedRepoInspection],
+            },
+            omegon_traits::ToolDefinition {
+                name: "understand".into(),
+                label: String::new(),
+                description: String::new(),
+                parameters: serde_json::json!({}),
+                capabilities: vec![omegon_traits::ToolCapability::TargetedRepoInspection],
+            },
+            omegon_traits::ToolDefinition {
+                name: "view".into(),
+                label: String::new(),
+                description: String::new(),
+                parameters: serde_json::json!({}),
+                capabilities: vec![omegon_traits::ToolCapability::TargetedRepoInspection],
+            },
+            omegon_traits::ToolDefinition {
+                name: "codebase_search".into(),
+                label: String::new(),
+                description: String::new(),
+                parameters: serde_json::json!({}),
+                capabilities: vec![omegon_traits::ToolCapability::BroadRepoInspection],
+            },
+            omegon_traits::ToolDefinition {
+                name: "edit".into(),
+                label: String::new(),
+                description: String::new(),
+                parameters: serde_json::json!({}),
+                capabilities: vec![omegon_traits::ToolCapability::Mutation],
+            },
+            omegon_traits::ToolDefinition {
+                name: "write".into(),
+                label: String::new(),
+                description: String::new(),
+                parameters: serde_json::json!({}),
+                capabilities: vec![omegon_traits::ToolCapability::Mutation],
+            },
+            omegon_traits::ToolDefinition {
+                name: "change".into(),
+                label: String::new(),
+                description: String::new(),
+                parameters: serde_json::json!({}),
+                capabilities: vec![omegon_traits::ToolCapability::Mutation],
+            },
+            omegon_traits::ToolDefinition {
+                name: "commit".into(),
+                label: String::new(),
+                description: String::new(),
+                parameters: serde_json::json!({}),
+                capabilities: vec![omegon_traits::ToolCapability::ProgressBoundary],
+            },
+        ])
+    }
+
     /// Insert an assistant message with a tool_call matching the given call_id.
     /// Required so that subsequent tool_result messages aren't stripped as orphans.
     fn push_matching_assistant(conv: &mut ConversationState, call_id: &str) {
@@ -2736,13 +2795,68 @@ mod tests {
                 arguments: serde_json::json!({"command": "ls"}),
             },
         ];
-        intent.update_from_tools(&calls, &[]);
+        intent.update_from_tools(&test_tool_catalog(), &calls, &[]);
         assert!(intent.files_read.contains(&PathBuf::from("src/foo.rs")));
         assert!(intent.files_modified.contains(&PathBuf::from("src/bar.rs")));
         assert!(intent.files_modified.contains(&PathBuf::from("src/new.rs")));
         assert_eq!(intent.files_read.len(), 1);
         assert_eq!(intent.files_modified.len(), 2);
         assert_eq!(intent.stats.tool_calls, 4);
+    }
+
+    #[test]
+    fn intent_tracks_view_file_reads_from_capability_catalog() {
+        let mut intent = IntentDocument::default();
+        let calls = vec![ToolCall {
+            id: "1".into(),
+            name: "view".into(),
+            arguments: serde_json::json!({"path": "README.md"}),
+        }];
+
+        intent.update_from_tools(&test_tool_catalog(), &calls, &[]);
+
+        assert!(intent.files_read.contains(&PathBuf::from("README.md")));
+    }
+
+    #[test]
+    fn intent_tracks_bash_file_reads_without_literal_read_tool() {
+        let mut intent = IntentDocument::default();
+        let call = ToolCall {
+            id: "1".into(),
+            name: "bash".into(),
+            arguments: serde_json::json!({
+                "command": "sed -n '1,80p' core/crates/omegon/src/conversation.rs"
+            }),
+        };
+        let result = ToolResultEntry {
+            call_id: "1".into(),
+            tool_name: "bash".into(),
+            content: vec![],
+            is_error: false,
+            args_summary: None,
+        };
+
+        intent.update_from_tools(&test_tool_catalog(), &[call], &[result]);
+
+        assert!(
+            intent
+                .files_read
+                .contains(&PathBuf::from("core/crates/omegon/src/conversation.rs"))
+        );
+    }
+
+    #[test]
+    fn intent_does_not_treat_search_as_file_read() {
+        let mut intent = IntentDocument::default();
+        let calls = vec![ToolCall {
+            id: "1".into(),
+            name: "codebase_search".into(),
+            arguments: serde_json::json!({"query": "ObservationNormalizer"}),
+        }];
+
+        intent.update_from_tools(&test_tool_catalog(), &calls, &[]);
+
+        assert!(intent.files_read.is_empty());
     }
 
     #[test]
@@ -2754,6 +2868,7 @@ mod tests {
 
         // Simulate: agent edits a file, then commits
         intent.update_from_tools(
+            &test_tool_catalog(),
             &[ToolCall {
                 id: "1".into(),
                 name: "edit".into(),
@@ -2764,6 +2879,7 @@ mod tests {
         assert!(!intent.files_modified.is_empty(), "should have a mutation");
 
         intent.update_from_tools(
+            &test_tool_catalog(),
             &[ToolCall {
                 id: "2".into(),
                 name: "commit".into(),
@@ -2800,7 +2916,7 @@ mod tests {
             args_summary: Some("git add src/foo.rs && git commit -m 'fix: foo'".into()),
         };
 
-        intent.update_from_tools(&[call], &[result]);
+        intent.update_from_tools(&test_tool_catalog(), &[call], &[result]);
 
         assert!(
             intent.files_modified.is_empty(),
@@ -2828,7 +2944,7 @@ mod tests {
             args_summary: Some("git add src/foo.rs && git commit -m 'fix: foo'".into()),
         };
 
-        intent.update_from_tools(&[call], &[result]);
+        intent.update_from_tools(&test_tool_catalog(), &[call], &[result]);
 
         assert!(
             !intent.files_modified.is_empty(),
@@ -3191,7 +3307,7 @@ mod tests {
                 ]
             }),
         }];
-        intent.update_from_tools(&calls, &[]);
+        intent.update_from_tools(&test_tool_catalog(), &calls, &[]);
         assert!(intent.files_modified.contains(&PathBuf::from("src/a.rs")));
         assert!(intent.files_modified.contains(&PathBuf::from("src/b.rs")));
     }

--- a/core/crates/omegon/src/conversation.rs
+++ b/core/crates/omegon/src/conversation.rs
@@ -153,6 +153,10 @@ pub struct IntentDocument {
 
     pub files_read: IndexSet<PathBuf>,
     pub files_modified: IndexSet<PathBuf>,
+    /// Per-session discovery ledger for A3 guidance. Tracks novelty and
+    /// revisit pressure separately from scalar file counts.
+    #[serde(default)]
+    pub evidence_ledger: EvidenceLedger,
     /// Set to true after the agent has been nudged to commit once.
     /// Persists across loop invocations (TUI re-enters run() per user turn)
     /// to prevent the nudge from firing every turn in the same session.
@@ -210,6 +214,102 @@ pub struct IntentDocument {
     pub open_questions: Vec<String>,
 
     pub stats: SessionStatsAccumulator,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+#[serde(default)]
+pub struct EvidenceLedger {
+    #[serde(default)]
+    pub seen_paths: IndexSet<PathBuf>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub turns: Vec<EvidenceTurn>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+#[serde(default)]
+pub struct EvidenceTurn {
+    pub observations: u32,
+    pub novel_paths: u32,
+    pub revisits: u32,
+    pub searches: u32,
+    pub mutation_or_validation: bool,
+}
+
+impl EvidenceTurn {
+    pub fn novelty_rate(&self) -> f32 {
+        if self.observations == 0 {
+            0.0
+        } else {
+            self.novel_paths as f32 / self.observations as f32
+        }
+    }
+
+    pub fn revisit_rate(&self) -> f32 {
+        if self.observations == 0 {
+            0.0
+        } else {
+            self.revisits as f32 / self.observations as f32
+        }
+    }
+}
+
+impl EvidenceLedger {
+    const MAX_TURNS: usize = 32;
+
+    pub fn record_turn(&mut self, events: &[ObservationEvent]) {
+        let mut turn = EvidenceTurn::default();
+        for event in events {
+            match event {
+                ObservationEvent::FileRead { path, .. } => {
+                    turn.observations = turn.observations.saturating_add(1);
+                    if self.seen_paths.insert(path.clone()) {
+                        turn.novel_paths = turn.novel_paths.saturating_add(1);
+                    } else {
+                        turn.revisits = turn.revisits.saturating_add(1);
+                    }
+                }
+                ObservationEvent::SearchPerformed { .. } => {
+                    turn.observations = turn.observations.saturating_add(1);
+                    turn.searches = turn.searches.saturating_add(1);
+                }
+                ObservationEvent::FileMutated { path, .. } => {
+                    turn.observations = turn.observations.saturating_add(1);
+                    turn.mutation_or_validation = true;
+                    self.seen_paths.insert(path.clone());
+                }
+                ObservationEvent::ValidationRun { .. } => {
+                    turn.observations = turn.observations.saturating_add(1);
+                    turn.mutation_or_validation = true;
+                }
+                ObservationEvent::ProgressBoundary { .. } => {
+                    turn.observations = turn.observations.saturating_add(1);
+                }
+            }
+        }
+        if turn.observations == 0 {
+            return;
+        }
+        self.turns.push(turn);
+        if self.turns.len() > Self::MAX_TURNS {
+            let excess = self.turns.len() - Self::MAX_TURNS;
+            self.turns.drain(..excess);
+        }
+    }
+
+    pub fn low_novelty_revisit_streak(&self) -> u32 {
+        let mut streak = 0u32;
+        for turn in self.turns.iter().rev() {
+            if turn.mutation_or_validation {
+                break;
+            }
+            if turn.observations > 0 && turn.novelty_rate() < 0.34 && turn.revisit_rate() >= 0.5 {
+                streak = streak.saturating_add(1);
+            } else {
+                break;
+            }
+        }
+        streak
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -400,7 +500,10 @@ impl IntentDocument {
     ) {
         self.stats.tool_calls += calls.len() as u32;
 
-        for event in ObservationNormalizer::new(catalog).normalize(calls, results) {
+        let observations = ObservationNormalizer::new(catalog).normalize(calls, results);
+        self.evidence_ledger.record_turn(&observations);
+
+        for event in observations {
             match event {
                 ObservationEvent::FileRead { path, .. } => {
                     self.files_read.insert(path);
@@ -2815,6 +2918,47 @@ mod tests {
         assert!(block.contains("30-minute TTL"));
         assert!(block.contains("Direct replacement"));
         assert!(block.contains("Cache holds stale refs"));
+    }
+
+    #[test]
+    fn evidence_ledger_tracks_novel_revisit_and_boundary() {
+        let mut intent = IntentDocument::default();
+        let read_call = ToolCall {
+            id: "1".into(),
+            name: "read".into(),
+            arguments: serde_json::json!({"path": "src/foo.rs"}),
+        };
+        let read_result = ToolResultEntry {
+            call_id: "1".into(),
+            tool_name: "read".into(),
+            content: vec![],
+            is_error: false,
+            args_summary: None,
+        };
+        intent.update_from_tools(
+            &test_tool_catalog(),
+            std::slice::from_ref(&read_call),
+            std::slice::from_ref(&read_result),
+        );
+        assert_eq!(intent.evidence_ledger.turns.last().unwrap().novel_paths, 1);
+        intent.update_from_tools(&test_tool_catalog(), &[read_call], &[read_result]);
+        assert_eq!(intent.evidence_ledger.turns.last().unwrap().revisits, 1);
+        assert_eq!(intent.evidence_ledger.low_novelty_revisit_streak(), 1);
+
+        let validate_call = ToolCall {
+            id: "2".into(),
+            name: "bash".into(),
+            arguments: serde_json::json!({"command": "cargo test -p omegon foo --locked"}),
+        };
+        let validate_result = ToolResultEntry {
+            call_id: "2".into(),
+            tool_name: "bash".into(),
+            content: vec![],
+            is_error: false,
+            args_summary: None,
+        };
+        intent.update_from_tools(&test_tool_catalog(), &[validate_call], &[validate_result]);
+        assert_eq!(intent.evidence_ledger.low_novelty_revisit_streak(), 0);
     }
 
     #[test]

--- a/core/crates/omegon/src/conversation.rs
+++ b/core/crates/omegon/src/conversation.rs
@@ -2842,7 +2842,17 @@ mod tests {
                 arguments: serde_json::json!({"command": "ls"}),
             },
         ];
-        intent.update_from_tools(&test_tool_catalog(), &calls, &[]);
+        let results: Vec<ToolResultEntry> = calls
+            .iter()
+            .map(|call| ToolResultEntry {
+                call_id: call.id.clone(),
+                tool_name: call.name.clone(),
+                content: vec![],
+                is_error: false,
+                args_summary: None,
+            })
+            .collect();
+        intent.update_from_tools(&test_tool_catalog(), &calls, &results);
         assert!(intent.files_read.contains(&PathBuf::from("src/foo.rs")));
         assert!(intent.files_modified.contains(&PathBuf::from("src/bar.rs")));
         assert!(intent.files_modified.contains(&PathBuf::from("src/new.rs")));
@@ -2860,7 +2870,14 @@ mod tests {
             arguments: serde_json::json!({"path": "README.md"}),
         }];
 
-        intent.update_from_tools(&test_tool_catalog(), &calls, &[]);
+        let results = vec![ToolResultEntry {
+            call_id: "1".into(),
+            tool_name: "view".into(),
+            content: vec![],
+            is_error: false,
+            args_summary: None,
+        }];
+        intent.update_from_tools(&test_tool_catalog(), &calls, &results);
 
         assert!(intent.files_read.contains(&PathBuf::from("README.md")));
     }
@@ -2921,7 +2938,13 @@ mod tests {
                 name: "edit".into(),
                 arguments: serde_json::json!({"path": "src/foo.rs"}),
             }],
-            &[],
+            &[ToolResultEntry {
+                call_id: "1".into(),
+                tool_name: "edit".into(),
+                content: vec![],
+                is_error: false,
+                args_summary: None,
+            }],
         );
         assert!(!intent.files_modified.is_empty(), "should have a mutation");
 
@@ -2932,7 +2955,13 @@ mod tests {
                 name: "commit".into(),
                 arguments: serde_json::json!({"message": "fix: foo"}),
             }],
-            &[],
+            &[ToolResultEntry {
+                call_id: "2".into(),
+                tool_name: "commit".into(),
+                content: vec![],
+                is_error: false,
+                args_summary: None,
+            }],
         );
         assert!(
             intent.files_modified.is_empty(),
@@ -3354,7 +3383,14 @@ mod tests {
                 ]
             }),
         }];
-        intent.update_from_tools(&test_tool_catalog(), &calls, &[]);
+        let results = vec![ToolResultEntry {
+            call_id: "1".into(),
+            tool_name: "change".into(),
+            content: vec![],
+            is_error: false,
+            args_summary: None,
+        }];
+        intent.update_from_tools(&test_tool_catalog(), &calls, &results);
         assert!(intent.files_modified.contains(&PathBuf::from("src/a.rs")));
         assert!(intent.files_modified.contains(&PathBuf::from("src/b.rs")));
     }

--- a/core/crates/omegon/src/ipc/connection.rs
+++ b/core/crates/omegon/src/ipc/connection.rs
@@ -1055,9 +1055,11 @@ fn project_event(ev: &AgentEvent) -> Option<IpcEventPayload> {
         AgentEvent::SystemNotification { message } => Some(IpcEventPayload::SystemNotification {
             message: message.clone(),
         }),
-        AgentEvent::OperatorCopyBlock { label, text, .. } => Some(IpcEventPayload::SystemNotification {
-            message: format!("{label}: {text}"),
-        }),
+        AgentEvent::OperatorCopyBlock { label, text, .. } => {
+            Some(IpcEventPayload::SystemNotification {
+                message: format!("{label}: {text}"),
+            })
+        }
         AgentEvent::StreamIdle {
             provider,
             model,

--- a/core/crates/omegon/src/loop.rs
+++ b/core/crates/omegon/src/loop.rs
@@ -4310,7 +4310,7 @@ impl StuckDetector {
                 self.recent.push((tool_name, hash_str_path(path), false));
                 self.recent_file_accesses.push(path.display().to_string());
             }
-            crate::observation::ObservationEvent::SearchPerformed { source_tool } => {
+            crate::observation::ObservationEvent::SearchPerformed { source_tool, .. } => {
                 let tool_name = source_tool
                     .strip_prefix("bash:")
                     .unwrap_or(source_tool)

--- a/core/crates/omegon/src/loop.rs
+++ b/core/crates/omegon/src/loop.rs
@@ -391,6 +391,13 @@ pub async fn run(
     let mut session_used_tools: std::collections::HashSet<String> =
         std::collections::HashSet::new();
     let mut turn: u32 = 0;
+    // Infer the guidance task mode for this operator prompt (A1). Inference
+    // never overrides a mode the operator explicitly pinned.
+    conversation
+        .intent
+        .observe_task_mode(crate::behavior::infer_task_mode_from_prompt(
+            conversation.last_user_prompt(),
+        ));
     // Active model for this turn — updated each iteration from settings.
     // Used in TurnEnd events and error classification instead of the
     // immutable config.model which is frozen at startup. Starts from the
@@ -1200,55 +1207,15 @@ pub async fn run(
             //   of whether tools were called to gather context first
             // - Skip if the user explicitly did not ask for a file write
             let in_task_mode = conversation.intent.stats.tool_calls > 0;
-            // Skip dead-mouse if the user's last prompt looks like a question,
-            // rundown, summary, or any read/explain-style request — text-only
-            // responses are legitimate. We err *strongly* on the side of NOT
-            // firing: false positives push the model to invent file-writing
-            // work the user never requested (worse failure mode than false
-            // negatives).
-            let user_asked_question = {
-                let prompt = conversation.last_user_prompt().to_lowercase();
-                let starts = |w: &str| prompt.trim_start().starts_with(w);
-                prompt.contains('?')
-                    || starts("explain")
-                    || starts("what")
-                    || starts("why")
-                    || starts("how")
-                    || starts("when")
-                    || starts("where")
-                    || starts("which")
-                    || starts("who")
-                    || starts("describe")
-                    || starts("summarize")
-                    || starts("summary")
-                    || starts("rundown")
-                    || starts("overview")
-                    || starts("review")
-                    || starts("analyze")
-                    || starts("compare")
-                    || starts("contrast")
-                    || starts("outline")
-                    || starts("discuss")
-                    || starts("tell me")
-                    || starts("show me")
-                    || starts("give me")
-                    || starts("list")
-                    || starts("can you")
-                    || starts("could you")
-                    || starts("do you")
-                    || starts("is ")
-                    || starts("are ")
-                    || starts("does")
-                    || starts("did")
-                    || starts("read")
-                    || starts("look")
-                    || starts("check")
-                    || starts("find")
-                    || starts("search")
-                    || prompt.contains(" rundown")
-                    || prompt.contains(" summary")
-                    || prompt.contains(" overview")
-            };
+            // Skip dead-mouse if the operator's task mode is Research —
+            // question / rundown / summary / read-style prompts make
+            // text-only responses legitimate. The shared inference in
+            // `behavior::infer_task_mode_from_prompt` errs *strongly* on the
+            // side of Research: false Implementation classifications push the
+            // model to invent file-writing work the user never requested
+            // (worse failure mode than false negatives).
+            let user_asked_question =
+                conversation.intent.task_mode == crate::conversation::TaskMode::Research;
             // If the model's last assistant message was substantial natural
             // language (i.e. it produced an actual answer), treat the turn
             // as complete regardless of mutations. Q&A is a primary mode for
@@ -6653,6 +6620,157 @@ This is the right first slice."#;
     }
 
     #[test]
+    fn infer_task_mode_classifies_research_and_implementation_prompts() {
+        use crate::behavior::infer_task_mode_from_prompt;
+        use crate::conversation::TaskMode;
+
+        for prompt in [
+            "what does the observation normalizer do?",
+            "Explain the OODA loop wiring",
+            "give me a rundown of the guidance affordances",
+            "review the recent additions",
+            "How does compaction work",
+            "investigate the flaky test",
+        ] {
+            assert_eq!(
+                infer_task_mode_from_prompt(prompt),
+                TaskMode::Research,
+                "prompt should classify as research: {prompt}"
+            );
+        }
+
+        for prompt in [
+            "fix the failing test in loop.rs",
+            "implement the task-mode intent channel",
+            "add a regression test and commit",
+            "refactor update_from_tools to use the catalog",
+        ] {
+            assert_eq!(
+                infer_task_mode_from_prompt(prompt),
+                TaskMode::Implementation,
+                "prompt should classify as implementation: {prompt}"
+            );
+        }
+    }
+
+    #[test]
+    fn observed_task_mode_does_not_override_pinned_mode() {
+        use crate::conversation::TaskMode;
+
+        let mut intent = IntentDocument::default();
+        intent.pin_task_mode(TaskMode::Implementation);
+        intent.observe_task_mode(TaskMode::Research);
+        assert_eq!(intent.task_mode, TaskMode::Implementation);
+
+        let mut unpinned = IntentDocument::default();
+        unpinned.observe_task_mode(TaskMode::Research);
+        assert_eq!(unpinned.task_mode, TaskMode::Research);
+    }
+
+    #[test]
+    fn execution_pressure_suppressed_in_research_mode() {
+        use crate::conversation::TaskMode;
+
+        let config = LoopConfig::default();
+        let mut conversation = ConversationState::new();
+        conversation
+            .intent
+            .files_read
+            .insert(std::path::PathBuf::from("src/lib.rs"));
+        conversation.intent.observe_task_mode(TaskMode::Research);
+        let tool_calls = vec![ToolCall {
+            id: "1".into(),
+            name: "codebase_search".into(),
+            arguments: Value::Null,
+        }];
+        // Same shape fires in implementation mode at turn 7 (see
+        // execution_pressure_detected_after_repeated_repo_inspection_without_edits)
+        // but must stay silent for research turns.
+        assert!(!should_inject_execution_pressure(
+            12,
+            &config,
+            &conversation,
+            &test_tool_catalog(),
+            &tool_calls,
+            BehavioralTier::Standard,
+        ));
+    }
+
+    #[test]
+    fn continuation_pressure_relaxed_but_not_disabled_in_research_mode() {
+        use crate::conversation::TaskMode;
+
+        let config = LoopConfig::default();
+        let mut conversation = ConversationState::new();
+        conversation
+            .intent
+            .files_read
+            .insert(std::path::PathBuf::from("core/src/context.rs"));
+        conversation.intent.observe_task_mode(TaskMode::Research);
+        let tool_calls = vec![ToolCall {
+            id: "1".into(),
+            name: "read".into(),
+            arguments: Value::Null,
+        }];
+
+        // Streaks that trigger tier 1 in implementation mode stay quiet.
+        let moderate = ControllerState {
+            consecutive_tool_continuations: 12,
+            orientation_churn_streak: 4,
+            ..ControllerState::default()
+        };
+        assert_eq!(
+            continuation_pressure_tier(
+                &config,
+                &moderate,
+                &conversation,
+                &tool_calls,
+                Some(OodaPhase::Observe),
+                BehavioralTier::Standard,
+            ),
+            None,
+            "research mode should absorb implementation-tier churn"
+        );
+
+        // The late safety net still exists for unbounded exploration.
+        let extreme = ControllerState {
+            consecutive_tool_continuations: 32,
+            orientation_churn_streak: 24,
+            ..ControllerState::default()
+        };
+        assert!(
+            continuation_pressure_tier(
+                &config,
+                &extreme,
+                &conversation,
+                &tool_calls,
+                Some(OodaPhase::Observe),
+                BehavioralTier::Standard,
+            )
+            .is_some(),
+            "research mode must keep a late safety net"
+        );
+
+        // Genuine pathology (repeated action failure) keeps full pressure.
+        let failing = ControllerState {
+            repeated_action_failure_streak: 2,
+            ..ControllerState::default()
+        };
+        assert_eq!(
+            continuation_pressure_tier(
+                &config,
+                &failing,
+                &conversation,
+                &tool_calls,
+                Some(OodaPhase::Observe),
+                BehavioralTier::Standard,
+            ),
+            Some(2),
+            "repeated action failure is mode-independent pathology"
+        );
+    }
+
+    #[test]
     fn continuation_pressure_detected_for_sustained_orientation_churn() {
         let config = LoopConfig {
             enforce_first_turn_execution_bias: true,
@@ -6690,6 +6808,154 @@ This is the right first slice."#;
                 BehavioralTier::Standard,
             ),
             Some(1)
+        );
+    }
+
+    #[test]
+    fn research_mode_relaxes_continuation_pressure_for_orientation_churn() {
+        let config = LoopConfig {
+            enforce_first_turn_execution_bias: true,
+            ..LoopConfig::default()
+        };
+        let mut conversation = ConversationState::new();
+        conversation
+            .intent
+            .pin_task_mode(crate::conversation::TaskMode::Research);
+        conversation
+            .intent
+            .files_read
+            .insert(std::path::PathBuf::from("core/src/context.rs"));
+        let tool_calls = vec![
+            ToolCall {
+                id: "1".into(),
+                name: "read".into(),
+                arguments: Value::Null,
+            },
+            ToolCall {
+                id: "2".into(),
+                name: "codebase_search".into(),
+                arguments: Value::Null,
+            },
+        ];
+        // The same streaks that trigger tier-1 pressure in Implementation
+        // mode stay quiet in Research mode.
+        let controller = ControllerState {
+            consecutive_tool_continuations: 12,
+            orientation_churn_streak: 4,
+            ..ControllerState::default()
+        };
+        assert_eq!(
+            continuation_pressure_tier(
+                &config,
+                &controller,
+                &conversation,
+                &tool_calls,
+                Some(OodaPhase::Observe),
+                BehavioralTier::Standard,
+            ),
+            None,
+            "research mode must not fire on implementation-mode thresholds"
+        );
+
+        // Genuinely unbounded exploration still hits the safety net.
+        let runaway = ControllerState {
+            consecutive_tool_continuations: 32,
+            orientation_churn_streak: 24,
+            ..ControllerState::default()
+        };
+        assert_eq!(
+            continuation_pressure_tier(
+                &config,
+                &runaway,
+                &conversation,
+                &tool_calls,
+                Some(OodaPhase::Observe),
+                BehavioralTier::Standard,
+            ),
+            Some(3),
+            "research mode keeps a late safety net"
+        );
+    }
+
+    #[test]
+    fn research_mode_keeps_failure_driven_pressure() {
+        let config = LoopConfig {
+            enforce_first_turn_execution_bias: true,
+            ..LoopConfig::default()
+        };
+        let mut conversation = ConversationState::new();
+        conversation
+            .intent
+            .pin_task_mode(crate::conversation::TaskMode::Research);
+        conversation
+            .intent
+            .files_read
+            .insert(std::path::PathBuf::from("core/src/context.rs"));
+        let tool_calls = vec![ToolCall {
+            id: "1".into(),
+            name: "read".into(),
+            arguments: Value::Null,
+        }];
+        // RepeatedActionFailure is genuine pathology in any mode.
+        let controller = ControllerState {
+            repeated_action_failure_streak: 2,
+            ..ControllerState::default()
+        };
+        assert_eq!(
+            continuation_pressure_tier(
+                &config,
+                &controller,
+                &conversation,
+                &tool_calls,
+                Some(OodaPhase::Observe),
+                BehavioralTier::Standard,
+            ),
+            Some(2),
+            "failure streaks must keep firing in research mode"
+        );
+    }
+
+    #[test]
+    fn research_mode_suppresses_execution_pressure() {
+        let config = LoopConfig {
+            enforce_first_turn_execution_bias: true,
+            ..LoopConfig::default()
+        };
+        let mut conversation = ConversationState::new();
+        conversation
+            .intent
+            .files_read
+            .insert(std::path::PathBuf::from("core/src/context.rs"));
+        let tool_calls = vec![ToolCall {
+            id: "1".into(),
+            name: "codebase_search".into(),
+            arguments: Value::Null,
+        }];
+        assert!(
+            should_inject_execution_pressure(
+                9,
+                &config,
+                &conversation,
+                &test_tool_catalog(),
+                &tool_calls,
+                BehavioralTier::Standard,
+            ),
+            "implementation mode still pressures repeated inspection"
+        );
+
+        conversation
+            .intent
+            .pin_task_mode(crate::conversation::TaskMode::Research);
+        assert!(
+            !should_inject_execution_pressure(
+                9,
+                &config,
+                &conversation,
+                &test_tool_catalog(),
+                &tool_calls,
+                BehavioralTier::Standard,
+            ),
+            "research mode must never pressure toward edits"
         );
     }
 

--- a/core/crates/omegon/src/loop.rs
+++ b/core/crates/omegon/src/loop.rs
@@ -391,13 +391,19 @@ pub async fn run(
     let mut session_used_tools: std::collections::HashSet<String> =
         std::collections::HashSet::new();
     let mut turn: u32 = 0;
-    // Infer the guidance task mode for this operator prompt (A1). Inference
-    // never overrides a mode the operator explicitly pinned.
-    conversation
-        .intent
-        .observe_task_mode(crate::behavior::infer_task_mode_from_prompt(
-            conversation.last_user_prompt(),
-        ));
+    // Infer the guidance task mode for this operator prompt (A1). Explicit
+    // operator declarations pin the mode; otherwise inference updates it for
+    // the current task without overriding a previously pinned mode.
+    let last_user_prompt = conversation.last_user_prompt();
+    if let Some(mode) = crate::behavior::explicit_task_mode_from_prompt(last_user_prompt) {
+        conversation.intent.pin_task_mode(mode);
+    } else {
+        conversation
+            .intent
+            .observe_task_mode(crate::behavior::infer_task_mode_from_prompt(
+                last_user_prompt,
+            ));
+    }
     // Active model for this turn — updated each iteration from settings.
     // Used in TurnEnd events and error classification instead of the
     // immutable config.model which is frozen at startup. Starts from the

--- a/core/crates/omegon/src/loop.rs
+++ b/core/crates/omegon/src/loop.rs
@@ -1421,7 +1421,7 @@ pub async fn run(
             work_plan_snapshot_with_lifecycle(&conversation.intent, &config.cwd);
         conversation
             .intent
-            .update_from_tools(dispatch_calls, &results);
+            .update_from_tools(&tool_catalog, dispatch_calls, &results);
         enrich_plan_list_tool_results(&mut results, dispatch_calls, &conversation.intent);
         for result in &results {
             conversation.push_tool_result(result.clone());
@@ -5404,7 +5404,7 @@ mod tests {
             name: "read".into(),
             arguments: serde_json::json!({"path": "src/main.rs"}),
         }];
-        intent.update_from_tools(&read_calls, &[]);
+        intent.update_from_tools(&test_tool_catalog(), &read_calls, &[]);
         let after_read = intent.work_plan_snapshot_json();
         assert!(!work_plan_snapshot_changed(&before, &after_read));
 
@@ -5413,7 +5413,7 @@ mod tests {
             name: crate::tool_registry::core::PLAN.into(),
             arguments: serde_json::json!({"action": "advance"}),
         }];
-        intent.update_from_tools(&plan_calls, &[]);
+        intent.update_from_tools(&test_tool_catalog(), &plan_calls, &[]);
         let after_plan = intent.work_plan_snapshot_json();
         assert!(work_plan_snapshot_changed(&after_read, &after_plan));
         assert_eq!(after_plan["completed"], 1);

--- a/core/crates/omegon/src/loop.rs
+++ b/core/crates/omegon/src/loop.rs
@@ -7591,7 +7591,7 @@ This is the right first slice."#;
             args_summary: None,
         }];
         let evidence = assess_evidence(&conversation, &test_tool_catalog(), &tool_calls, &results);
-        assert_eq!(evidence.local, EvidenceSufficiency::Actionable);
+        assert_eq!(evidence.local, EvidenceSufficiency::Targeted);
         assert_eq!(evidence.global, EvidenceSufficiency::None);
     }
 

--- a/core/crates/omegon/src/loop.rs
+++ b/core/crates/omegon/src/loop.rs
@@ -1545,12 +1545,19 @@ pub async fn run(
         }
         context.update_phase_from_activity(dispatch_calls);
 
+        let observations = crate::observation::ObservationNormalizer::new(&tool_catalog)
+            .normalize(dispatch_calls, &results);
+        for event in &observations {
+            stuck_detector.record_observation(event);
+        }
         for call in dispatch_calls {
             let is_error = results
                 .iter()
                 .find(|r| r.call_id == call.id)
                 .is_some_and(|r| r.is_error);
-            stuck_detector.record(&tool_catalog, call, is_error);
+            if is_error {
+                stuck_detector.record(&tool_catalog, call, true);
+            }
         }
 
         let system_prompt =
@@ -4287,6 +4294,60 @@ impl StuckDetector {
         }
     }
 
+    fn record_observation(&mut self, event: &crate::observation::ObservationEvent) {
+        match event {
+            crate::observation::ObservationEvent::FileRead { source_tool, path } => {
+                let tool_name = source_tool
+                    .strip_prefix("bash:")
+                    .unwrap_or(source_tool)
+                    .to_string();
+                self.recent.push((tool_name, hash_str_path(path), false));
+                self.recent_file_accesses.push(path.display().to_string());
+            }
+            crate::observation::ObservationEvent::SearchPerformed { source_tool } => {
+                let tool_name = source_tool
+                    .strip_prefix("bash:")
+                    .unwrap_or(source_tool)
+                    .to_string();
+                self.recent.push((tool_name, hash_str("<search>"), false));
+            }
+            crate::observation::ObservationEvent::FileMutated { source_tool, path } => {
+                self.recent
+                    .push((source_tool.clone(), hash_str_path(path), false));
+                let rendered = path.display().to_string();
+                self.recent_file_accesses.retain(|p| p != &rendered);
+            }
+            crate::observation::ObservationEvent::ValidationRun { source_tool } => {
+                let tool_name = if source_tool == "bash" {
+                    crate::tool_registry::core::VALIDATE.to_string()
+                } else {
+                    source_tool.clone()
+                };
+                self.recent
+                    .push((tool_name, hash_str("<validation>"), false));
+                // Validation is a convergence action, not inspection churn.
+                // Clear path-only churn history so a validate→re-read loop is
+                // treated as post-validation investigation rather than stale
+                // pre-validation spinning.
+                self.recent_file_accesses.clear();
+            }
+            crate::observation::ObservationEvent::ProgressBoundary { source_tool, .. } => {
+                let tool_name = if source_tool == "bash" {
+                    crate::tool_registry::core::COMMIT.to_string()
+                } else {
+                    source_tool.clone()
+                };
+                self.recent.push((tool_name, hash_str("<progress>"), false));
+            }
+        }
+        if self.recent.len() > self.window * 2 {
+            self.recent.drain(..self.window);
+        }
+        if self.recent_file_accesses.len() > self.window * 2 {
+            self.recent_file_accesses.drain(..self.window);
+        }
+    }
+
     /// Check for stuck patterns. Returns a warning with escalation level if detected.
     fn check(&mut self, catalog: &ToolCapabilityCatalog) -> Option<StuckWarning> {
         let len = self.recent.len();
@@ -4538,6 +4599,16 @@ fn hash_value(v: &Value) -> u64 {
     let s = v.to_string();
     s.hash(&mut hasher);
     hasher.finish()
+}
+
+fn hash_str(s: &str) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    s.hash(&mut hasher);
+    hasher.finish()
+}
+
+fn hash_str_path(path: &std::path::Path) -> u64 {
+    hash_str(&path.display().to_string())
 }
 
 #[cfg(test)]
@@ -4961,6 +5032,155 @@ mod tests {
         let warning = detector.check(&test_tool_catalog());
         assert!(warning.is_some());
         assert!(warning.unwrap().message.contains("same arguments"));
+    }
+
+    #[test]
+    fn stuck_detector_tracks_file_churn_through_observation_events() {
+        let mut detector = StuckDetector::new();
+        let path = "src/main.rs";
+
+        for command in [
+            "sed -n '1,40p' src/main.rs",
+            "cat src/main.rs",
+            "head -20 src/main.rs",
+            "tail -20 src/main.rs",
+        ] {
+            let call = ToolCall {
+                id: command.into(),
+                name: "bash".into(),
+                arguments: serde_json::json!({"command": command}),
+            };
+            let result = ToolResultEntry {
+                call_id: command.into(),
+                tool_name: "bash".into(),
+                content: vec![],
+                is_error: false,
+                args_summary: None,
+            };
+            let events = crate::observation::ObservationNormalizer::new(&test_tool_catalog())
+                .normalize(&[call], &[result]);
+            for event in events {
+                detector.record_observation(&event);
+            }
+        }
+
+        let warning = detector.check(&test_tool_catalog()).expect("warning");
+        assert!(warning.message.contains(path), "{}", warning.message);
+    }
+
+    #[test]
+    fn stuck_detector_bash_validation_breaks_file_churn() {
+        let mut detector = StuckDetector::new();
+        let catalog = test_tool_catalog();
+
+        for command in [
+            "sed -n '1,40p' src/main.rs",
+            "cat src/main.rs",
+            "head -20 src/main.rs",
+            "cargo test -p omegon observation --locked",
+            "tail -20 src/main.rs",
+            "sed -n '41,80p' src/main.rs",
+        ] {
+            let call = ToolCall {
+                id: command.into(),
+                name: "bash".into(),
+                arguments: serde_json::json!({"command": command}),
+            };
+            let result = ToolResultEntry {
+                call_id: command.into(),
+                tool_name: "bash".into(),
+                content: vec![],
+                is_error: false,
+                args_summary: None,
+            };
+            let events = crate::observation::ObservationNormalizer::new(&catalog)
+                .normalize(&[call], &[result]);
+            for event in events {
+                detector.record_observation(&event);
+            }
+        }
+
+        assert!(
+            detector.check(&catalog).is_none(),
+            "bash validation should break repeated read-only churn"
+        );
+    }
+
+    #[test]
+    fn stuck_detector_mutation_observation_clears_file_churn() {
+        let mut detector = StuckDetector::new();
+        let catalog = test_tool_catalog();
+
+        for command in [
+            "sed -n '1,40p' src/main.rs",
+            "cat src/main.rs",
+            "head -20 src/main.rs",
+        ] {
+            let call = ToolCall {
+                id: command.into(),
+                name: "bash".into(),
+                arguments: serde_json::json!({"command": command}),
+            };
+            let result = ToolResultEntry {
+                call_id: command.into(),
+                tool_name: "bash".into(),
+                content: vec![],
+                is_error: false,
+                args_summary: None,
+            };
+            let events = crate::observation::ObservationNormalizer::new(&catalog)
+                .normalize(&[call], &[result]);
+            for event in events {
+                detector.record_observation(&event);
+            }
+        }
+
+        let edit = ToolCall {
+            id: "edit".into(),
+            name: "edit".into(),
+            arguments: serde_json::json!({"path": "src/main.rs", "oldText": "a", "newText": "b"}),
+        };
+        let edit_result = ToolResultEntry {
+            call_id: "edit".into(),
+            tool_name: "edit".into(),
+            content: vec![],
+            is_error: false,
+            args_summary: None,
+        };
+        let events = crate::observation::ObservationNormalizer::new(&catalog)
+            .normalize(&[edit], &[edit_result]);
+        for event in events {
+            detector.record_observation(&event);
+        }
+
+        for command in [
+            "tail -20 src/main.rs",
+            "sed -n '41,80p' src/main.rs",
+            "cat src/main.rs",
+        ] {
+            let call = ToolCall {
+                id: command.into(),
+                name: "bash".into(),
+                arguments: serde_json::json!({"command": command}),
+            };
+            let result = ToolResultEntry {
+                call_id: command.into(),
+                tool_name: "bash".into(),
+                content: vec![],
+                is_error: false,
+                args_summary: None,
+            };
+            let events = crate::observation::ObservationNormalizer::new(&catalog)
+                .normalize(&[call], &[result]);
+            for event in events {
+                detector.record_observation(&event);
+            }
+        }
+
+        assert!(
+            detector.check(&catalog).is_none(),
+            "mutation observation should clear prior access entries for the path"
+        );
     }
 
     #[test]

--- a/core/crates/omegon/src/main.rs
+++ b/core/crates/omegon/src/main.rs
@@ -61,6 +61,7 @@ mod ipc;
 #[cfg(feature = "local-embeddings")]
 mod local_embedding;
 mod migrate;
+mod observation;
 mod shadow_context;
 mod skills;
 mod smoke;

--- a/core/crates/omegon/src/main.rs
+++ b/core/crates/omegon/src/main.rs
@@ -10794,10 +10794,8 @@ mod tests {
 
     #[test]
     fn plan_list_renders_visible_completed_and_openspec_sections() {
-        let _guard = crate::test_support::cwd::lock();
         let cwd = tempfile::tempdir().unwrap();
-        let previous_cwd = std::env::current_dir().unwrap();
-        std::env::set_current_dir(cwd.path()).unwrap();
+        let _cwd = crate::test_support::cwd::CurrentDirGuard::enter(cwd.path());
         std::fs::create_dir_all("openspec/changes/example/specs/lifecycle").unwrap();
         std::fs::write("openspec/changes/example/proposal.md", "# Example\n").unwrap();
         std::fs::write(
@@ -10817,7 +10815,6 @@ mod tests {
             .set_work_plan(vec!["visible work".into()]);
 
         let output = render_plan_list(&runtime_state);
-        std::env::set_current_dir(previous_cwd).unwrap();
 
         assert!(output.contains("Visible"), "{output}");
         assert!(output.contains("visible work"), "{output}");

--- a/core/crates/omegon/src/main.rs
+++ b/core/crates/omegon/src/main.rs
@@ -23,8 +23,8 @@ use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
 
 #[cfg(test)]
-pub(crate) static GLOBAL_TEST_ENV_LOCK: std::sync::LazyLock<tokio::sync::Mutex<()>> =
-    std::sync::LazyLock::new(|| tokio::sync::Mutex::new(()));
+pub(crate) static GLOBAL_TEST_ENV_LOCK: std::sync::LazyLock<&'static tokio::sync::Mutex<()>> =
+    std::sync::LazyLock::new(|| &crate::test_support::cwd::CWD_LOCK);
 
 #[allow(clippy::await_holding_refcell_ref)] // single-threaded LocalSet — no concurrent mutations
 mod acp;
@@ -10794,6 +10794,7 @@ mod tests {
 
     #[test]
     fn plan_list_renders_visible_completed_and_openspec_sections() {
+        let _guard = crate::test_support::cwd::lock();
         let cwd = tempfile::tempdir().unwrap();
         let previous_cwd = std::env::current_dir().unwrap();
         std::env::set_current_dir(cwd.path()).unwrap();

--- a/core/crates/omegon/src/mqtt_bridge.rs
+++ b/core/crates/omegon/src/mqtt_bridge.rs
@@ -228,9 +228,11 @@ fn project_event(ev: &AgentEvent) -> Option<IpcEventPayload> {
         AgentEvent::SystemNotification { message } => Some(IpcEventPayload::SystemNotification {
             message: message.clone(),
         }),
-        AgentEvent::OperatorCopyBlock { label, text, .. } => Some(IpcEventPayload::SystemNotification {
-            message: format!("{label}: {text}"),
-        }),
+        AgentEvent::OperatorCopyBlock { label, text, .. } => {
+            Some(IpcEventPayload::SystemNotification {
+                message: format!("{label}: {text}"),
+            })
+        }
         AgentEvent::StreamIdle {
             provider,
             model,

--- a/core/crates/omegon/src/observation.rs
+++ b/core/crates/omegon/src/observation.rs
@@ -41,7 +41,7 @@ impl<'a> ObservationNormalizer<'a> {
     ) -> Vec<ObservationEvent> {
         let mut events = Vec::new();
         for call in calls {
-            if call_failed(call, results) {
+            if !call_succeeded(call, results) {
                 continue;
             }
             if call.name == "bash" {
@@ -107,10 +107,10 @@ impl<'a> ObservationNormalizer<'a> {
     }
 }
 
-fn call_failed(call: &ToolCall, results: &[ToolResultEntry]) -> bool {
+fn call_succeeded(call: &ToolCall, results: &[ToolResultEntry]) -> bool {
     results
         .iter()
-        .any(|result| result.call_id == call.id && result.is_error)
+        .any(|result| result.call_id == call.id && !result.is_error)
 }
 
 fn mutation_paths(call: &ToolCall) -> Vec<PathBuf> {
@@ -187,10 +187,54 @@ fn classify_bash_segment(segment: &str) -> Vec<ObservationEvent> {
                 })
                 .collect()
         }
-        _ => Vec::new(),
+        "touch" | "rm" => mutation_paths_from_tokens(&tokens)
+            .into_iter()
+            .map(|path| ObservationEvent::FileMutated {
+                source_tool: format!("bash:{program}"),
+                path,
+            })
+            .collect(),
+        "mv" | "cp" => tokens
+            .last()
+            .filter(|path| !path.starts_with('-'))
+            .map(|path| {
+                vec![ObservationEvent::FileMutated {
+                    source_tool: format!("bash:{program}"),
+                    path: PathBuf::from(path),
+                }]
+            })
+            .unwrap_or_default(),
+        _ => redirect_mutation_targets(&tokens)
+            .into_iter()
+            .map(|path| ObservationEvent::FileMutated {
+                source_tool: "bash:redirection".into(),
+                path,
+            })
+            .collect(),
     }
 }
 
+fn mutation_paths_from_tokens(tokens: &[String]) -> Vec<PathBuf> {
+    tokens
+        .iter()
+        .skip(1)
+        .filter(|token| !token.starts_with('-'))
+        .map(PathBuf::from)
+        .collect()
+}
+
+fn redirect_mutation_targets(tokens: &[String]) -> Vec<PathBuf> {
+    let mut paths = Vec::new();
+    let mut iter = tokens.iter();
+    while let Some(token) = iter.next() {
+        if (token == ">" || token == ">>")
+            && let Some(path) = iter.next()
+        {
+            paths.push(PathBuf::from(path));
+        }
+    }
+    paths
+}
 fn read_paths_from_tokens(tokens: &[String]) -> Vec<PathBuf> {
     let mut paths = Vec::new();
     let mut skip_next = false;
@@ -332,6 +376,43 @@ mod tests {
             &[error_result()],
         );
         assert!(events.is_empty());
+    }
+
+    #[test]
+    fn missing_result_records_no_positive_evidence() {
+        let catalog = catalog(vec![("view", vec![ToolCapability::TargetedRepoInspection])]);
+        let events = ObservationNormalizer::new(&catalog)
+            .normalize(&[call("view", json!({"path": "docs/a.md"}))], &[]);
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn bash_mutation_commands_are_observed() {
+        let catalog = catalog(vec![]);
+        let events = ObservationNormalizer::new(&catalog).normalize(
+            &[call(
+                "bash",
+                json!({"command": "touch docs/a.md && mv docs/a.md docs/b.md && echo hi > docs/c.md"}),
+            )],
+            &[ok_result()],
+        );
+        assert_eq!(
+            events,
+            vec![
+                ObservationEvent::FileMutated {
+                    source_tool: "bash:touch".into(),
+                    path: PathBuf::from("docs/a.md"),
+                },
+                ObservationEvent::FileMutated {
+                    source_tool: "bash:mv".into(),
+                    path: PathBuf::from("docs/b.md"),
+                },
+                ObservationEvent::FileMutated {
+                    source_tool: "bash:redirection".into(),
+                    path: PathBuf::from("docs/c.md"),
+                },
+            ]
+        );
     }
 
     #[test]

--- a/core/crates/omegon/src/observation.rs
+++ b/core/crates/omegon/src/observation.rs
@@ -11,6 +11,8 @@ pub(crate) enum ObservationEvent {
     },
     SearchPerformed {
         source_tool: String,
+        query: Option<String>,
+        roots: Vec<PathBuf>,
     },
     FileMutated {
         source_tool: String,
@@ -99,11 +101,52 @@ impl<'a> ObservationNormalizer<'a> {
             } else if caps.contains(&ToolCapability::BroadRepoInspection) {
                 events.push(ObservationEvent::SearchPerformed {
                     source_tool: call.name.clone(),
+                    query: call
+                        .arguments
+                        .get("query")
+                        .and_then(|v| v.as_str())
+                        .map(str::to_string),
+                    roots: search_roots(call),
                 });
             }
         }
 
         events
+    }
+}
+
+fn search_roots(call: &ToolCall) -> Vec<PathBuf> {
+    let mut roots = Vec::new();
+    if let Some(within) = call.arguments.get("within").and_then(|v| v.as_str()) {
+        roots.push(PathBuf::from(within));
+    }
+    if let Some(path) = call.arguments.get("path").and_then(|v| v.as_str()) {
+        roots.push(PathBuf::from(path));
+    }
+    if let Some(paths) = call.arguments.get("paths").and_then(|v| v.as_array()) {
+        roots.extend(paths.iter().filter_map(|v| v.as_str()).map(PathBuf::from));
+    }
+    roots
+}
+
+fn search_query(program: &str, tokens: &[String]) -> Option<String> {
+    match program {
+        "rg" | "grep" => tokens.iter().skip(1).find(|t| !t.starts_with('-')).cloned(),
+        "find" | "fd" | "ls" | "tree" => None,
+        _ => None,
+    }
+}
+
+fn search_roots_from_tokens(program: &str, tokens: &[String]) -> Vec<PathBuf> {
+    let args: Vec<&String> = tokens
+        .iter()
+        .skip(1)
+        .filter(|t| !t.starts_with('-'))
+        .collect();
+    match program {
+        "rg" | "grep" => args.into_iter().skip(1).map(PathBuf::from).collect(),
+        "find" | "fd" | "ls" | "tree" => args.into_iter().map(PathBuf::from).collect(),
+        _ => Vec::new(),
     }
 }
 
@@ -177,6 +220,8 @@ fn classify_bash_segment(segment: &str) -> Vec<ObservationEvent> {
         }
         "rg" | "grep" | "find" | "fd" | "ls" | "tree" => vec![ObservationEvent::SearchPerformed {
             source_tool: format!("bash:{program}"),
+            query: search_query(program, &tokens),
+            roots: search_roots_from_tokens(program, &tokens),
         }],
         "cat" | "head" | "tail" | "sed" | "awk" | "wc" | "nl" | "strings" | "xxd" | "hexdump" => {
             read_paths_from_tokens(&tokens)
@@ -363,7 +408,9 @@ mod tests {
         assert_eq!(
             events,
             vec![ObservationEvent::SearchPerformed {
-                source_tool: "codebase_search".into()
+                source_tool: "codebase_search".into(),
+                query: Some("OrientationChurn".into()),
+                roots: Vec::new(),
             }]
         );
     }
@@ -447,7 +494,12 @@ mod tests {
         assert_eq!(
             events,
             vec![ObservationEvent::SearchPerformed {
-                source_tool: "bash:rg".into()
+                source_tool: "bash:rg".into(),
+                query: Some("OrientationChurn".into()),
+                roots: vec![
+                    PathBuf::from("core/crates/omegon/src"),
+                    PathBuf::from("docs")
+                ],
             }]
         );
     }

--- a/core/crates/omegon/src/observation.rs
+++ b/core/crates/omegon/src/observation.rs
@@ -5,11 +5,24 @@ use std::path::PathBuf;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum ObservationEvent {
-    FileRead { path: PathBuf },
-    SearchPerformed,
-    FileMutated { path: PathBuf },
-    ValidationRun,
-    ProgressBoundary { clears_mutation_state: bool },
+    FileRead {
+        source_tool: String,
+        path: PathBuf,
+    },
+    SearchPerformed {
+        source_tool: String,
+    },
+    FileMutated {
+        source_tool: String,
+        path: PathBuf,
+    },
+    ValidationRun {
+        source_tool: String,
+    },
+    ProgressBoundary {
+        source_tool: String,
+        clears_mutation_state: bool,
+    },
 }
 
 pub(crate) struct ObservationNormalizer<'a> {
@@ -46,6 +59,7 @@ impl<'a> ObservationNormalizer<'a> {
 
         if caps.contains(&ToolCapability::ProgressBoundary) || call.name == "commit" {
             events.push(ObservationEvent::ProgressBoundary {
+                source_tool: call.name.clone(),
                 clears_mutation_state: call.name == "commit",
             });
         }
@@ -54,12 +68,17 @@ impl<'a> ObservationNormalizer<'a> {
             || matches!(call.name.as_str(), "change" | "write" | "edit")
         {
             for path in mutation_paths(call) {
-                events.push(ObservationEvent::FileMutated { path });
+                events.push(ObservationEvent::FileMutated {
+                    source_tool: call.name.clone(),
+                    path,
+                });
             }
         }
 
         if caps.contains(&ToolCapability::Validation) {
-            events.push(ObservationEvent::ValidationRun);
+            events.push(ObservationEvent::ValidationRun {
+                source_tool: call.name.clone(),
+            });
         }
 
         let is_repo_inspection = caps.iter().any(|cap| {
@@ -74,10 +93,13 @@ impl<'a> ObservationNormalizer<'a> {
         if is_repo_inspection {
             if let Some(path) = call.arguments.get("path").and_then(|v| v.as_str()) {
                 events.push(ObservationEvent::FileRead {
+                    source_tool: call.name.clone(),
                     path: PathBuf::from(path),
                 });
             } else if caps.contains(&ToolCapability::BroadRepoInspection) {
-                events.push(ObservationEvent::SearchPerformed);
+                events.push(ObservationEvent::SearchPerformed {
+                    source_tool: call.name.clone(),
+                });
             }
         }
 
@@ -126,6 +148,7 @@ fn classify_bash_segment(segment: &str) -> Vec<ObservationEvent> {
     match program {
         "git" | "jj" if tokens.get(1).is_some_and(|arg| arg == "commit") => {
             vec![ObservationEvent::ProgressBoundary {
+                source_tool: "bash".into(),
                 clears_mutation_state: true,
             }]
         }
@@ -134,23 +157,34 @@ fn classify_bash_segment(segment: &str) -> Vec<ObservationEvent> {
                 matches!(arg.as_str(), "test" | "check" | "clippy" | "build")
             }) =>
         {
-            vec![ObservationEvent::ValidationRun]
+            vec![ObservationEvent::ValidationRun {
+                source_tool: "bash".into(),
+            }]
         }
         "just"
             if tokens.get(1).is_some_and(|arg| {
                 arg.starts_with("test") || matches!(arg.as_str(), "lint" | "check" | "build")
             }) =>
         {
-            vec![ObservationEvent::ValidationRun]
+            vec![ObservationEvent::ValidationRun {
+                source_tool: "bash".into(),
+            }]
         }
         "npm" | "pnpm" | "yarn" if tokens.iter().any(|arg| arg == "test" || arg == "check") => {
-            vec![ObservationEvent::ValidationRun]
+            vec![ObservationEvent::ValidationRun {
+                source_tool: "bash".into(),
+            }]
         }
-        "rg" | "grep" | "find" | "fd" | "ls" | "tree" => vec![ObservationEvent::SearchPerformed],
+        "rg" | "grep" | "find" | "fd" | "ls" | "tree" => vec![ObservationEvent::SearchPerformed {
+            source_tool: format!("bash:{program}"),
+        }],
         "cat" | "head" | "tail" | "sed" | "awk" | "wc" | "nl" | "strings" | "xxd" | "hexdump" => {
             read_paths_from_tokens(&tokens)
                 .into_iter()
-                .map(|path| ObservationEvent::FileRead { path })
+                .map(|path| ObservationEvent::FileRead {
+                    source_tool: format!("bash:{program}"),
+                    path,
+                })
                 .collect()
         }
         _ => Vec::new(),
@@ -263,6 +297,7 @@ mod tests {
         assert_eq!(
             events,
             vec![ObservationEvent::FileRead {
+                source_tool: "view".into(),
                 path: PathBuf::from("docs/a.md")
             }]
         );
@@ -281,7 +316,12 @@ mod tests {
             )],
             &[ok_result()],
         );
-        assert_eq!(events, vec![ObservationEvent::SearchPerformed]);
+        assert_eq!(
+            events,
+            vec![ObservationEvent::SearchPerformed {
+                source_tool: "codebase_search".into()
+            }]
+        );
     }
 
     #[test]
@@ -307,6 +347,7 @@ mod tests {
         assert_eq!(
             events,
             vec![ObservationEvent::FileRead {
+                source_tool: "bash:sed".into(),
                 path: PathBuf::from("core/crates/omegon/src/conversation.rs")
             }]
         );
@@ -322,7 +363,12 @@ mod tests {
             )],
             &[ok_result()],
         );
-        assert_eq!(events, vec![ObservationEvent::SearchPerformed]);
+        assert_eq!(
+            events,
+            vec![ObservationEvent::SearchPerformed {
+                source_tool: "bash:rg".into()
+            }]
+        );
     }
 
     #[test]
@@ -338,8 +384,11 @@ mod tests {
         assert_eq!(
             events,
             vec![
-                ObservationEvent::ValidationRun,
+                ObservationEvent::ValidationRun {
+                    source_tool: "bash".into(),
+                },
                 ObservationEvent::ProgressBoundary {
+                    source_tool: "bash".into(),
                     clears_mutation_state: true,
                 },
             ]

--- a/core/crates/omegon/src/observation.rs
+++ b/core/crates/omegon/src/observation.rs
@@ -1,0 +1,358 @@
+use crate::behavior::ToolCapabilityCatalog;
+use crate::conversation::{ToolCall, ToolResultEntry};
+use omegon_traits::ToolCapability;
+use std::path::PathBuf;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ObservationEvent {
+    FileRead { path: PathBuf },
+    SearchPerformed,
+    FileMutated { path: PathBuf },
+    ValidationRun,
+    ProgressBoundary { clears_mutation_state: bool },
+}
+
+pub(crate) struct ObservationNormalizer<'a> {
+    catalog: &'a ToolCapabilityCatalog,
+}
+
+impl<'a> ObservationNormalizer<'a> {
+    pub(crate) fn new(catalog: &'a ToolCapabilityCatalog) -> Self {
+        Self { catalog }
+    }
+
+    pub(crate) fn normalize(
+        &self,
+        calls: &[ToolCall],
+        results: &[ToolResultEntry],
+    ) -> Vec<ObservationEvent> {
+        let mut events = Vec::new();
+        for call in calls {
+            if call_failed(call, results) {
+                continue;
+            }
+            if call.name == "bash" {
+                events.extend(normalize_bash(call));
+                continue;
+            }
+            events.extend(self.normalize_structured_tool(call));
+        }
+        events
+    }
+
+    fn normalize_structured_tool(&self, call: &ToolCall) -> Vec<ObservationEvent> {
+        let mut events = Vec::new();
+        let caps = self.catalog.capabilities_for(&call.name);
+
+        if caps.contains(&ToolCapability::ProgressBoundary) || call.name == "commit" {
+            events.push(ObservationEvent::ProgressBoundary {
+                clears_mutation_state: call.name == "commit",
+            });
+        }
+
+        if caps.contains(&ToolCapability::Mutation)
+            || matches!(call.name.as_str(), "change" | "write" | "edit")
+        {
+            for path in mutation_paths(call) {
+                events.push(ObservationEvent::FileMutated { path });
+            }
+        }
+
+        if caps.contains(&ToolCapability::Validation) {
+            events.push(ObservationEvent::ValidationRun);
+        }
+
+        let is_repo_inspection = caps.iter().any(|cap| {
+            matches!(
+                cap,
+                ToolCapability::RepoInspection
+                    | ToolCapability::TargetedRepoInspection
+                    | ToolCapability::BroadRepoInspection
+            )
+        }) || matches!(call.name.as_str(), "read" | "understand" | "view");
+
+        if is_repo_inspection {
+            if let Some(path) = call.arguments.get("path").and_then(|v| v.as_str()) {
+                events.push(ObservationEvent::FileRead {
+                    path: PathBuf::from(path),
+                });
+            } else if caps.contains(&ToolCapability::BroadRepoInspection) {
+                events.push(ObservationEvent::SearchPerformed);
+            }
+        }
+
+        events
+    }
+}
+
+fn call_failed(call: &ToolCall, results: &[ToolResultEntry]) -> bool {
+    results
+        .iter()
+        .any(|result| result.call_id == call.id && result.is_error)
+}
+
+fn mutation_paths(call: &ToolCall) -> Vec<PathBuf> {
+    let mut paths = Vec::new();
+    if let Some(path) = call.arguments.get("path").and_then(|v| v.as_str()) {
+        paths.push(PathBuf::from(path));
+    }
+    if let Some(edits) = call.arguments.get("edits").and_then(|v| v.as_array()) {
+        for edit in edits {
+            if let Some(path) = edit.get("file").and_then(|v| v.as_str()) {
+                paths.push(PathBuf::from(path));
+            }
+        }
+    }
+    paths
+}
+
+fn normalize_bash(call: &ToolCall) -> Vec<ObservationEvent> {
+    let Some(command) = call.arguments.get("command").and_then(|v| v.as_str()) else {
+        return Vec::new();
+    };
+    command
+        .split(['\n', ';', '|'])
+        .flat_map(|segment| segment.split("&&"))
+        .flat_map(|segment| segment.split("||"))
+        .flat_map(classify_bash_segment)
+        .collect()
+}
+
+fn classify_bash_segment(segment: &str) -> Vec<ObservationEvent> {
+    let tokens = shell_words(segment);
+    let Some(program) = tokens.first().map(String::as_str) else {
+        return Vec::new();
+    };
+    match program {
+        "git" | "jj" if tokens.get(1).is_some_and(|arg| arg == "commit") => {
+            vec![ObservationEvent::ProgressBoundary {
+                clears_mutation_state: true,
+            }]
+        }
+        "cargo"
+            if tokens.get(1).is_some_and(|arg| {
+                matches!(arg.as_str(), "test" | "check" | "clippy" | "build")
+            }) =>
+        {
+            vec![ObservationEvent::ValidationRun]
+        }
+        "just"
+            if tokens.get(1).is_some_and(|arg| {
+                arg.starts_with("test") || matches!(arg.as_str(), "lint" | "check" | "build")
+            }) =>
+        {
+            vec![ObservationEvent::ValidationRun]
+        }
+        "npm" | "pnpm" | "yarn" if tokens.iter().any(|arg| arg == "test" || arg == "check") => {
+            vec![ObservationEvent::ValidationRun]
+        }
+        "rg" | "grep" | "find" | "fd" | "ls" | "tree" => vec![ObservationEvent::SearchPerformed],
+        "cat" | "head" | "tail" | "sed" | "awk" | "wc" | "nl" | "strings" | "xxd" | "hexdump" => {
+            read_paths_from_tokens(&tokens)
+                .into_iter()
+                .map(|path| ObservationEvent::FileRead { path })
+                .collect()
+        }
+        _ => Vec::new(),
+    }
+}
+
+fn read_paths_from_tokens(tokens: &[String]) -> Vec<PathBuf> {
+    let mut paths = Vec::new();
+    let mut skip_next = false;
+    for token in tokens.iter().skip(1) {
+        if skip_next {
+            skip_next = false;
+            continue;
+        }
+        if token == ">" || token == ">>" || token == "<" {
+            skip_next = token != "<";
+            continue;
+        }
+        if token.starts_with('-') || token.contains('=') || token.parse::<usize>().is_ok() {
+            continue;
+        }
+        if token.contains('/') || token.contains('.') {
+            paths.push(PathBuf::from(token));
+        }
+    }
+    paths
+}
+
+fn shell_words(input: &str) -> Vec<String> {
+    let mut words = Vec::new();
+    let mut current = String::new();
+    let mut quote: Option<char> = None;
+    let mut chars = input.chars().peekable();
+    while let Some(ch) = chars.next() {
+        match (quote, ch) {
+            (Some(q), c) if c == q => quote = None,
+            (None, '\'' | '"') => quote = Some(ch),
+            (None, c) if c.is_whitespace() => {
+                if !current.is_empty() {
+                    words.push(std::mem::take(&mut current));
+                }
+            }
+            (_, '\\') => {
+                if let Some(next) = chars.next() {
+                    current.push(next);
+                }
+            }
+            _ => current.push(ch),
+        }
+    }
+    if !current.is_empty() {
+        words.push(current);
+    }
+    words
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use omegon_traits::ToolDefinition;
+    use serde_json::json;
+
+    fn catalog(defs: Vec<(&str, Vec<ToolCapability>)>) -> ToolCapabilityCatalog {
+        ToolCapabilityCatalog::from_tool_defs(
+            &defs
+                .into_iter()
+                .map(|(name, capabilities)| ToolDefinition {
+                    name: name.into(),
+                    label: String::new(),
+                    description: String::new(),
+                    parameters: json!({}),
+                    capabilities,
+                })
+                .collect::<Vec<_>>(),
+        )
+    }
+
+    fn call(name: &str, arguments: serde_json::Value) -> ToolCall {
+        ToolCall {
+            id: "1".into(),
+            name: name.into(),
+            arguments,
+        }
+    }
+
+    fn ok_result() -> ToolResultEntry {
+        ToolResultEntry {
+            call_id: "1".into(),
+            tool_name: String::new(),
+            content: Vec::new(),
+            is_error: false,
+            args_summary: None,
+        }
+    }
+
+    fn error_result() -> ToolResultEntry {
+        ToolResultEntry {
+            is_error: true,
+            ..ok_result()
+        }
+    }
+
+    #[test]
+    fn targeted_repo_inspection_records_file_read() {
+        let catalog = catalog(vec![("view", vec![ToolCapability::TargetedRepoInspection])]);
+        let events = ObservationNormalizer::new(&catalog).normalize(
+            &[call("view", json!({"path": "docs/a.md"}))],
+            &[ok_result()],
+        );
+        assert_eq!(
+            events,
+            vec![ObservationEvent::FileRead {
+                path: PathBuf::from("docs/a.md")
+            }]
+        );
+    }
+
+    #[test]
+    fn broad_repo_inspection_records_search_not_file_read() {
+        let catalog = catalog(vec![(
+            "codebase_search",
+            vec![ToolCapability::BroadRepoInspection],
+        )]);
+        let events = ObservationNormalizer::new(&catalog).normalize(
+            &[call(
+                "codebase_search",
+                json!({"query": "OrientationChurn"}),
+            )],
+            &[ok_result()],
+        );
+        assert_eq!(events, vec![ObservationEvent::SearchPerformed]);
+    }
+
+    #[test]
+    fn failed_call_records_no_positive_evidence() {
+        let catalog = catalog(vec![("view", vec![ToolCapability::TargetedRepoInspection])]);
+        let events = ObservationNormalizer::new(&catalog).normalize(
+            &[call("view", json!({"path": "docs/a.md"}))],
+            &[error_result()],
+        );
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn bash_sed_records_file_read() {
+        let catalog = catalog(vec![]);
+        let events = ObservationNormalizer::new(&catalog).normalize(
+            &[call(
+                "bash",
+                json!({"command": "sed -n '1,80p' core/crates/omegon/src/conversation.rs"}),
+            )],
+            &[ok_result()],
+        );
+        assert_eq!(
+            events,
+            vec![ObservationEvent::FileRead {
+                path: PathBuf::from("core/crates/omegon/src/conversation.rs")
+            }]
+        );
+    }
+
+    #[test]
+    fn bash_search_records_search() {
+        let catalog = catalog(vec![]);
+        let events = ObservationNormalizer::new(&catalog).normalize(
+            &[call(
+                "bash",
+                json!({"command": "rg OrientationChurn core/crates/omegon/src docs"}),
+            )],
+            &[ok_result()],
+        );
+        assert_eq!(events, vec![ObservationEvent::SearchPerformed]);
+    }
+
+    #[test]
+    fn bash_validation_and_commit_are_observed() {
+        let catalog = catalog(vec![]);
+        let events = ObservationNormalizer::new(&catalog).normalize(
+            &[call(
+                "bash",
+                json!({"command": "cargo test -p omegon pressure_behavior --locked && git commit -m 'fix: x'"}),
+            )],
+            &[ok_result()],
+        );
+        assert_eq!(
+            events,
+            vec![
+                ObservationEvent::ValidationRun,
+                ObservationEvent::ProgressBoundary {
+                    clears_mutation_state: true,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn unknown_bash_program_is_opaque() {
+        let catalog = catalog(vec![]);
+        let events = ObservationNormalizer::new(&catalog).normalize(
+            &[call("bash", json!({"command": "custom-tool --flag value"}))],
+            &[ok_result()],
+        );
+        assert!(events.is_empty());
+    }
+}

--- a/core/crates/omegon/src/plugins/http_feature.rs
+++ b/core/crates/omegon/src/plugins/http_feature.rs
@@ -353,9 +353,27 @@ mod tests {
         .unwrap();
 
         let feature = HttpPluginFeature::new(manifest);
-        // Set cwd to the temp dir so the local file is found
-        let old_cwd = std::env::current_dir().unwrap();
-        std::env::set_current_dir(dir.path()).unwrap();
+        // Set cwd to the temp dir so the local file is found. Hold the shared
+        // CWD lock and restore via RAII so a panic cannot leave the process in
+        // a deleted tempdir and poison unrelated tests.
+        struct CwdRestore {
+            original: std::path::PathBuf,
+            _guard: tokio::sync::MutexGuard<'static, ()>,
+        }
+        impl Drop for CwdRestore {
+            fn drop(&mut self) {
+                let _ = std::env::set_current_dir(&self.original);
+            }
+        }
+        let _cwd = {
+            let guard = crate::test_support::cwd::lock();
+            let original = std::env::current_dir().unwrap();
+            std::env::set_current_dir(dir.path()).unwrap();
+            CwdRestore {
+                original,
+                _guard: guard,
+            }
+        };
 
         let signals = ContextSignals {
             user_prompt: "",
@@ -370,7 +388,5 @@ mod tests {
         let injection = ctx.unwrap();
         assert!(injection.content.contains("partnership: acme"));
         assert_eq!(injection.ttl_turns, 15);
-
-        std::env::set_current_dir(old_cwd).unwrap();
     }
 }

--- a/core/crates/omegon/src/providers.rs
+++ b/core/crates/omegon/src/providers.rs
@@ -2308,16 +2308,16 @@ fn copilot_responses_input_from_chat_messages(messages: &[Value]) -> Vec<Value> 
             .unwrap_or("user");
         match role {
             "assistant" => {
-                if let Some(content) = message.get("content").and_then(Value::as_str) {
-                    if !content.trim().is_empty() {
-                        input.push(json!({
-                            "role": "assistant",
-                            "content": [{"type": "output_text", "text": content, "annotations": []}],
-                            "id": "msg_123",
-                            "status": "completed",
-                            "type": "message",
-                        }));
-                    }
+                if let Some(content) = message.get("content").and_then(Value::as_str)
+                    && !content.trim().is_empty()
+                {
+                    input.push(json!({
+                        "role": "assistant",
+                        "content": [{"type": "output_text", "text": content, "annotations": []}],
+                        "id": "msg_123",
+                        "status": "completed",
+                        "type": "message",
+                    }));
                 }
                 if let Some(tool_calls) = message.get("tool_calls").and_then(Value::as_array) {
                     for call in tool_calls {
@@ -2467,10 +2467,9 @@ fn parse_copilot_responses_completion(value: &Value) -> anyhow::Result<CopilotPa
                         if matches!(
                             part.get("type").and_then(Value::as_str),
                             Some("output_text")
-                        ) {
-                            if let Some(text) = part.get("text").and_then(Value::as_str) {
-                                content_parts.push(text.to_string());
-                            }
+                        ) && let Some(text) = part.get("text").and_then(Value::as_str)
+                        {
+                            content_parts.push(text.to_string());
                         }
                     }
                 }

--- a/core/crates/omegon/src/providers.rs
+++ b/core/crates/omegon/src/providers.rs
@@ -6192,8 +6192,15 @@ mod tests {
 
     #[tokio::test]
     async fn compat_endpoints_are_reachable_and_speak_openai_protocol() {
+        if std::env::var_os("OMEGON_LIVE_ENDPOINT_PROBES").is_none() {
+            eprintln!(
+                "skipping live compat endpoint probes; set OMEGON_LIVE_ENDPOINT_PROBES=1 to run"
+            );
+            return;
+        }
+
         // Probe every non-local OpenAI-compatible endpoint without auth.
-        // This is a free validation that base URLs are correct.
+        // This is a live validation that base URLs are correct.
         // HuggingFace excluded: returns HTML on 401 (auth page).
         // Perplexity excluded: returns 404 on unauthenticated probe.
         // Both work correctly with valid tokens.

--- a/core/crates/omegon/src/providers.rs
+++ b/core/crates/omegon/src/providers.rs
@@ -2251,7 +2251,11 @@ fn copilot_model_requires_responses_api(model: &str) -> bool {
     matches!(model.trim(), "gpt-5.5")
 }
 
-fn build_copilot_chat_completions_body(model: &str, wire_msgs: &[Value], wire_tools: &[Value]) -> Value {
+fn build_copilot_chat_completions_body(
+    model: &str,
+    wire_msgs: &[Value],
+    wire_tools: &[Value],
+) -> Value {
     let mut body = json!({
         "model": model,
         "messages": wire_msgs,
@@ -2460,7 +2464,10 @@ fn parse_copilot_responses_completion(value: &Value) -> anyhow::Result<CopilotPa
             Some("message") => {
                 if let Some(parts) = item.get("content").and_then(Value::as_array) {
                     for part in parts {
-                        if matches!(part.get("type").and_then(Value::as_str), Some("output_text")) {
+                        if matches!(
+                            part.get("type").and_then(Value::as_str),
+                            Some("output_text")
+                        ) {
                             if let Some(text) = part.get("text").and_then(Value::as_str) {
                                 content_parts.push(text.to_string());
                             }
@@ -4428,7 +4435,10 @@ mod tests {
     fn model_id_from_spec_or_default_handles_empty_copilot_routes() {
         assert_eq!(model_id_from_spec("github-copilot:gpt-5.4"), "gpt-5.4");
         assert_eq!(model_id_from_spec_or_default(None, "gpt-5.4"), "gpt-5.4");
-        assert_eq!(model_id_from_spec_or_default(Some(""), "gpt-5.4"), "gpt-5.4");
+        assert_eq!(
+            model_id_from_spec_or_default(Some(""), "gpt-5.4"),
+            "gpt-5.4"
+        );
         assert_eq!(
             model_id_from_spec_or_default(Some("github-copilot:"), "gpt-5.4"),
             "gpt-5.4"

--- a/core/crates/omegon/src/skills.rs
+++ b/core/crates/omegon/src/skills.rs
@@ -1093,13 +1093,18 @@ path = "{skill_path}"
 
     struct CwdRestore {
         original: std::path::PathBuf,
+        _guard: tokio::sync::MutexGuard<'static, ()>,
     }
 
     impl CwdRestore {
         fn enter(path: &std::path::Path) -> Self {
+            let guard = crate::test_support::cwd::lock();
             let original = std::env::current_dir().unwrap();
             std::env::set_current_dir(path).unwrap();
-            Self { original }
+            Self {
+                original,
+                _guard: guard,
+            }
         }
     }
 

--- a/core/crates/omegon/src/skills.rs
+++ b/core/crates/omegon/src/skills.rs
@@ -1408,10 +1408,9 @@ description: Project git override
         )
         .unwrap();
 
-        let original = std::env::current_dir().unwrap();
-        std::env::set_current_dir(dir.path()).unwrap();
+        let _cwd = CwdRestore::enter(dir.path());
         let entries = list_structured().unwrap();
-        std::env::set_current_dir(original).unwrap();
+        drop(_cwd);
 
         let project_git = entries
             .iter()
@@ -1441,10 +1440,9 @@ description: Project git override
         )
         .unwrap();
 
-        let original = std::env::current_dir().unwrap();
-        std::env::set_current_dir(dir.path()).unwrap();
+        let _cwd = CwdRestore::enter(dir.path());
         let details = get_skill_details("git").unwrap();
-        std::env::set_current_dir(original).unwrap();
+        drop(_cwd);
 
         assert_eq!(details.manifest.description, "Project git override");
         let entry = details.entry.expect("resolved listing metadata");

--- a/core/crates/omegon/src/test_support.rs
+++ b/core/crates/omegon/src/test_support.rs
@@ -22,3 +22,22 @@ pub mod env {
         ENV_LOCK.blocking_lock()
     }
 }
+
+#[cfg(test)]
+pub mod cwd {
+    use std::sync::LazyLock;
+
+    /// Global current-working-directory lock for tests that call
+    /// `std::env::set_current_dir`. The process CWD is shared across all test
+    /// threads, and tempdir-backed CWDs disappear when their guard drops.
+    pub static CWD_LOCK: LazyLock<tokio::sync::Mutex<()>> =
+        LazyLock::new(|| tokio::sync::Mutex::new(()));
+
+    pub async fn lock_async() -> tokio::sync::MutexGuard<'static, ()> {
+        CWD_LOCK.lock().await
+    }
+
+    pub fn lock() -> tokio::sync::MutexGuard<'static, ()> {
+        CWD_LOCK.blocking_lock()
+    }
+}

--- a/core/crates/omegon/src/test_support.rs
+++ b/core/crates/omegon/src/test_support.rs
@@ -25,6 +25,7 @@ pub mod env {
 
 #[cfg(test)]
 pub mod cwd {
+    use std::path::{Path, PathBuf};
     use std::sync::LazyLock;
 
     /// Global current-working-directory lock for tests that call
@@ -39,5 +40,41 @@ pub mod cwd {
 
     pub fn lock() -> tokio::sync::MutexGuard<'static, ()> {
         CWD_LOCK.blocking_lock()
+    }
+
+    /// RAII current-directory guard for tests. It holds the shared CWD lock for
+    /// its lifetime and restores the original directory on drop, so panics do
+    /// not leave the process inside a tempdir that gets deleted underneath
+    /// unrelated tests.
+    pub struct CurrentDirGuard {
+        original: PathBuf,
+        _guard: tokio::sync::MutexGuard<'static, ()>,
+    }
+
+    impl CurrentDirGuard {
+        pub fn enter(path: &Path) -> Self {
+            let guard = lock();
+            Self::with_guard(path, guard)
+        }
+
+        pub async fn enter_async(path: &Path) -> Self {
+            let guard = lock_async().await;
+            Self::with_guard(path, guard)
+        }
+
+        fn with_guard(path: &Path, guard: tokio::sync::MutexGuard<'static, ()>) -> Self {
+            let original = std::env::current_dir().expect("current dir");
+            std::env::set_current_dir(path).expect("set current dir");
+            Self {
+                original,
+                _guard: guard,
+            }
+        }
+    }
+
+    impl Drop for CurrentDirGuard {
+        fn drop(&mut self) {
+            let _ = std::env::set_current_dir(&self.original);
+        }
     }
 }

--- a/core/crates/omegon/src/tools/mod.rs
+++ b/core/crates/omegon/src/tools/mod.rs
@@ -482,11 +482,12 @@ impl WorkspaceBoundary {
 
     /// Record a directory as approved for this session.
     pub fn approve_directory(&self, dir: PathBuf) {
+        let canonical = canonicalize_existing_parent(&dir);
         if let Ok(mut approved) = self.session_approved.lock()
-            && !approved.iter().any(|d| d == &dir)
+            && !approved.iter().any(|d| d == &canonical)
         {
-            tracing::info!(dir = %dir.display(), count = approved.len() + 1, "session directory approved");
-            approved.push(dir);
+            tracing::info!(dir = %canonical.display(), count = approved.len() + 1, "session directory approved");
+            approved.push(canonical);
         }
     }
 

--- a/core/crates/omegon/src/tui/segments.rs
+++ b/core/crates/omegon/src/tui/segments.rs
@@ -15,9 +15,10 @@ use super::inline_render::DETAILS_HINT_LABEL;
 use super::theme::Theme;
 use crate::surfaces::conversation::{
     AssistantSegment, BorrowedConversationSegmentProjection, ConversationSegmentKind,
-    ConversationSegmentProjection, ImageSegment, LifecycleSegment, OperatorCopySegment, PeerAgentSegment,
-    PeerAgentSource, PeerAgentStatus, ProjectConversationSegment, SegmentCopyPolicy,
-    SegmentPresentation, SegmentRole, SkillEventSegment, SystemSegment, ToolSegment, UserSegment,
+    ConversationSegmentProjection, ImageSegment, LifecycleSegment, OperatorCopySegment,
+    PeerAgentSegment, PeerAgentSource, PeerAgentStatus, ProjectConversationSegment,
+    SegmentCopyPolicy, SegmentPresentation, SegmentRole, SkillEventSegment, SystemSegment,
+    ToolSegment, UserSegment,
 };
 
 const FILE_URL_ENCODE_SET: &percent_encoding::AsciiSet = &percent_encoding::CONTROLS
@@ -2059,7 +2060,10 @@ status: {}
                 copy_attempt,
                 ..
             } => {
-                let status = copy_attempt.as_ref().map(|s| s.label()).unwrap_or_else(|| "copy available".to_string());
+                let status = copy_attempt
+                    .as_ref()
+                    .map(|s| s.label())
+                    .unwrap_or_else(|| "copy available".to_string());
                 let rendered = format!("{label} · {status}\n{text}");
                 super::segment_components::system::render(
                     super::segment_components::system::SystemRenderProps {

--- a/core/crates/omegon/src/tui/tests.rs
+++ b/core/crates/omegon/src/tui/tests.rs
@@ -7043,7 +7043,7 @@ fn slash_logout_usage_lists_supported_remote_logout_providers() {
     assert!(message.contains("openai"), "got: {message}");
     assert!(message.contains("openai-codex"), "got: {message}");
     assert!(message.contains("openrouter"), "got: {message}");
-    assert!(message.contains("ollama-cloud"), "got: {message}");
+    assert!(!message.contains("ollama-cloud"), "got: {message}");
     assert!(!message.contains("ollama,"), "got: {message}");
 }
 

--- a/core/crates/omegon/src/tui/tests.rs
+++ b/core/crates/omegon/src/tui/tests.rs
@@ -15,14 +15,11 @@ use crate::web::WebDaemonStatus;
 use ratatui::Terminal;
 use ratatui::backend::TestBackend;
 use std::path::{Path, PathBuf};
-use std::sync::{Mutex, MutexGuard};
 use tokio::sync::mpsc;
-
-static CURRENT_DIR_LOCK: Mutex<()> = Mutex::new(());
 
 struct CurrentDirGuard {
     prev: PathBuf,
-    _guard: MutexGuard<'static, ()>,
+    _guard: tokio::sync::MutexGuard<'static, ()>,
 }
 
 impl Drop for CurrentDirGuard {
@@ -32,7 +29,7 @@ impl Drop for CurrentDirGuard {
 }
 
 fn push_current_dir(path: &Path) -> CurrentDirGuard {
-    let guard = CURRENT_DIR_LOCK.lock().expect("current dir lock");
+    let guard = crate::test_support::cwd::lock();
     let prev = std::env::current_dir().expect("current dir");
     std::env::set_current_dir(path).expect("set current dir");
     CurrentDirGuard {

--- a/core/crates/omegon/src/web/api.rs
+++ b/core/crates/omegon/src/web/api.rs
@@ -2502,10 +2502,8 @@ required = ["MISSING_REQUIRED_TOKEN"]
 
     #[tokio::test]
     async fn workspace_leases_status_reports_active_instance_leases() {
-        let _guard = crate::GLOBAL_TEST_ENV_LOCK.lock().await;
         let dir = tempfile::tempdir().unwrap();
-        let previous_cwd = std::env::current_dir().unwrap();
-        std::env::set_current_dir(dir.path()).unwrap();
+        let _cwd = crate::test_support::cwd::CurrentDirGuard::enter_async(dir.path()).await;
         let lease = crate::workspace::types::WorkspaceLease {
             project_id: "project".into(),
             workspace_id: crate::workspace::runtime::workspace_id_from_path(dir.path()),
@@ -2531,7 +2529,6 @@ required = ["MISSING_REQUIRED_TOKEN"]
         crate::workspace::runtime::write_workspace_lease(dir.path(), "test-1", &lease).unwrap();
 
         let response = get_workspace_leases_status().await.unwrap().0;
-        std::env::set_current_dir(previous_cwd).unwrap();
 
         assert_eq!(response.schema_version, 1);
         assert_eq!(response.leases.len(), 1);
@@ -2587,10 +2584,8 @@ required = ["MISSING_REQUIRED_TOKEN"]
 
     #[tokio::test]
     async fn web_attachments_stage_and_read_browser_payload() {
-        let _guard = crate::GLOBAL_TEST_ENV_LOCK.lock().await;
-        let cwd = std::env::current_dir().unwrap();
         let home = tempfile::tempdir().unwrap();
-        std::env::set_current_dir(home.path()).unwrap();
+        let _cwd = crate::test_support::cwd::CurrentDirGuard::enter_async(home.path()).await;
 
         let (status, created) = post_web_attachment(Json(WebAttachmentCreateRequest {
             filename: "note.txt".to_string(),
@@ -2612,8 +2607,6 @@ required = ["MISSING_REQUIRED_TOKEN"]
             fetched.data_base64,
             base64::engine::general_purpose::STANDARD.encode(b"hello")
         );
-
-        std::env::set_current_dir(cwd).unwrap();
     }
 
     #[tokio::test]
@@ -2935,14 +2928,11 @@ required = ["MISSING_REQUIRED_TOKEN"]
 
     #[tokio::test]
     async fn web_sessions_endpoint_lists_default_session() {
-        let _guard = crate::GLOBAL_TEST_ENV_LOCK.lock().await;
-        let cwd = std::env::current_dir().unwrap();
         let home = tempfile::tempdir().unwrap();
-        std::env::set_current_dir(home.path()).unwrap();
+        let _cwd = crate::test_support::cwd::CurrentDirGuard::enter_async(home.path()).await;
 
         let response = get_web_sessions().await.unwrap().0;
 
-        std::env::set_current_dir(cwd).unwrap();
         assert_eq!(response.sessions.len(), 1);
         assert_eq!(response.sessions[0].session_id, "default");
         assert!(response.sessions[0].current);
@@ -2978,10 +2968,8 @@ required = ["MISSING_REQUIRED_TOKEN"]
 
     #[tokio::test]
     async fn web_session_endpoint_404s_missing_session() {
-        let _guard = crate::GLOBAL_TEST_ENV_LOCK.lock().await;
-        let cwd = std::env::current_dir().unwrap();
         let home = tempfile::tempdir().unwrap();
-        std::env::set_current_dir(home.path()).unwrap();
+        let _cwd = crate::test_support::cwd::CurrentDirGuard::enter_async(home.path()).await;
 
         let response = get_web_session(
             axum::extract::State(test_state()),
@@ -2989,7 +2977,6 @@ required = ["MISSING_REQUIRED_TOKEN"]
         )
         .await;
 
-        std::env::set_current_dir(cwd).unwrap();
         assert!(matches!(response, Err(StatusCode::NOT_FOUND)));
     }
 
@@ -3149,31 +3136,25 @@ required = ["MISSING_REQUIRED_TOKEN"]
 
     #[tokio::test]
     async fn assistant_runs_endpoint_returns_empty_runtime_projection() {
-        let _guard = crate::GLOBAL_TEST_ENV_LOCK.lock().await;
-        let cwd = std::env::current_dir().unwrap();
         let home = tempfile::tempdir().unwrap();
-        std::env::set_current_dir(home.path()).unwrap();
+        let _cwd = crate::test_support::cwd::CurrentDirGuard::enter_async(home.path()).await;
         let response = get_assistant_runs(axum::extract::State(test_state()))
             .await
             .unwrap()
             .0;
-        std::env::set_current_dir(cwd).unwrap();
         assert!(response.runs.is_empty());
     }
 
     #[tokio::test]
     async fn assistant_run_endpoint_404s_missing_runtime_run() {
-        let _guard = crate::GLOBAL_TEST_ENV_LOCK.lock().await;
-        let cwd = std::env::current_dir().unwrap();
         let home = tempfile::tempdir().unwrap();
-        std::env::set_current_dir(home.path()).unwrap();
+        let _cwd = crate::test_support::cwd::CurrentDirGuard::enter_async(home.path()).await;
         let err = get_assistant_run(
             axum::extract::State(test_state()),
             axum::extract::Path("missing".into()),
         )
         .await
         .unwrap_err();
-        std::env::set_current_dir(cwd).unwrap();
         assert_eq!(err, StatusCode::NOT_FOUND);
     }
 

--- a/core/crates/omegon/src/web/ws.rs
+++ b/core/crates/omegon/src/web/ws.rs
@@ -2324,7 +2324,12 @@ fn serialize_agent_event(event: &AgentEvent) -> Value {
             "event_name": "system.notification",
             "message": escape_html(message),
         }),
-        AgentEvent::OperatorCopyBlock { label, text, kind, copy_attempt } => json!({
+        AgentEvent::OperatorCopyBlock {
+            label,
+            text,
+            kind,
+            copy_attempt,
+        } => json!({
             "type": "operator_copy_block",
             "event_name": "operator.copy_block",
             "label": escape_html(label),

--- a/docs/harness-loop-guidance-affordances.md
+++ b/docs/harness-loop-guidance-affordances.md
@@ -1,0 +1,228 @@
++++
+title = "Harness Loop Guidance — Design Affordances"
+status = "exploring"
++++
+
+# Harness Loop Guidance — Design Affordances
+
+Companion to `harness-loop-ooda-friction-audit.md`. Defines the architectural
+primitives required to move the guidance system from "brakepads on legitimate
+work" to a controller that can distinguish healthy investigation from churn.
+
+New evidence since the audit (`conversation.rs:349-380`):
+`IntentDocument::update_from_tools` populates `files_read` from **hardcoded
+tool names** (`"read" | "understand"`) and `files_modified` from
+(`"change" | "write" | "edit"`). Reads via `bash` (grep/sed/cat),
+`codebase_search`, and `view` count as *nothing*. The controller's primary
+sensor is blind to most real research activity, and it bypasses the
+capability catalog that every other layer uses. This makes sensor
+unification the foundational affordance — classification fixes built on the
+current sensor inherit its blindness.
+
+## Affordance map
+
+Dependency order: A2 → (A1, A3) → (A4, A5) → (A6, A7, A8).
+
+### A2 — Unified observation layer (foundational)
+
+**Problem it removes:** triple bookkeeping + sensor blindness. Today
+`IntentDocument`, `ControllerState`/drift, and `StuckDetector` each parse raw
+tool calls independently, with different taxonomies (string match vs.
+capability catalog vs. path-normalized hashes).
+
+**Affordance:** a single `ObservationNormalizer` that maps every
+`(ToolCall, ToolResultEntry)` pair → semantic observation events:
+
+```
+ObservationEvent =
+  | FileRead { path, source_tool, novel: bool }
+  | FileMutated { path }
+  | SearchPerformed { scope: Broad | Targeted, novel_hits: usize }
+  | ValidationRun { scope: Broad | Targeted, passed: bool }
+  | ProgressBoundary { kind: Commit | Completion }
+  | ExternalAction { .. }
+```
+
+- Derives classification from `ToolCapabilityCatalog`, never name strings.
+- Classifies `bash` commands into read/search/mutation/validation via a
+  conservative arg classifier (grep/rg/sed -n/cat/ls → read;
+  cargo test/check → validation; git commit → boundary). Unknown → opaque,
+  not "no evidence".
+- `IntentDocument`, drift classification, evidence assessment, and
+  StuckDetector all consume the event stream. One sensor, one truth.
+
+**Cost:** bash arg classification is heuristic and will misclassify edge
+cases. Acceptable: today's baseline is 100% misclassification for bash reads.
+
+### A1 — Task-mode contract (intent channel)
+
+**Problem it removes:** F1/F3 — the controller cannot distinguish "operator
+asked for analysis" from "agent is lost".
+
+**Affordance:** a first-class `TaskMode` on the session/turn:
+
+```
+TaskMode = Implementation | Research | QA | Maintenance
+```
+
+Sources, in precedence order:
+1. Operator declaration (`/mode research`, or per-prompt marker).
+2. Directive classification at turn 0 (the dead-mouse path already has
+   `user_asked_question` heuristics — promote and share them).
+3. Agent self-declaration via the `plan` tool (a plan of read-steps ⇒
+   Research), revisable and audited.
+
+Consumption: drift rules and pressure tiers become **mode-conditional policy
+rows** instead of hardcoded predicates. In Research mode:
+- OrientationChurn, execution pressure, `om_local_first_lock`,
+  evidence-sufficiency convergence: suppressed or thresholds ×3.
+- RepeatedActionFailure, StuckDetector, ValidationThrash: unchanged —
+  genuine pathology in any mode.
+- Deliverable pressure changes shape: "produce findings" not "produce edits".
+
+### A3 — Evidence ledger (discovery-rate model)
+
+**Problem it removes:** F4/F6 — absolute turn thresholds and the perverse
+`files_read <= 2 ⇒ Actionable` gradient that pressures targeted work fastest
+while broad wandering escapes.
+
+**Affordance:** replace scalar file counters with a per-session ledger
+tracking novelty:
+
+- `novelty_rate`: fraction of this turn's observations touching paths/symbols
+  not previously seen (directly computable from `FileRead.novel` /
+  `SearchPerformed.novel_hits`).
+- `revisit_rate`: re-reads of already-seen targets without interleaved
+  mutation/validation (StuckDetector's pattern 1, generalized).
+
+Controller semantics: **high novelty = healthy investigation regardless of
+turn count; falling novelty + no output = churn.** Convergence pressure keys
+on the derivative, not the odometer. `assess_evidence` becomes "novelty has
+decayed below threshold for K turns AND a target hypothesis exists" instead
+of "≤ 2 files read".
+
+### A4 — Vetoable checkpoints (nudge protocol)
+
+**Problem it removes:** F2 — nudges assert facts the harness cannot know
+("You have enough context") and models obey them as scope directives.
+
+**Affordance:** nudges become structured checkpoints with an explicit
+continue path:
+
+- Wording contract: state the *observation* (turns without output, novelty
+  decay), then offer the fork: "Answer now if you have enough evidence;
+  otherwise state in one line what you still need, and continue."
+- A justified continuation is recognized (cheap regex/marker on next
+  assistant text) and **suppresses that nudge class for K turns** — the
+  model can push back without being re-nudged every turn.
+- Escalation only when continuations repeat without novelty (ties into A3).
+
+Never assert epistemic states. The harness observes behavior; the model owns
+the sufficiency judgment; the operator owns the override.
+
+### A5 — Nudge arbiter (single actuator with budget)
+
+**Problem it removes:** F5/F8 — scattered injectors (cascade at
+`loop.rs:1479`, five text-only injectors, StuckDetector) with independent
+counters, no contradiction prevention, and turn-budget consumption.
+
+**Affordance:** one `NudgeArbiter` owning all injection:
+
+- Every candidate nudge is a `(class, priority, message)` submitted to the
+  arbiter; at most one fires per turn (already true for the cascade; not
+  true across cascade + text-only paths).
+- **Consistency memory:** the arbiter records the last directive issued and
+  refuses to issue a semantically contradictory one within K turns (e.g.,
+  dead-mouse "take action now" followed by local-first "stop searching").
+- Per-class caps and a session-wide nudge budget in one place (today:
+  scattered `dead_mouse_nudges`, `meta_recovery_nudges`,
+  `commit_nudged`, `plan_reconciliation_nudges`, `skill_completion_nudged`,
+  `consecutive_warnings`).
+- Nudge turns accounted separately from `max_turns` (or the budget is
+  extended by nudges injected) so guidance doesn't eat the work budget.
+- Single emission point for `BusEvent::NudgeInjected` with class + outcome
+  slot (feeds A7).
+
+### A6 — Phase history (make OODA load-bearing or drop Decide)
+
+**Problem it removes:** F7 — per-turn phase snapshots with no rhythm model;
+Decide rendered but never emitted.
+
+**Affordance:** a phase-history ring on the controller:
+
+- Healthy rhythms (Observe→Orient oscillation while novelty is high;
+  Act→Observe verification loops) are recognized and *exempt* from
+  continuation pressure.
+- `Decide` gets real semantics: emitted when a turn produces
+  reasoning/plan/decision text after evidence-gathering (text +
+  plan-tool calls, no mutation). This is the missing vocabulary for "the
+  model is deliberating" — currently classified as dead-mouse territory.
+- If this is not adopted, remove Decide from the statusline; a control
+  surface must not display states the controller cannot produce.
+
+### A7 — Controller telemetry & outcome tracking
+
+**Problem it removes:** the tuning loop is blind. We cannot currently answer
+"do models comply with, ignore, or over-obey nudges?" except by operator
+anecdote (the motivating symptom of this whole effort).
+
+**Affordance:**
+- Extend `NudgeInjected` with an outcome field resolved on the following
+  turn: `Complied | Truncated | JustifiedContinue | Ignored`.
+  `Truncated` = produced final answer with markedly lower output than the
+  session's evidence trajectory implied (heuristic, flagged not judged).
+- Per-session nudge report in the session log; corpus-level offline
+  evaluation script over session logs to validate the audit's standing
+  [assumption] that nudge text acts as a scope directive.
+- Threshold changes (A3/A8) get evaluated against the corpus before and
+  after. The controller becomes empirically tunable instead of vibes-tuned.
+
+### A8 — Guidance policy as configuration
+
+**Problem it removes:** thresholds are hardcoded tuples inside match arms
+(`continuation_pressure_tier`); every tuning experiment is a recompile.
+
+**Affordance:** a `GuidancePolicy` struct — per `(BehavioralTier, TaskMode)`
+row: pressure tiers, drift turn-thresholds, novelty decay constants, nudge
+class caps, checkpoint cooldowns. Loaded from settings with a Pkl schema
+(consistent with the existing `pkl/` config surface), defaulting to current
+values. Operators who find the leash tight can loosen it without a fork;
+experiments become config diffs.
+
+## What deliberately stays
+
+- StuckDetector's three patterns — the mutation-clears-path and
+  path-normalized hashing design is sound; it just moves onto the A2 event
+  stream.
+- RepeatedActionFailure and dead-mouse detection (with A5 arbitration) —
+  these catch real failure modes across all task modes.
+- The anti-meta-spiral messaging ("do not apologize / self-criticize") —
+  orthogonal to the friction and demonstrably needed for some models.
+- Commit hygiene and plan reconciliation nudges — correct as-is, capped,
+  fire on real closure obligations.
+
+## Sequencing proposal
+
+1. **A2** — sensor unification (largest correctness fix, enables everything).
+2. **A1 + A3** — mode contract + evidence ledger (kills F1/F3/F4/F6).
+3. **A4 + A5** — checkpoint protocol + arbiter (kills F2/F5/F8).
+4. **A7** — telemetry (validates the above empirically).
+5. **A6 + A8** — phase history and policy config (hardening).
+
+Each stage is independently shippable and independently testable against the
+existing `loop.rs` test corpus (~60 tests already cover
+`continuation_pressure_tier` / `should_inject_execution_pressure` behavior
+and will pin regressions).
+
+## Open questions
+
+- [ ] [assumption] Bash arg classification can reach useful precision with a
+  small conservative ruleset — needs a sample of real session bash commands.
+- [ ] Should `TaskMode` be mutually exclusive or a per-turn blend? (A deep
+  dive often ends in a patch; mode transition semantics needed.)
+- [ ] Does justified-continue recognition (A4) need a structured tool/marker,
+  or is text-pattern recognition reliable enough across providers?
+- [ ] Where does `dominant_phase` get computed today, and can the A6 ring
+  reuse it directly? (Still unlocated outside TurnEnd emission sites.)
+- [ ] Nudge-turn budget exemption: exempt entirely, or cap exemptions to
+  avoid unbounded sessions under `Autonomous` automation?

--- a/docs/harness-loop-ooda-friction-audit.md
+++ b/docs/harness-loop-ooda-friction-audit.md
@@ -1,0 +1,167 @@
++++
+title = "Harness Loop OODA & Churn Guidance — Friction Audit"
+status = "exploring"
++++
+
+# Harness Loop OODA & Churn Guidance — Friction Audit
+
+Branch: `deep-dive-agent-harness-ooda`. Audit of the internal nudge/OODA/churn
+control stack. Motivating symptom (operator-reported, multiple instances): the
+agent truncates legitimate work and reports *"I didn't do anything except
+research because the harness told me to."* The guidance layer is acting as
+brakepads on legitimate long-form investigation.
+
+## System inventory (evidence-grounded)
+
+All line references at `main` tip `5cc1c2c6`.
+
+### Layer 1 — Tool capability taxonomy
+`behavior.rs:16-127`. `ToolCapabilityCatalog` maps tool name → capability
+labels (`Orientation`, `RepoInspection` broad/targeted, `Mutation`,
+`Validation`, `StateChanging`, `ProgressBoundary`). Every downstream
+classifier keys off these labels.
+
+### Layer 2 — OODA phase classifier
+`classify_turn_phase` (`behavior.rs:128-185`). Emits Observe/Orient/Act only.
+`OodaPhase::Decide` exists in `omegon-traits` and renders in the statusline
+(`tui/statusline.rs:327`) but is **never emitted** — display fiction.
+
+### Layer 3 — Drift classification
+`classify_drift_kind` (`behavior.rs:187+`). Four kinds:
+
+| Drift | Trigger | Nudge reason |
+|---|---|---|
+| OrientationChurn | no files modified, files read, all-repo-inspection turn, turn ≥ 4, any broad inspection, ≤ 1 targeted | AntiOrientation |
+| OrientationChurn (early) | nothing read/modified, turn ≥ 3, all broad orientation | AntiOrientation |
+| RepeatedActionFailure | ≥ 2 failing mutations, same tool + path | ActionRecovery |
+| ValidationThrash | ≥ 2 validation calls, no files modified, not targeted | ValidationPressure |
+| ClosureStall | files modified but turn all-inspection with broad calls | ClosurePressure |
+
+### Layer 4 — ControllerState streaks
+`behavior.rs:395+`. Per-drift streaks: increment on match, **halve** on
+mismatch (never hard-clear except on Mutation/Commit/Completion).
+TargetedValidation/ConstraintDiscovery halve orientation/continuation, zero
+failure/thrash.
+
+### Layer 5 — Evidence sufficiency
+`assess_evidence` (`behavior.rs:632`). `files_read ≤ 2` + targeted-only reads
+of known paths ⇒ local evidence "Actionable". Feeds
+`local_evidence_sufficient_streak` / `evidence_sufficient_streak`.
+
+### Layer 6 — Behavioral tiers & thresholds
+`behavioral_tier` (`behavior.rs`): Frontier/Max ⇒ Standard, Mid/Leaf ⇒
+Constrained. `continuation_pressure_tier` (`behavior.rs:736-796`) thresholds
+(tier1/2/3 = turns of continuation before pressure):
+
+| Mode | Constrained | Standard |
+|---|---|---|
+| om_local_first_lock (Slim UI + local evidence + read-not-modified) | 2/3/5 | 4/6/8 |
+| evidence_sufficient | 3/4/6 | 6/8/10 |
+| slim execution bias | 4/6/8 | 8/12/16 |
+| default | 3/5/7 | 12/16/20 |
+
+### Layer 7 — Nudge injection cascade
+`loop.rs:1479-1550`, priority order (first match wins, one per turn):
+1. `first_turn_execution_bias` (`is_first_turn_orientation_churn`)
+2. `om_local_first_lock` → "You have enough context. Produce the requested output…"
+3. `evidence_sufficiency` → forced convergence
+4. `execution_pressure` (`should_inject_execution_pressure`, turn ≥ 3-6 by tier)
+5. `continuation_pressure_tier_{1,2,3}`
+
+Plus text-only-turn injectors (`loop.rs:942-1284`):
+- meta-recovery (max 2) — `is_pathological_meta_response`
+- commit hygiene (once/session, near budget or completion language)
+- plan reconciliation (fingerprinted, repeatable)
+- skill phase completion (once/session)
+- dead-mouse auto-continue (max 3; guarded by `should_continue_text_only_turn`
+  — automation level, question detection, completion/blocked detection,
+  `looks_like_continuation_request`)
+
+### Layer 8 — StuckDetector
+`loop.rs:4257+`. Sliding window (10): same-target re-reads ≥ 5 without
+mutation/validation; same tool+args ≥ 3; ≥ 3 consecutive same-tool errors.
+Path-normalized hashing collapses offset/limit variations. Skips detection if
+any mutation/validation appears in window.
+
+Every injected nudge consumes a turn (`TurnEndReason::ProgressNudge`) and
+recomputes/re-emits context composition.
+
+## Friction points
+
+**F1 — Research work is structurally classified as pathology.**
+`files_modified.is_empty()` is the core stall predicate in OrientationChurn,
+execution pressure, `has_local_target_hypothesis`, and evidence sufficiency.
+A directed deep-dive/audit *never* modifies files, so from turn ~4 the
+classifiers read sustained legitimate investigation as drift. The
+`om_local_first_lock` fires precisely on "read files but modified none" —
+i.e., on the definition of research.
+
+**F2 — Nudge wording says "you have enough context" when the harness cannot
+know that.** `evidence_sufficiency_message`, `om_local_first_message`, and
+execution-pressure all assert sufficiency from a 2-files-read heuristic
+(`assess_evidence`: `local_target_count <= 2`). For a deep dive spanning an
+8k-line `loop.rs` and 1k-line `behavior.rs`, 2 files ≠ enough. The model
+obeys the assertion and truncates — producing exactly the reported "the
+harness told me to stop" behavior. Verified live: this audit session received
+`om_local_first_message` after 2 read-turns and answered before finishing the
+planned reads.
+
+**F3 — No task-intent input.** `IntentDocument.lifecycle_phase` exists but
+`classify_drift_kind` / pressure tiers consult only files_read/modified and
+tool labels. "Operator asked for analysis" is indistinguishable from "agent
+is lost." The dead-mouse path *does* parse operator prompts
+(`user_asked_question` heuristics) — the drift path does not.
+
+**F4 — Absolute turn thresholds.** `turn >= 4` fires identically for a typo
+fix and a multi-thousand-line subsystem audit. No scaling by evidence
+accumulation rate, file sizes, or directive complexity.
+
+**F5 — Nudges consume budget.** Each nudge burns a turn against `max_turns`
+plus prompt mass. Worst case per session: 2 meta + 3 dead-mouse + 1 commit +
+N plan-reconciliation + 1 skill + per-turn drift nudges.
+
+**F6 — evidence_sufficient "streak" is a misnomer.** `local <= 2 files read`
+⇒ Actionable; a *broad* investigation (many files) yields
+`EvidenceSufficiency::None` — paradoxically, reading *more* protects you
+from convergence pressure while a tight targeted read triggers it fastest.
+The incentive gradient points the wrong way for focused work.
+
+**F7 — OODA Decide phase is dead.** Emitted nowhere; statusline renders a
+4-phase model the classifier can't produce. Cosmetic debt, but it also means
+no "deliberation" state exists between Observe and forced Act — the control
+model literally has no vocabulary for "still deciding."
+
+**F8 — Priority cascade can double-tap.** A dead-mouse nudge on a text turn
+followed by an om_local_first nudge on the next tool turn gives the model two
+contradictory instructions within two turns ("take action now" then "stop
+searching, answer now"). Verified live in this session.
+
+## Fix directions (not yet decided)
+
+1. **Task-mode signal.** Infer or accept operator declaration of
+   research/analysis mode; suppress OrientationChurn + execution pressure +
+   om_local_first_lock while active. Keep RepeatedActionFailure, StuckDetector,
+   ValidationThrash (genuine pathology regardless of mode).
+2. **Honest wording.** Replace "You have enough context" with a question the
+   model can veto: "If you have enough evidence, answer now; if not, state
+   what you still need and continue." Assertion → checkpoint.
+3. **Evidence-relative thresholds.** Scale tier thresholds by
+   novel-information rate (new files/paths per turn) instead of absolute turn
+   counts; a session still discovering new targets is not churning.
+4. **Nudge budget accounting.** Cap total injected nudges per session and/or
+   exempt nudge turns from `max_turns`.
+5. **Fix or remove Decide.** Either emit it (e.g., text-only turn with
+   reasoning after evidence gathering) or drop it from the statusline.
+
+## Open questions
+
+- [ ] [assumption] The model treats nudge text as scope directive rather than
+  hint — inferred from operator reports + one live observation; needs session
+  log corpus confirmation.
+- [ ] Where does `dominant_phase` get computed per turn, and is phase
+  *history* consulted anywhere? (Believed no — unverified.)
+- [ ] Does `should_nudge_plan_reconciliation` loop indefinitely on a
+  fingerprint-stable plan? (`plan_reconciliation_nudges` counts but cap not
+  yet located.)
+- [ ] What writes `intent.files_read` — do `codebase_search`/`view` count, or
+  only `read`? Determines how often research undercounts as "no evidence."

--- a/docs/harness-loop-ooda-friction-audit.md
+++ b/docs/harness-loop-ooda-friction-audit.md
@@ -160,8 +160,11 @@ searching, answer now"). Verified live in this session.
   log corpus confirmation.
 - [ ] Where does `dominant_phase` get computed per turn, and is phase
   *history* consulted anywhere? (Believed no — unverified.)
-- [ ] Does `should_nudge_plan_reconciliation` loop indefinitely on a
-  fingerprint-stable plan? (`plan_reconciliation_nudges` counts but cap not
-  yet located.)
-- [ ] What writes `intent.files_read` — do `codebase_search`/`view` count, or
-  only `read`? Determines how often research undercounts as "no evidence."
+- [x] ~~Does `should_nudge_plan_reconciliation` loop indefinitely?~~ No —
+  capped by `MAX_PLAN_RECONCILIATION_NUDGES` (`loop.rs:4206`).
+- [x] ~~What writes `intent.files_read`?~~ **Resolved, and it's F9:** only
+  hardcoded names `"read" | "understand"` count (`conversation.rs:353-357`).
+  `bash` grep/sed reads, `codebase_search`, and `view` register zero
+  evidence, and the string match bypasses the capability catalog. Research
+  via bash appears to the controller as "read nothing" — worst-case
+  classification. See `harness-loop-guidance-affordances.md` (A2).

--- a/openspec/changes/a3-evidence-ledger/proposal.md
+++ b/openspec/changes/a3-evidence-ledger/proposal.md
@@ -1,0 +1,24 @@
+# A3 evidence ledger
+
+## Intent
+
+Replace scalar evidence-convergence thresholds with a per-session discovery-rate ledger so guidance distinguishes healthy investigation from repeated low-novelty churn.
+
+## Scope
+
+- Track per-turn observation totals, novel file reads, revisits, searches, and mutation/validation boundaries.
+- Feed the ledger from normalized observation events in `IntentDocument::update_from_tools`.
+- Use the ledger in evidence assessment so targeted reads become actionable only after novelty decays for repeated turns, not merely because few files were read.
+- Preserve mutation/validation/failure-driven actionability.
+
+## Out of scope
+
+- A4 vetoable checkpoint wording.
+- A5 nudge arbiter consolidation.
+- Symbol-level novelty and search hit counts beyond the minimal A3 path/search ledger.
+
+## Success criteria
+
+- Novel file discovery keeps evidence below forced-convergence actionability.
+- Repeated revisits to known targets without mutation/validation make a known target hypothesis actionable.
+- Mutation and validation boundaries reset/interrupt revisit decay.

--- a/openspec/changes/a3-evidence-ledger/specs/harness-guidance/evidence-ledger.md
+++ b/openspec/changes/a3-evidence-ledger/specs/harness-guidance/evidence-ledger.md
@@ -1,0 +1,41 @@
+# Harness Guidance Evidence Ledger — Delta Spec
+
+## ADDED Requirements
+
+### Requirement: Evidence ledger tracks discovery rate
+
+The guidance loop must maintain a per-session evidence ledger derived from normalized observation events.
+
+#### Scenario: Novel reads record discovery
+Given a successful read observation for a path not previously observed
+When guidance state updates from tool calls
+Then the evidence ledger records the path as novel for that turn
+And the turn's novelty rate is greater than zero
+
+#### Scenario: Repeated reads record revisit churn
+Given a path was already read in an earlier turn
+When a later turn reads the same path without an intervening mutation or validation
+Then the evidence ledger records a revisit for that turn
+And the turn can contribute to low-novelty streaks
+
+#### Scenario: Mutation and validation interrupt revisit decay
+Given the evidence ledger has low-novelty revisit turns
+When a mutation or validation observation is recorded
+Then the low-novelty streak is interrupted
+
+### Requirement: Evidence convergence uses novelty decay
+
+The guidance loop must not treat a small number of read files as actionable evidence by itself.
+
+#### Scenario: First targeted read is not actionable by count alone
+Given no files have been modified
+And the agent reads one targeted file successfully for the first time
+When evidence is assessed
+Then local evidence is targeted, not actionable
+And global evidence is not actionable
+
+#### Scenario: Repeated low-novelty revisits become actionable
+Given no files have been modified
+And the agent repeatedly rereads a known targeted file across multiple turns without mutation or validation
+When evidence is assessed for that target
+Then local evidence is actionable

--- a/openspec/changes/a3-evidence-ledger/tasks.md
+++ b/openspec/changes/a3-evidence-ledger/tasks.md
@@ -1,0 +1,22 @@
+# A3 evidence ledger — Tasks
+
+## 1. Ledger data model
+<!-- specs: harness-guidance/evidence-ledger -->
+
+- [x] 1.1 Add serializable evidence ledger state to `IntentDocument`.
+- [x] 1.2 Track seen paths and per-turn novelty/revisit/mutation-validation summaries.
+- [x] 1.3 Add unit coverage for novel reads, revisits, and boundary interruption.
+
+## 2. Evidence assessment integration
+<!-- specs: harness-guidance/evidence-ledger -->
+
+- [x] 2.1 Feed ledger state from normalized observations.
+- [x] 2.2 Replace `files_read <= 2` actionability with low-novelty target-hypothesis actionability.
+- [x] 2.3 Add regressions for first targeted read vs repeated low-novelty revisits.
+
+## 3. Validation and release memory
+<!-- specs: harness-guidance/evidence-ledger -->
+
+- [x] 3.1 Run focused behavior/conversation tests.
+- [x] 3.2 Run `cargo test -p omegon --locked`.
+- [x] 3.3 Update `CHANGELOG.md`.

--- a/openspec/changes/unified-observation-layer/design.md
+++ b/openspec/changes/unified-observation-layer/design.md
@@ -1,0 +1,49 @@
+# Unified observation layer — Design
+
+## Architecture decisions
+
+### Decision: Add `observation` as a first-class loop module
+
+Create `core/crates/omegon/src/observation.rs` with:
+
+- `ObservationEvent`
+- `ObservationNormalizer`
+- conservative bash classifiers
+- normalization tests independent of `ConversationState`
+
+`main.rs` exposes it with `mod observation;` so guidance code can share the same sensor.
+
+### Decision: Capability catalog is authoritative for non-bash tool classification
+
+Non-bash tools are classified through `ToolCapabilityCatalog` and `ToolCapability` metadata. Name-specific fallbacks stay only where unavoidable for shell programs and legacy compatibility boundaries.
+
+This keeps extension tools from needing bespoke guidance wiring when their tool definitions already declare inspection, mutation, or validation capability.
+
+### Decision: Bash classification is conservative and evidence-positive only on success
+
+Bash commands are parsed segment-by-segment across simple separators (`;`, `&&`, `||`, `|`, newline). The classifier recognizes:
+
+- read programs: `cat`, `head`, `tail`, `sed`, `awk`, `wc`, `nl`, `strings`, `xxd`, `hexdump`
+- search/list programs: `rg`, `grep`, `find`, `fd`, `ls`, `tree`
+- validation programs: `cargo test/check/clippy/build`, `just test*/lint/check`, common package test commands
+- progress boundary: `git commit`, `jj commit`
+
+Unknown commands emit no event. Redirect targets are not counted as reads.
+
+### Decision: A2 only rewires `IntentDocument` initially
+
+The A2 implementation starts by routing `IntentDocument::update_from_tools` through normalized observations, because F9 is directly there and it is the lowest-risk integration point. Drift and StuckDetector can be moved onto the same stream in follow-up changes after the event model is proven.
+
+## File scope
+
+- `core/crates/omegon/src/observation.rs` — new observation event model, normalizer, bash classifier, tests.
+- `core/crates/omegon/src/main.rs` — module declaration.
+- `core/crates/omegon/src/conversation.rs` — replace hardcoded `IntentDocument::update_from_tools` read/mutation/commit parsing with normalized observations.
+- `CHANGELOG.md` — Unreleased entry.
+
+## Compatibility notes
+
+- Existing `files_read` / `files_modified` fields remain the state surface for this stage.
+- Existing commit and plan nudges remain intact.
+- Failed tool results must not create positive evidence.
+- The normalizer should be deterministic and allocation-light; full shell parsing is deliberately not attempted.

--- a/openspec/changes/unified-observation-layer/proposal.md
+++ b/openspec/changes/unified-observation-layer/proposal.md
@@ -1,0 +1,30 @@
+# Unified observation layer
+
+## Intent
+
+Implement A2 from `docs/harness-loop-guidance-affordances.md`: replace scattered raw tool-call parsing with one capability-aware observation normalizer that feeds harness guidance sensors consistently.
+
+This fixes F9: research performed through `bash`, `grep`/`rg`, `sed`, `cat`, `view`, and search tools currently registers as zero file evidence because `IntentDocument::update_from_tools` only counts literal `read`/`understand` calls.
+
+## Scope
+
+- Add a unified `ObservationNormalizer` and semantic `ObservationEvent` model for completed tool calls.
+- Derive non-bash tool classification from `ToolCapabilityCatalog` instead of hardcoded tool-name tables.
+- Add conservative bash command classification for read/search/validation/progress-boundary observations.
+- Route `IntentDocument::update_from_tools` through the observation stream for file-read, mutation, validation, and commit-boundary tracking.
+- Preserve existing StuckDetector patterns and pressure behavior unless the new sensor data changes their inputs.
+- Add focused regressions for F9 and existing behavior compatibility.
+
+## Out of scope
+
+- A1 task-mode policy.
+- A3 novelty-rate/evidence ledger beyond event fields needed by A2.
+- A4/A5 nudge wording or arbiter changes.
+- A6/A7/A8 phase history, nudge outcome telemetry, and Pkl policy config.
+
+## Success criteria
+
+- `view`, `codebase_search`, and targeted capability-catalog tools contribute observation events without name-specific logic in `IntentDocument`.
+- Successful bash read/search commands contribute evidence conservatively; failed commands do not.
+- `git commit` through bash still clears mutation state as a progress boundary.
+- Existing pressure-behavior tests remain green, with new F9 regressions pinned.

--- a/openspec/changes/unified-observation-layer/specs/harness-guidance/observation.md
+++ b/openspec/changes/unified-observation-layer/specs/harness-guidance/observation.md
@@ -1,0 +1,80 @@
+# Harness Guidance Observation — Delta Spec
+
+## ADDED Requirements
+
+### Requirement: Unified observation events
+
+The harness guidance loop must normalize completed tool calls into semantic observation events before updating guidance state.
+
+#### Scenario: Capability-catalog read tool records file evidence
+Given a successful tool call whose tool definition has repo-inspection capability
+And the tool call arguments include `path: "docs/a.md"`
+When the conversation state updates from tool calls
+Then the guidance intent records `docs/a.md` as read evidence
+And the implementation does not require that tool name to be literally `read` or `understand`
+
+#### Scenario: Broad search records search evidence without pretending to read a file
+Given a successful broad repo-inspection tool call with no file path argument
+When observations are normalized
+Then a search observation is emitted
+And no file-read path is added for that search alone
+
+#### Scenario: Failed tool calls produce no positive evidence
+Given a tool call result is marked as an error
+When observations are normalized
+Then no file-read, mutation, validation, or progress-boundary event is emitted for that failed call
+
+### Requirement: Conservative bash observation classification
+
+The harness guidance loop must classify common bash commands into observation events without treating arbitrary shell text as evidence.
+
+#### Scenario: Bash file read records the referenced file
+Given a successful bash command `sed -n '1,80p' core/crates/omegon/src/conversation.rs`
+When observations are normalized
+Then the guidance intent records `core/crates/omegon/src/conversation.rs` as read evidence
+And the sed range argument is not treated as a file path
+
+#### Scenario: Bash search records search evidence
+Given a successful bash command `rg "OrientationChurn" core/crates/omegon/src docs`
+When observations are normalized
+Then a search observation is emitted
+And the search does not add every search-root argument as a read file
+
+#### Scenario: Bash validation records validation activity
+Given a successful bash command `cargo test -p omegon pressure_behavior --locked`
+When observations are normalized
+Then a validation observation is emitted
+
+#### Scenario: Bash commit records a progress boundary
+Given a successful bash command `git commit -m 'fix: example'`
+When observations are normalized
+Then a progress-boundary observation is emitted
+And outstanding modified-file guidance state is cleared
+
+#### Scenario: Unknown bash program is opaque
+Given a successful bash command `custom-tool --flag value`
+When observations are normalized
+Then no positive evidence event is emitted
+
+## MODIFIED Requirements
+
+### Requirement: Guidance state updates use normalized observations
+
+Existing guidance state updates must consume normalized observation events instead of independently parsing raw tool calls with local name tables.
+
+#### Scenario: Intent document no longer has a read-tool allowlist blind spot
+Given a successful `view` tool call with `path: "README.md"`
+When `IntentDocument::update_from_tools` runs
+Then `README.md` is present in `files_read`
+
+#### Scenario: Existing mutation tracking remains compatible
+Given a successful edit-style mutation observation for `src/lib.rs`
+When guidance state updates
+Then `src/lib.rs` is present in `files_modified`
+
+#### Scenario: Bash commit behavior remains compatible
+Given `files_modified` is non-empty
+And a successful bash commit command is observed
+When guidance state updates
+Then `files_modified` is empty
+And commit nudging is reset

--- a/openspec/changes/unified-observation-layer/tasks.md
+++ b/openspec/changes/unified-observation-layer/tasks.md
@@ -6,8 +6,8 @@
 - [x] 1.1 Add `core/crates/omegon/src/observation.rs` and `mod observation;`.
 - [x] 1.2 Define `ObservationEvent` variants for file reads, mutations, searches, validations, and progress boundaries.
 - [x] 1.3 Implement non-bash normalization from `ToolCapabilityCatalog` and successful `ToolResultEntry` matching.
-- [x] 1.4 Implement conservative bash classification for read/search/validation/commit commands.
-- [x] 1.5 Add unit tests for capability-catalog read/search/mutation, failed calls, bash read/search/validation/commit, and unknown bash opacity.
+- [x] 1.4 Implement conservative bash classification for read/search/validation/commit commands plus minimal mutation evidence from `touch`/`rm`/`mv`/`cp` and shell redirects.
+- [x] 1.5 Add unit tests for capability-catalog read/search/mutation, failed and missing results, bash read/search/validation/commit/mutation, and unknown bash opacity.
 
 ## 2. IntentDocument integration
 <!-- specs: harness-guidance/observation -->
@@ -30,3 +30,7 @@
 ## Implementation notes
 
 - The normalizer distinguishes progress boundaries that clear mutation state from non-commit boundaries. Structured `commit` and successful `git commit`/`jj commit` through bash clear `files_modified`; other `ProgressBoundary` tools remain observable without falsely suppressing commit nudges.
+- Positive observation evidence now requires a matching successful `ToolResultEntry`; missing results are treated as incomplete/opaque, not success.
+- A1 currently implements the `Implementation` and `Research` policy rows. `QA` and `Maintenance` remain deferred until there are policy consumers for those modes.
+- A2 intentionally keeps the minimal event schema needed by existing consumers. Novelty, search scope, and richer validation metadata are deferred to A3's evidence-ledger work.
+- Non-bash classification is catalog-first, with legacy built-in name fallbacks retained as a compatibility boundary for existing tools.

--- a/openspec/changes/unified-observation-layer/tasks.md
+++ b/openspec/changes/unified-observation-layer/tasks.md
@@ -1,0 +1,32 @@
+# Unified observation layer — Tasks
+
+## 1. Observation normalizer
+<!-- specs: harness-guidance/observation -->
+
+- [x] 1.1 Add `core/crates/omegon/src/observation.rs` and `mod observation;`.
+- [x] 1.2 Define `ObservationEvent` variants for file reads, mutations, searches, validations, and progress boundaries.
+- [x] 1.3 Implement non-bash normalization from `ToolCapabilityCatalog` and successful `ToolResultEntry` matching.
+- [x] 1.4 Implement conservative bash classification for read/search/validation/commit commands.
+- [x] 1.5 Add unit tests for capability-catalog read/search/mutation, failed calls, bash read/search/validation/commit, and unknown bash opacity.
+
+## 2. IntentDocument integration
+<!-- specs: harness-guidance/observation -->
+
+- [x] 2.1 Replace hardcoded read/mutation/commit parsing in `IntentDocument::update_from_tools` with observation consumption.
+- [x] 2.2 Preserve plan action handling in `IntentDocument::update_from_tools`.
+- [x] 2.3 Preserve failed-approach tracking for error tool results.
+- [x] 2.4 Add regression tests proving `view` and search-capable tools no longer hit the F9 blind spot.
+- [x] 2.5 Add regression tests proving successful bash read and bash commit update guidance state correctly.
+
+## 3. Compatibility validation
+<!-- specs: harness-guidance/observation -->
+
+- [x] 3.1 Run focused observation and conversation tests.
+- [x] 3.2 Run existing pressure/behavior guidance tests affected by `files_read` / `files_modified`.
+- [x] 3.3 Run `cargo check -p omegon --locked`.
+- [x] 3.4 Update `CHANGELOG.md` under `[Unreleased]`.
+
+
+## Implementation notes
+
+- The normalizer distinguishes progress boundaries that clear mutation state from non-commit boundaries. Structured `commit` and successful `git commit`/`jj commit` through bash clear `files_modified`; other `ProgressBoundary` tools remain observable without falsely suppressing commit nudges.


### PR DESCRIPTION
## Summary

Reworks how the harness loop generates guidance pressure, replacing scalar file-count heuristics with an observation-driven pipeline:

- **OODA friction audit + design affordances** (`docs/harness-loop-ooda-friction-audit.md`, `docs/harness-loop-guidance-affordances.md`) — the analysis that motivated the changes.
- **A1 — Task-mode channel**: guidance distinguishes implementation vs research intent, inferred per prompt; explicit `/mode` / `[mode: ...]` declarations pin the mode and always beat inference. Research sessions relax orientation-churn and convergence pressure; failure-driven pressure stays active.
- **A2 — Unified observation layer** (`observation.rs`, new; OpenSpec `unified-observation-layer`, 14/14 tasks): normalizes structured tool calls *and* conservative bash commands (read/search/mutate/validate/commit) into one event stream. Only successful calls produce evidence. Stuck detection and intent tracking consume this stream instead of per-tool name matching.
- **A3 — Evidence ledger** (OpenSpec `a3-evidence-ledger`, 9/9 tasks): per-task novelty/revisit accounting drives convergence pressure instead of raw file counts. Bounded (32-turn window), resets on task-scope change, streaks break on any mutation/validation.
- **Supporting fixes**: duplicate tool-result coalescing before Anthropic replay, workspace-boundary approval canonicalization, shared `CWD_LOCK` test guard eliminating cwd races, live endpoint probes gated behind `OMEGON_LIVE_ENDPOINT_PROBES=1`, obsolete `ollama-cloud` auth rows removed.

## Verification

- `just lint` clean (fmt, check, clippy `-D warnings`)
- `cargo test -p omegon --locked` — full suite green (3753+ lib tests plus all integration binaries)
- Adversarial review passed on the guidance core (`observation.rs`, `conversation.rs`, `loop.rs`, `behavior.rs`) and peripheral surfaces; all findings fixed on-branch
- Merges fast-forward: merge-base == main HEAD at time of push

## Known accepted limitations (deliberate for v1)

1. Evidence-ledger scope resets on every operator prompt change — novelty history is per-prompt-task, not per-session.
2. Search-heavy turns dilute revisit-rate below the trigger threshold — under-triggers, never over-triggers.
3. Bash observation heuristics have quoting blind spots (e.g. `rg "a|b"`); misclassification degrades to "no event," not wrong pressure.
