### PR TITLE
feat: surface extension tool provenance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [Semantic V
 
 ## [Unreleased]
 
+### Added
+
+- Added an environment-gated `OMEGON_RECRO_COE_DIR` host litmus test that builds and launches the real Recro COE extension, verifies manifest and SDK handshake compatibility, applies typed configuration, executes its partnership workflow, and confirms extension-owned skill discovery.
+
+### Changed
+
+- Extension startup now treats rejected resolved configuration as a registration failure instead of continuing with an extension that did not accept its host-provided settings.
+
 ## [0.28.4] - 2026-07-15
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [Semantic V
 
 ### Added
 
+- Tool lifecycle events now preserve the authoritative producer selected by `EventBus` arbitration. Conversation tool cards qualify extension-owned calls as `tool (extension-name)` while built-ins retain their existing labels, and IPC, MQTT, web-stream, WebSocket, and web tool-run projections carry the same provenance for operator-visible auditability.
+
+### Added
+
 - Added an environment-gated `OMEGON_RECRO_COE_DIR` host litmus test that builds and launches the real Recro COE extension, verifies manifest and SDK handshake compatibility, applies typed configuration, executes its partnership workflow, and confirms extension-owned skill discovery.
 
 ### Changed

--- a/core/crates/omegon-traits/src/lib.rs
+++ b/core/crates/omegon-traits/src/lib.rs
@@ -1243,6 +1243,8 @@ pub enum IpcEventPayload {
     ToolStarted {
         id: String,
         name: String,
+        #[serde(default)]
+        provenance: ToolProvenance,
         /// Serialized tool arguments. May be large; clients may truncate for display.
         args: Value,
     },
@@ -1264,6 +1266,8 @@ pub enum IpcEventPayload {
     ToolEnded {
         id: String,
         name: String,
+        #[serde(default)]
+        provenance: ToolProvenance,
         is_error: bool,
         /// Human-readable summary of the result for display purposes.
         #[serde(skip_serializing_if = "Option::is_none")]
@@ -2193,10 +2197,29 @@ pub type HostActionApprovalSink = std::sync::Arc<
 /// Features are created during setup, receive `on_event()` calls for the
 /// duration of the session, and are dropped at shutdown. The bus delivers
 /// events sequentially in registration order — `&mut self` is safe.
+/// Authoritative producer of a tool after runtime name arbitration.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum ToolProvenance {
+    BuiltIn,
+    Extension { name: String },
+}
+
+impl Default for ToolProvenance {
+    fn default() -> Self {
+        Self::BuiltIn
+    }
+}
+
 #[async_trait]
 pub trait Feature: Send + Sync {
     /// Human-readable name for logging and debugging.
     fn name(&self) -> &str;
+
+    /// Producer identity attached to tools owned by this feature.
+    fn tool_provenance(&self) -> ToolProvenance {
+        ToolProvenance::BuiltIn
+    }
 
     /// Tool definitions this feature provides. Called once at startup.
     fn tools(&self) -> Vec<ToolDefinition> {
@@ -2746,6 +2769,7 @@ pub enum AgentEvent {
         id: String,
         name: String,
         args: Value,
+        provenance: ToolProvenance,
     },
     ToolUpdate {
         id: String,
@@ -2756,6 +2780,7 @@ pub enum AgentEvent {
         name: String,
         result: ToolResult,
         is_error: bool,
+        provenance: ToolProvenance,
     },
     /// The agent needs operator permission before executing a tool operation.
     /// The operator surface renders a blocking permission prompt and sends
@@ -3313,6 +3338,7 @@ mod tests {
         let ev = IpcEventPayload::ToolEnded {
             id: "call-1".into(),
             name: "bash".into(),
+            provenance: ToolProvenance::BuiltIn,
             is_error: false,
             summary: Some("exit 0".into()),
         };

--- a/core/crates/omegon/src/bus.rs
+++ b/core/crates/omegon/src/bus.rs
@@ -407,6 +407,20 @@ impl EventBus {
             || self.internal_tool_owners.contains_key(tool_name)
     }
 
+    /// Authoritative producer for the feature that won tool-name arbitration.
+    pub fn tool_provenance(&self, tool_name: &str) -> omegon_traits::ToolProvenance {
+        let owner = self
+            .tool_defs
+            .iter()
+            .find(|(_, def)| def.name == tool_name)
+            .map(|(idx, _)| *idx)
+            .or_else(|| self.internal_tool_owners.get(tool_name).copied());
+        owner
+            .and_then(|idx| self.features.get(idx))
+            .map(|feature| feature.tool_provenance())
+            .unwrap_or_default()
+    }
+
     /// Tool definitions with optional schema compaction for token efficiency.
     pub fn tool_definitions_mode(&self, compact: bool) -> Vec<ToolDefinition> {
         let disabled = self.disabled_tools.as_ref().and_then(|d| d.lock().ok());
@@ -820,6 +834,65 @@ mod tests {
                 vec![]
             }
         }
+    }
+
+    struct ExtensionCounterFeature;
+
+    #[async_trait]
+    impl Feature for ExtensionCounterFeature {
+        fn name(&self) -> &str {
+            "recro-coe-agent"
+        }
+
+        fn tool_provenance(&self) -> omegon_traits::ToolProvenance {
+            omegon_traits::ToolProvenance::Extension {
+                name: self.name().into(),
+            }
+        }
+
+        fn tools(&self) -> Vec<ToolDefinition> {
+            vec![ToolDefinition {
+                name: "count".into(),
+                label: "count".into(),
+                description: "Extension override".into(),
+                parameters: json!({"type": "object", "properties": {}}),
+                capabilities: vec![],
+            }]
+        }
+
+        async fn execute(
+            &self,
+            _tool_name: &str,
+            _call_id: &str,
+            _args: serde_json::Value,
+            _cancel: tokio_util::sync::CancellationToken,
+        ) -> anyhow::Result<ToolResult> {
+            Ok(ToolResult {
+                content: vec![ContentBlock::Text {
+                    text: "extension".into(),
+                }],
+                details: json!(null),
+            })
+        }
+    }
+
+    #[test]
+    fn resolved_tool_provenance_tracks_the_collision_winner() {
+        let mut bus = EventBus::new();
+        bus.register(Box::new(ExtensionCounterFeature));
+        bus.register(Box::new(CounterFeature { event_count: 0 }));
+        bus.finalize();
+
+        assert_eq!(
+            bus.tool_provenance("count"),
+            omegon_traits::ToolProvenance::Extension {
+                name: "recro-coe-agent".into(),
+            }
+        );
+        assert_eq!(
+            bus.tool_provenance("unknown"),
+            omegon_traits::ToolProvenance::BuiltIn
+        );
     }
 
     #[test]

--- a/core/crates/omegon/src/extensions/mod.rs
+++ b/core/crates/omegon/src/extensions/mod.rs
@@ -1108,23 +1108,20 @@ async fn handshake(
     // stays in the same channel as secrets and never depends on inherited env.
     let config = resolved_config(manifest, ext_dir)?;
     if !config.is_empty() {
-        match handles
+        handles
             .rpc_call_with_notifications(
                 "bootstrap_config",
                 Value::Object(config),
                 notification_sink,
             )
             .await
-        {
-            Ok(_) => tracing::debug!(extension = name, "bootstrap_config delivered"),
-            Err(e) => {
-                tracing::warn!(
-                    extension = name,
-                    error = %e,
-                    "bootstrap_config delivery failed"
-                );
-            }
-        }
+            .map_err(|error| {
+                anyhow!(
+                    "extension '{}' failed to accept bootstrap_config: {error}. Configuration delivery is required when resolved values are present.",
+                    name
+                )
+            })?;
+        tracing::debug!(extension = name, "bootstrap_config delivered");
     }
 
     // 4. Deliver secrets over pipe — never via env var
@@ -1622,6 +1619,65 @@ mod tests {
         assert!(!is_extension_transport_error(&anyhow!(
             "RPC error: MethodNotFound"
         )));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn handshake_rejects_extension_that_refuses_resolved_config() {
+        let _env_guard = crate::test_support::env::lock_async().await;
+        unsafe {
+            std::env::remove_var("OMEGON_RUNTIME_CONTEXT");
+            std::env::remove_var("KUBERNETES_SERVICE_HOST");
+        }
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = tempfile::tempdir().unwrap();
+        let script = temp.path().join("reject-config.sh");
+        std::fs::write(
+            &script,
+            r#"#!/bin/sh
+while IFS= read -r line; do
+  id=$(printf '%s' "$line" | sed -n 's/.*"id":\([^,}}]*\).*/\1/p')
+  case "$line" in
+    *initialize*) printf '%s\n' "{\"jsonrpc\":\"2.0\",\"id\":$id,\"result\":{\"sdk_contract_version\":\"0.25\"}}" ;;
+    *get_tools*) printf '%s\n' "{\"jsonrpc\":\"2.0\",\"id\":$id,\"result\":[]}" ;;
+    *bootstrap_config*) printf '%s\n' "{\"jsonrpc\":\"2.0\",\"id\":$id,\"error\":{\"code\":-32602,\"message\":\"invalid data_dir\"}}" ;;
+  esac
+done
+"#,
+        )
+        .unwrap();
+        let mut permissions = std::fs::metadata(&script).unwrap().permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&script, permissions).unwrap();
+        std::fs::write(
+            temp.path().join("manifest.toml"),
+            format!(
+                r#"[extension]
+name = "reject-config"
+version = "0.1.0"
+description = "fixture"
+[runtime]
+type = "native"
+binary = "{}"
+[runtime.config]
+data_dir = "relative"
+"#,
+                script.display()
+            ),
+        )
+        .unwrap();
+
+        let error = match spawn_from_manifest(temp.path(), &[]).await {
+            Ok(_) => panic!("rejected bootstrap config must prevent registration"),
+            Err(error) => error,
+        };
+        assert!(
+            error
+                .to_string()
+                .contains("failed to accept bootstrap_config")
+        );
+        assert!(error.to_string().contains("invalid data_dir"));
     }
 
     #[cfg(unix)]

--- a/core/crates/omegon/src/extensions/mod.rs
+++ b/core/crates/omegon/src/extensions/mod.rs
@@ -658,6 +658,12 @@ impl Feature for ExtensionFeature {
         &self.runtime.name
     }
 
+    fn tool_provenance(&self) -> omegon_traits::ToolProvenance {
+        omegon_traits::ToolProvenance::Extension {
+            name: self.runtime.name.clone(),
+        }
+    }
+
     fn tools(&self) -> Vec<ToolDefinition> {
         self.tools.clone()
     }

--- a/core/crates/omegon/src/ipc/connection.rs
+++ b/core/crates/omegon/src/ipc/connection.rs
@@ -1008,9 +1008,15 @@ fn project_event(ev: &AgentEvent) -> Option<IpcEventPayload> {
             Some(IpcEventPayload::ThinkingDelta { text: text.clone() })
         }
         AgentEvent::MessageEnd => Some(IpcEventPayload::MessageCompleted),
-        AgentEvent::ToolStart { id, name, args } => Some(IpcEventPayload::ToolStarted {
+        AgentEvent::ToolStart {
+            id,
+            name,
+            args,
+            provenance,
+        } => Some(IpcEventPayload::ToolStarted {
             id: id.clone(),
             name: name.clone(),
+            provenance: provenance.clone(),
             args: args.clone(),
         }),
         AgentEvent::ToolUpdate { id, partial } => Some(IpcEventPayload::ToolUpdated {
@@ -1022,6 +1028,7 @@ fn project_event(ev: &AgentEvent) -> Option<IpcEventPayload> {
             name,
             result,
             is_error,
+            provenance,
         } => {
             let summary = result
                 .content
@@ -1035,6 +1042,7 @@ fn project_event(ev: &AgentEvent) -> Option<IpcEventPayload> {
             Some(IpcEventPayload::ToolEnded {
                 id: id.clone(),
                 name: name.clone(),
+                provenance: provenance.clone(),
                 is_error: *is_error,
                 summary: if summary.is_empty() {
                     None

--- a/core/crates/omegon/src/loop.rs
+++ b/core/crates/omegon/src/loop.rs
@@ -2903,6 +2903,7 @@ async fn dispatch_tools(
                     details: Value::Null,
                 },
                 is_error: true,
+                provenance: bus.tool_provenance(&call.name),
             });
             indexed_results.push((
                 idx,
@@ -2987,6 +2988,7 @@ async fn dispatch_tools(
                     details: Value::Null,
                 },
                 is_error: true,
+                provenance: bus.tool_provenance(&call.name),
             });
 
             indexed_results.push((
@@ -3149,6 +3151,7 @@ async fn execute_tool_invocation(
     permission_policy: Option<&crate::permissions::LayeredPermissionPolicy>,
     permission_role: Option<styrene_rbac::Role>,
 ) -> (omegon_traits::ToolResult, bool) {
+    let provenance = bus.tool_provenance(execution_tool_name);
     if let Some(sm) = secrets
         && let Some(decision) = sm.check_guard(visible_tool_name, visible_args)
         && decision.is_block()
@@ -3169,6 +3172,7 @@ async fn execute_tool_invocation(
                     details: Value::Null,
                 },
                 is_error: true,
+                provenance: provenance.clone(),
             });
         }
         return (
@@ -3185,6 +3189,7 @@ async fn execute_tool_invocation(
             id: visible_call_id.to_string(),
             name: visible_tool_name.to_string(),
             args: visible_args.clone(),
+            provenance: provenance.clone(),
         });
     }
 
@@ -3356,6 +3361,7 @@ async fn execute_tool_invocation(
                 name: visible_tool_name.to_string(),
                 result: tool_result.clone(),
                 is_error,
+                provenance: provenance.clone(),
             });
         }
         return (tool_result, is_error);
@@ -3743,6 +3749,7 @@ async fn execute_tool_invocation(
                 details: result.details.clone(),
             },
             is_error,
+            provenance,
         });
     }
 
@@ -3812,6 +3819,7 @@ async fn dispatch_edit_batch(
             id: call.id.clone(),
             name: call.name.clone(),
             args: call.arguments.clone(),
+            provenance: bus.tool_provenance(&call.name),
         });
     }
 
@@ -3877,6 +3885,7 @@ async fn dispatch_edit_batch(
                 },
             },
             is_error: batch_error,
+            provenance: bus.tool_provenance(&call.name),
         });
 
         indexed_results.push((

--- a/core/crates/omegon/src/main.rs
+++ b/core/crates/omegon/src/main.rs
@@ -4630,6 +4630,7 @@ fn build_tui_secret_readiness_snapshot(
                     id: id.clone(),
                     name: "bash".to_string(),
                     args: serde_json::json!({ "command": command }),
+                    provenance: omegon_traits::ToolProvenance::BuiltIn,
                 });
 
                 tokio::spawn(async move {
@@ -4683,6 +4684,7 @@ fn build_tui_secret_readiness_snapshot(
                         name: "bash".to_string(),
                         result: tool_result.clone(),
                         is_error,
+                        provenance: omegon_traits::ToolProvenance::BuiltIn,
                     });
 
                     let exit_code = tool_result
@@ -7553,6 +7555,7 @@ async fn run_agent_command(cli: &Cli, usage_json: Option<PathBuf>) -> anyhow::Re
                     name: _,
                     result,
                     is_error,
+                    ..
                 } => {
                     let status = if is_error { "✗" } else { "✓" };
                     let text = result

--- a/core/crates/omegon/src/main.rs
+++ b/core/crates/omegon/src/main.rs
@@ -66,6 +66,8 @@ mod ipc;
 mod local_embedding;
 mod migrate;
 mod observation;
+#[cfg(test)]
+mod recro_coe_integration_tests;
 mod shadow_context;
 mod skills;
 mod smoke;

--- a/core/crates/omegon/src/mqtt_bridge.rs
+++ b/core/crates/omegon/src/mqtt_bridge.rs
@@ -147,9 +147,15 @@ fn project_event(ev: &AgentEvent) -> Option<IpcEventPayload> {
             Some(IpcEventPayload::ThinkingDelta { text: text.clone() })
         }
         AgentEvent::MessageEnd => Some(IpcEventPayload::MessageCompleted),
-        AgentEvent::ToolStart { id, name, args } => Some(IpcEventPayload::ToolStarted {
+        AgentEvent::ToolStart {
+            id,
+            name,
+            args,
+            provenance,
+        } => Some(IpcEventPayload::ToolStarted {
             id: id.clone(),
             name: name.clone(),
+            provenance: provenance.clone(),
             args: args.clone(),
         }),
         AgentEvent::ToolUpdate { id, partial } => Some(IpcEventPayload::ToolUpdated {
@@ -161,6 +167,7 @@ fn project_event(ev: &AgentEvent) -> Option<IpcEventPayload> {
             name,
             result,
             is_error,
+            provenance,
         } => {
             let summary: String = result
                 .content
@@ -174,6 +181,7 @@ fn project_event(ev: &AgentEvent) -> Option<IpcEventPayload> {
             Some(IpcEventPayload::ToolEnded {
                 id: id.clone(),
                 name: name.clone(),
+                provenance: provenance.clone(),
                 is_error: *is_error,
                 summary: if summary.is_empty() {
                     None

--- a/core/crates/omegon/src/recro_coe_integration_tests.rs
+++ b/core/crates/omegon/src/recro_coe_integration_tests.rs
@@ -1,0 +1,216 @@
+//! Opt-in host compatibility test for the separately versioned Recro COE extension.
+//! Set `OMEGON_RECRO_COE_DIR` to its checkout to exercise the real binary/package.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use anyhow::{Context, Result, bail};
+use serde_json::json;
+use tokio_util::sync::CancellationToken;
+
+use crate::extensions::manifest::ExtensionManifest;
+use crate::extensions::sdk_compat::SdkCompatibilityStatus;
+
+fn recro_checkout() -> Option<PathBuf> {
+    std::env::var_os("OMEGON_RECRO_COE_DIR").map(PathBuf::from)
+}
+
+struct EnvRestore {
+    key: &'static str,
+    previous: Option<std::ffi::OsString>,
+}
+
+impl EnvRestore {
+    fn set(key: &'static str, value: &std::ffi::OsStr) -> Self {
+        let previous = std::env::var_os(key);
+        unsafe { std::env::set_var(key, value) };
+        Self { key, previous }
+    }
+}
+
+impl Drop for EnvRestore {
+    fn drop(&mut self) {
+        match self.previous.take() {
+            Some(value) => unsafe { std::env::set_var(self.key, value) },
+            None => unsafe { std::env::remove_var(self.key) },
+        }
+    }
+}
+
+fn build_extension(checkout: &Path) -> Result<()> {
+    let status = Command::new("cargo")
+        .args(["build", "--release", "--locked"])
+        .current_dir(checkout)
+        .status()
+        .context("failed to start Recro COE release build")?;
+    if !status.success() {
+        bail!("Recro COE release build failed with {status}");
+    }
+    Ok(())
+}
+
+fn stage_extension(checkout: &Path, extension_dir: &Path, data_dir: &Path) -> Result<()> {
+    std::fs::create_dir_all(extension_dir.join("target/release"))?;
+    std::fs::create_dir_all(extension_dir.join("skills/recro-coe"))?;
+    std::fs::copy(
+        checkout.join("target/release/omegon-recro-coe"),
+        extension_dir.join("target/release/omegon-recro-coe"),
+    )?;
+    std::fs::copy(
+        checkout.join("skills/recro-coe/skill.md"),
+        extension_dir.join("skills/recro-coe/skill.md"),
+    )?;
+    let manifest_path = checkout.join("manifest.toml");
+    let manifest_source = std::fs::read_to_string(&manifest_path)?;
+    let mut manifest: toml::Value = toml::from_str(&manifest_source)
+        .with_context(|| format!("parse {}", manifest_path.display()))?;
+    let runtime = manifest
+        .get_mut("runtime")
+        .and_then(toml::Value::as_table_mut)
+        .context("Recro COE manifest runtime table")?;
+    let mut runtime_config = toml::map::Map::new();
+    runtime_config.insert(
+        "data_dir".into(),
+        toml::Value::String(data_dir.display().to_string()),
+    );
+    runtime.insert("config".into(), toml::Value::Table(runtime_config));
+    std::fs::write(
+        extension_dir.join("manifest.toml"),
+        toml::to_string(&manifest)?,
+    )?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn real_recro_coe_manifest_handshake_config_tools_skill_and_execution() -> Result<()> {
+    let _env_guard = crate::test_support::env::lock_async().await;
+    let Some(checkout) = recro_checkout() else {
+        eprintln!("skipping: OMEGON_RECRO_COE_DIR is not set");
+        return Ok(());
+    };
+    let checkout = checkout
+        .canonicalize()
+        .context("canonicalize Recro COE checkout")?;
+    build_extension(&checkout)?;
+
+    let temp = tempfile::tempdir()?;
+    let home = temp.path().join("home");
+    let extension_dir = home.join("extensions/omegon-recro-coe");
+    let data_dir = temp.path().join("data");
+    stage_extension(&checkout, &extension_dir, &data_dir)?;
+    let _home_guard = EnvRestore::set("OMEGON_HOME", home.as_os_str());
+
+    let manifest = ExtensionManifest::from_extension_dir(&extension_dir)?;
+    assert_eq!(manifest.extension.name, "omegon-recro-coe");
+    assert_eq!(manifest.skills.len(), 1);
+    assert_eq!(manifest.skills[0].path, "skills/recro-coe/skill.md");
+
+    let spawned = crate::extensions::spawn_from_manifest(&extension_dir, &[]).await?;
+    assert_eq!(
+        spawned.sdk_compatibility.status,
+        SdkCompatibilityStatus::Supported
+    );
+    let metadata = spawned.metadata.as_ref().context("initialize metadata")?;
+    assert_eq!(metadata["extension_info"]["name"], "omegon-recro-coe");
+    assert_eq!(metadata["extension_info"]["sdk_version"], "0.25");
+
+    let tools = spawned.feature.tools();
+    let tool_names: std::collections::HashSet<_> =
+        tools.iter().map(|tool| tool.name.as_str()).collect();
+    assert_eq!(
+        tool_names.len(),
+        tools.len(),
+        "duplicate Recro COE tool names"
+    );
+    for required in [
+        "recro_workspace_init",
+        "recro_partnership_create",
+        "recro_partnership_get",
+        "recro_report",
+    ] {
+        assert!(
+            tool_names.contains(required),
+            "missing required tool {required}"
+        );
+    }
+
+    let result = spawned
+        .feature
+        .execute(
+            "recro_workspace_init",
+            "recro-host-init",
+            json!({"workspace_id": "field-litmus"}),
+            CancellationToken::new(),
+        )
+        .await?;
+    let text = result
+        .content
+        .first()
+        .and_then(|block| block.as_text())
+        .unwrap_or_default();
+    assert!(
+        text.contains("field-litmus"),
+        "unexpected init result: {text}"
+    );
+
+    let result = spawned
+        .feature
+        .execute(
+            "recro_partnership_create",
+            "recro-host-create",
+            json!({
+                "id": "field-litmus",
+                "name": "Field Litmus",
+                "kind": "client"
+            }),
+            CancellationToken::new(),
+        )
+        .await?;
+    let text = result
+        .content
+        .first()
+        .and_then(|block| block.as_text())
+        .unwrap_or_default();
+    assert!(
+        text.contains("field-litmus"),
+        "unexpected create result: {text}"
+    );
+
+    let result = spawned
+        .feature
+        .execute(
+            "recro_partnership_get",
+            "recro-host-get",
+            json!({"id": "field-litmus"}),
+            CancellationToken::new(),
+        )
+        .await?;
+    let text = result
+        .content
+        .first()
+        .and_then(|block| block.as_text())
+        .unwrap_or_default();
+    assert!(
+        text.contains("field-litmus"),
+        "unexpected get result: {text}"
+    );
+    assert!(
+        text.contains("Field Litmus"),
+        "unexpected get result: {text}"
+    );
+    assert!(
+        data_dir.join("partnerships/field-litmus.json").is_file(),
+        "bootstrap_config was not applied"
+    );
+
+    let skills = crate::skills::list_structured()?;
+    let skill = skills
+        .iter()
+        .find(|entry| entry.name == "recro-coe")
+        .context("Recro COE extension skill was not discovered")?;
+    assert_eq!(skill.source, "extension:omegon-recro-coe");
+    assert!(!skill.editable);
+
+    drop(spawned);
+    Ok(())
+}

--- a/core/crates/omegon/src/tui/conv_widget.rs
+++ b/core/crates/omegon/src/tui/conv_widget.rs
@@ -1219,6 +1219,7 @@ mod tests {
                 content: SegmentContent::ToolCard {
                     id: "1".into(),
                     name: "bash".into(),
+                    provenance: omegon_traits::ToolProvenance::BuiltIn,
                     args_summary: None,
                     detail_args: Some("echo hi".into()),
                     result_summary: None,

--- a/core/crates/omegon/src/tui/conversation.rs
+++ b/core/crates/omegon/src/tui/conversation.rs
@@ -534,13 +534,21 @@ impl ConversationView {
         args_summary: Option<&str>,
         detail_args: Option<&str>,
     ) {
-        self.push_tool_start_with_expanded(id, name, args_summary, detail_args, false);
+        self.push_tool_start_with_expanded(
+            id,
+            name,
+            omegon_traits::ToolProvenance::BuiltIn,
+            args_summary,
+            detail_args,
+            false,
+        );
     }
 
     pub fn push_tool_start_with_expanded(
         &mut self,
         id: &str,
         name: &str,
+        provenance: omegon_traits::ToolProvenance,
         args_summary: Option<&str>,
         detail_args: Option<&str>,
         expanded_by_default: bool,
@@ -558,7 +566,7 @@ impl ConversationView {
             return;
         }
 
-        let mut seg = Segment::tool_card(id, name);
+        let mut seg = Segment::tool_card_with_provenance(id, name, provenance);
         if let SegmentContent::ToolCard {
             args_summary: ref mut a,
             detail_args: ref mut d,
@@ -2190,7 +2198,14 @@ mod tests {
     #[test]
     fn tool_start_can_opt_into_default_expansion() {
         let mut cv = ConversationView::new();
-        cv.push_tool_start_with_expanded("t1", "bash", Some("ls"), Some("ls"), true);
+        cv.push_tool_start_with_expanded(
+            "t1",
+            "bash",
+            omegon_traits::ToolProvenance::BuiltIn,
+            Some("ls"),
+            Some("ls"),
+            true,
+        );
         cv.push_tool_start("t2", "bash", Some("echo hi"), Some("echo hi"));
 
         if let SegmentContent::ToolCard { expanded, .. } = &cv.segments[0].content {

--- a/core/crates/omegon/src/tui/conversation_projection.rs
+++ b/core/crates/omegon/src/tui/conversation_projection.rs
@@ -300,6 +300,7 @@ mod tests {
             content: SegmentContent::ToolCard {
                 id: id.into(),
                 name: "bash".into(),
+                provenance: omegon_traits::ToolProvenance::BuiltIn,
                 args_summary: None,
                 detail_args: None,
                 result_summary: Some(result.into()),

--- a/core/crates/omegon/src/tui/conversation_render_projection.rs
+++ b/core/crates/omegon/src/tui/conversation_render_projection.rs
@@ -74,6 +74,20 @@ pub struct ToolCardChrome {
 pub fn tool_display_name(name: &str, detail_args: Option<&str>) -> String {
     crate::surfaces::conversation::tool_visual_identity(name, detail_args).label
 }
+pub fn tool_display_label(
+    name: &str,
+    detail_args: Option<&str>,
+    provenance: &omegon_traits::ToolProvenance,
+) -> String {
+    let display_name = tool_display_name(name, detail_args);
+    match provenance {
+        omegon_traits::ToolProvenance::BuiltIn => display_name,
+        omegon_traits::ToolProvenance::Extension { name: extension } => {
+            format!("{display_name} ({extension})")
+        }
+    }
+}
+
 pub fn tool_card_chrome(
     name: &str,
     detail_args: Option<&str>,
@@ -300,6 +314,34 @@ mod tests {
         assert_eq!(tool_display_name("request_context", None), "context");
         assert_eq!(tool_display_name("wait_for_operator", None), "tool");
         assert_eq!(tool_display_name("browser_search", None), "browser");
+    }
+
+    #[test]
+    fn tool_display_label_discloses_extension_without_renaming_builtins() {
+        assert_eq!(
+            tool_display_label("read", None, &omegon_traits::ToolProvenance::BuiltIn),
+            "read"
+        );
+        assert_eq!(
+            tool_display_label(
+                "read",
+                None,
+                &omegon_traits::ToolProvenance::Extension {
+                    name: "recro-coe-agent".into(),
+                },
+            ),
+            "read (recro-coe-agent)"
+        );
+        assert_eq!(
+            tool_display_label(
+                "bash",
+                Some("cargo check"),
+                &omegon_traits::ToolProvenance::Extension {
+                    name: "recro-coe-agent".into(),
+                },
+            ),
+            "cargo (recro-coe-agent)"
+        );
     }
 
     #[test]

--- a/core/crates/omegon/src/tui/mod.rs
+++ b/core/crates/omegon/src/tui/mod.rs
@@ -11862,7 +11862,12 @@ Scroll transcript:
                     self.conversation.stamp_meta(self.current_meta());
                 }
             }
-            AgentEvent::ToolStart { id, name, args } => {
+            AgentEvent::ToolStart {
+                id,
+                name,
+                args,
+                provenance,
+            } => {
                 self.working_verb = spinner::next_verb();
                 self.instrument_panel.tool_started(&name);
                 self.slim_turn_state = SlimTurnState::Tool(name.replace('_', " "));
@@ -11936,6 +11941,7 @@ Scroll transcript:
                 self.conversation.push_tool_start_with_expanded(
                     &id,
                     &name,
+                    provenance,
                     args_summary.as_deref(),
                     detail_args.as_deref(),
                     id.starts_with("shell-"),
@@ -12014,6 +12020,7 @@ Scroll transcript:
                 name,
                 result,
                 is_error,
+                provenance,
             } => {
                 if name == crate::tool_registry::core::WAIT_FOR_OPERATOR
                     && self.pending_operator_wait.is_some()
@@ -12053,6 +12060,7 @@ Scroll transcript:
 
                 // Use enriched message if available, otherwise the full text payload.
                 let display = enriched.as_deref().or(full_text.as_deref());
+                let _ = provenance;
                 self.conversation.push_tool_end(&id, is_error, display);
                 self.mark_activity_tool_end(
                     &id,

--- a/core/crates/omegon/src/tui/segment_components/tool_card.rs
+++ b/core/crates/omegon/src/tui/segment_components/tool_card.rs
@@ -143,6 +143,7 @@ fn slim_tool_header_cells(
 
 pub struct ToolCardRenderProps<'a> {
     pub name: &'a str,
+    pub provenance: &'a omegon_traits::ToolProvenance,
     pub detail_args: Option<&'a str>,
     pub detail_result: Option<&'a str>,
     pub is_error: bool,
@@ -739,6 +740,7 @@ pub fn render(
     let theme = ctx.theme;
     render_tool_card(
         props.name,
+        props.provenance,
         props.detail_args,
         props.detail_result,
         props.is_error,
@@ -760,6 +762,7 @@ pub fn render(
 #[allow(clippy::too_many_arguments)]
 fn render_tool_card(
     name: &str,
+    provenance: &omegon_traits::ToolProvenance,
     detail_args: Option<&str>,
     detail_result: Option<&str>,
     is_error: bool,
@@ -786,7 +789,11 @@ fn render_tool_card(
         tool_category,
         t,
     );
-    let display_name = chrome.display_name;
+    let display_name = crate::tui::conversation_render_projection::tool_display_label(
+        name,
+        detail_args,
+        provenance,
+    );
     let status_icon = chrome.status_icon;
     let status_color = chrome.status_color;
     let border_color = chrome.border_color;
@@ -1178,6 +1185,7 @@ mod tests {
             content: segments::SegmentContent::ToolCard {
                 id: "tool-1".into(),
                 name: "bash".into(),
+                provenance: omegon_traits::ToolProvenance::BuiltIn,
                 args_summary: None,
                 detail_args: Some("git status".into()),
                 result_summary: None,
@@ -1448,6 +1456,7 @@ mod tests {
         let meta = SegmentMeta::default();
         let props = ToolCardRenderProps {
             name: "bash",
+            provenance: &omegon_traits::ToolProvenance::BuiltIn,
             detail_args: Some("cargo check"),
             detail_result: Some("ok"),
             is_error: false,

--- a/core/crates/omegon/src/tui/segments.rs
+++ b/core/crates/omegon/src/tui/segments.rs
@@ -1423,6 +1423,7 @@ pub enum SegmentContent {
     ToolCard {
         id: String,
         name: String,
+        provenance: omegon_traits::ToolProvenance,
         args_summary: Option<String>,
         detail_args: Option<String>,
         result_summary: Option<String>,
@@ -1534,11 +1535,20 @@ impl Segment {
         }
     }
     pub fn tool_card(id: impl Into<String>, name: impl Into<String>) -> Self {
+        Self::tool_card_with_provenance(id, name, omegon_traits::ToolProvenance::BuiltIn)
+    }
+
+    pub fn tool_card_with_provenance(
+        id: impl Into<String>,
+        name: impl Into<String>,
+        provenance: omegon_traits::ToolProvenance,
+    ) -> Self {
         Self {
             meta: SegmentMeta::default(),
             content: SegmentContent::ToolCard {
                 id: id.into(),
                 name: name.into(),
+                provenance,
                 args_summary: None,
                 detail_args: None,
                 result_summary: None,
@@ -2054,6 +2064,7 @@ status: {}
             }
             ToolCard {
                 name,
+                provenance,
                 detail_args,
                 detail_result,
                 is_error,
@@ -2066,6 +2077,7 @@ status: {}
                 super::segment_components::tool_card::render(
                     super::segment_components::tool_card::ToolCardRenderProps {
                         name,
+                        provenance,
                         detail_args: detail_args.as_deref(),
                         detail_result: detail_result.as_deref(),
                         is_error: *is_error,
@@ -4193,6 +4205,7 @@ mod tests {
             content: SegmentContent::ToolCard {
                 id: "1".into(),
                 name: "bash".into(),
+                provenance: omegon_traits::ToolProvenance::BuiltIn,
                 args_summary: None,
                 detail_args: Some("echo hi".into()),
                 result_summary: None,
@@ -4237,6 +4250,7 @@ mod tests {
             content: SegmentContent::ToolCard {
                 id: "1".into(),
                 name: "bash".into(),
+                provenance: omegon_traits::ToolProvenance::BuiltIn,
                 args_summary: None,
                 detail_args: Some("echo hi".into()),
                 result_summary: None,
@@ -4316,6 +4330,7 @@ mod tests {
             content: SegmentContent::ToolCard {
                 id: "1".into(),
                 name: "edit".into(),
+                provenance: omegon_traits::ToolProvenance::BuiltIn,
                 args_summary: None,
                 detail_args: Some(args),
                 result_summary: None,
@@ -4389,6 +4404,7 @@ mod tests {
             content: SegmentContent::ToolCard {
                 id: "1".into(),
                 name: "change".into(),
+                provenance: omegon_traits::ToolProvenance::BuiltIn,
                 args_summary: None,
                 detail_args: Some(args),
                 result_summary: None,
@@ -4455,6 +4471,7 @@ mod tests {
             content: SegmentContent::ToolCard {
                 id: "1".into(),
                 name: "edit".into(),
+                provenance: omegon_traits::ToolProvenance::BuiltIn,
                 args_summary: None,
                 detail_args: Some(args),
                 result_summary: None,
@@ -4621,6 +4638,7 @@ mod tests {
             content: SegmentContent::ToolCard {
                 id: "tool-1".into(),
                 name: "bash".into(),
+                provenance: omegon_traits::ToolProvenance::BuiltIn,
                 args_summary: Some("cargo check".into()),
                 detail_args: Some("cargo check -p omegon".into()),
                 result_summary: Some("ok".into()),
@@ -4981,6 +4999,7 @@ mod tests {
             content: SegmentContent::ToolCard {
                 id: "1".into(),
                 name: "edit".into(),
+                provenance: omegon_traits::ToolProvenance::BuiltIn,
                 args_summary: None,
                 detail_args: Some(
                     r#"{"file":"src/main.rs","oldText":"a\nb","newText":"c\nd\ne"}"#.into(),
@@ -5024,6 +5043,7 @@ mod tests {
             content: SegmentContent::ToolCard {
                 id: "1".into(),
                 name: "change".into(),
+                provenance: omegon_traits::ToolProvenance::BuiltIn,
                 args_summary: None,
                 detail_args: Some(
                     r#"{"edits":[{"file":"src/main.rs","oldText":"a","newText":"b"},{"file":"src/lib.rs","oldText":"c","newText":"d"}],"validate":"cargo test"}"#.into(),
@@ -5071,6 +5091,7 @@ mod tests {
             content: SegmentContent::ToolCard {
                 id: "1".into(),
                 name: "read".into(),
+                provenance: omegon_traits::ToolProvenance::BuiltIn,
                 args_summary: None,
                 detail_args: Some("/tmp/demo.rs".into()),
                 result_summary: None,
@@ -5134,6 +5155,7 @@ mod tests {
             content: SegmentContent::ToolCard {
                 id: "1".into(),
                 name: "codebase_search".into(),
+                provenance: omegon_traits::ToolProvenance::BuiltIn,
                 args_summary: None,
                 detail_args: Some("{\"query\":\"foo\"}".into()),
                 result_summary: None,
@@ -5443,6 +5465,7 @@ mod tests {
             content: SegmentContent::ToolCard {
                 id: "1".into(),
                 name: "bash".into(),
+                provenance: omegon_traits::ToolProvenance::BuiltIn,
                 args_summary: None,
                 detail_args: Some("cargo build".into()),
                 result_summary: None,
@@ -5499,6 +5522,7 @@ mod tests {
             content: SegmentContent::ToolCard {
                 id: "1".into(),
                 name: "bash".into(),
+                provenance: omegon_traits::ToolProvenance::BuiltIn,
                 args_summary: None,
                 detail_args: Some("sleep 30".into()),
                 result_summary: None,
@@ -5553,6 +5577,7 @@ mod tests {
             content: SegmentContent::ToolCard {
                 id: "1".into(),
                 name: "bash".into(),
+                provenance: omegon_traits::ToolProvenance::BuiltIn,
                 args_summary: None,
                 detail_args: Some("cargo build".into()),
                 result_summary: None,
@@ -5635,6 +5660,7 @@ mod tests {
             content: SegmentContent::ToolCard {
                 id: "1".into(),
                 name: "bash".into(),
+                provenance: omegon_traits::ToolProvenance::BuiltIn,
                 args_summary: None,
                 detail_args: Some("sleep 60".into()),
                 result_summary: None,
@@ -5687,6 +5713,7 @@ mod tests {
             content: SegmentContent::ToolCard {
                 id: "1".into(),
                 name: "bash".into(),
+                provenance: omegon_traits::ToolProvenance::BuiltIn,
                 args_summary: None,
                 detail_args: Some("sleep 30".into()),
                 result_summary: None,
@@ -5724,6 +5751,7 @@ mod tests {
             content: SegmentContent::ToolCard {
                 id: "1".into(),
                 name: "codebase_search".into(),
+                provenance: omegon_traits::ToolProvenance::BuiltIn,
                 args_summary: None,
                 detail_args: Some("{\"query\":\"foo\"}".into()),
                 result_summary: None,
@@ -5806,6 +5834,7 @@ mod tests {
             content: SegmentContent::ToolCard {
                 id: "1".into(),
                 name: "bash".into(),
+                provenance: omegon_traits::ToolProvenance::BuiltIn,
                 args_summary: Some("ls -la".into()),
                 detail_args: Some("ls -la".into()),
                 result_summary: Some("total 42".into()),
@@ -5847,6 +5876,7 @@ mod tests {
             content: SegmentContent::ToolCard {
                 id: "1".into(),
                 name: "read".into(),
+                provenance: omegon_traits::ToolProvenance::BuiltIn,
                 args_summary: None,
                 detail_args: Some("/Users/cwilson/workspace/black-meridian/omegon/core/crates/omegon/src/tui/really_long_filename.rs".into()),
                 result_summary: Some("fn main() {}".into()),
@@ -5863,6 +5893,7 @@ mod tests {
             content: SegmentContent::ToolCard {
                 id: "1".into(),
                 name: "read".into(),
+                provenance: omegon_traits::ToolProvenance::BuiltIn,
                 args_summary: None,
                 detail_args: Some("src/tui/mod.rs".into()),
                 result_summary: Some("mod tui;".into()),
@@ -5914,6 +5945,7 @@ mod tests {
             content: SegmentContent::ToolCard {
                 id: "1".into(),
                 name: "read".into(),
+                provenance: omegon_traits::ToolProvenance::BuiltIn,
                 args_summary: None,
                 detail_args: Some(
                     "/very/long/path/to/some_extremely_verbose_filename_that_used_to_bleed.rs"
@@ -5966,6 +5998,7 @@ mod tests {
             content: SegmentContent::ToolCard {
                 id: "1".into(),
                 name: "read".into(),
+                provenance: omegon_traits::ToolProvenance::BuiltIn,
                 args_summary: None,
                 detail_args: Some(
                     "/Users/cwilson/workspace/black-meridian/omegon/core/Cargo.toml".into(),
@@ -5984,6 +6017,7 @@ mod tests {
             content: SegmentContent::ToolCard {
                 id: "1".into(),
                 name: "read".into(),
+                provenance: omegon_traits::ToolProvenance::BuiltIn,
                 args_summary: None,
                 detail_args: Some("package.json".into()),
                 result_summary: None,
@@ -6036,6 +6070,7 @@ mod tests {
             content: SegmentContent::ToolCard {
                 id: "1".into(),
                 name: "write".into(),
+                provenance: omegon_traits::ToolProvenance::BuiltIn,
                 args_summary: None,
                 detail_args: Some("/tmp/test".into()),
                 result_summary: None,
@@ -6074,6 +6109,7 @@ mod tests {
             content: SegmentContent::ToolCard {
                 id: "1".into(),
                 name: "read".into(),
+                provenance: omegon_traits::ToolProvenance::BuiltIn,
                 args_summary: None,
                 detail_args: Some("Cargo.toml".into()),
                 result_summary: None,
@@ -6220,6 +6256,7 @@ After fence text.
             content: SegmentContent::ToolCard {
                 id: "1".into(),
                 name: "bash".into(),
+                provenance: omegon_traits::ToolProvenance::BuiltIn,
                 args_summary: None,
                 detail_args: Some("echo hello".into()),
                 result_summary: None,
@@ -6244,6 +6281,7 @@ After fence text.
             content: SegmentContent::ToolCard {
                 id: "1".into(),
                 name: "bash".into(),
+                provenance: omegon_traits::ToolProvenance::BuiltIn,
                 args_summary: None,
                 detail_args: Some("echo hello".into()),
                 result_summary: None,
@@ -6275,6 +6313,7 @@ After fence text.
             content: SegmentContent::ToolCard {
                 id: "1".into(),
                 name: "bash".into(),
+                provenance: omegon_traits::ToolProvenance::BuiltIn,
                 args_summary: None,
                 detail_args: Some("echo hi".into()),
                 result_summary: None,
@@ -6298,6 +6337,7 @@ After fence text.
             content: SegmentContent::ToolCard {
                 id: "1".into(),
                 name: "read".into(),
+                provenance: omegon_traits::ToolProvenance::BuiltIn,
                 args_summary: None,
                 detail_args: Some("/tmp/example.rs".into()),
                 result_summary: None,
@@ -6608,6 +6648,7 @@ After fence text.
             content: SegmentContent::ToolCard {
                 id: "1".into(),
                 name: "read".into(),
+                provenance: omegon_traits::ToolProvenance::BuiltIn,
                 args_summary: None,
                 detail_args: Some("file.rs".into()),
                 result_summary: None,
@@ -6624,6 +6665,7 @@ After fence text.
             content: SegmentContent::ToolCard {
                 id: "1".into(),
                 name: "read".into(),
+                provenance: omegon_traits::ToolProvenance::BuiltIn,
                 args_summary: None,
                 detail_args: Some("file.rs".into()),
                 result_summary: None,
@@ -6651,6 +6693,7 @@ After fence text.
             content: SegmentContent::ToolCard {
                 id: "t1".into(),
                 name: "bash".into(),
+                provenance: omegon_traits::ToolProvenance::BuiltIn,
                 args_summary: Some("echo hi".into()),
                 detail_args: Some("echo hi".into()),
                 result_summary: None,
@@ -6682,6 +6725,7 @@ After fence text.
             content: SegmentContent::ToolCard {
                 id: "t1".into(),
                 name: "bash".into(),
+                provenance: omegon_traits::ToolProvenance::BuiltIn,
                 args_summary: Some("printf smoke".into()),
                 detail_args: Some("printf smoke".into()),
                 result_summary: None,
@@ -6719,6 +6763,7 @@ After fence text.
             content: SegmentContent::ToolCard {
                 id: "t1".into(),
                 name: "bash".into(),
+                provenance: omegon_traits::ToolProvenance::BuiltIn,
                 args_summary: Some("cargo check".into()),
                 detail_args: Some("cargo check".into()),
                 result_summary: None,
@@ -6759,6 +6804,7 @@ After fence text.
             content: SegmentContent::ToolCard {
                 id: "t1".into(),
                 name: "bash".into(),
+                provenance: omegon_traits::ToolProvenance::BuiltIn,
                 args_summary: Some("echo hi".into()),
                 detail_args: Some("echo hi".into()),
                 result_summary: None,

--- a/core/crates/omegon/src/tui/tests.rs
+++ b/core/crates/omegon/src/tui/tests.rs
@@ -289,6 +289,7 @@ fn session_reset_clears_instrument_panel_tool_activity() {
     app.handle_agent_event(AgentEvent::ToolStart {
         id: "tool-1".into(),
         name: "context_clear".into(),
+        provenance: omegon_traits::ToolProvenance::BuiltIn,
         args: serde_json::json!({}),
     });
 
@@ -2232,6 +2233,7 @@ fn slim_status_line_marks_turn_state() {
     app.handle_agent_event(AgentEvent::ToolStart {
         id: "tool-1".into(),
         name: "bash".into(),
+        provenance: omegon_traits::ToolProvenance::BuiltIn,
         args: serde_json::json!({"command":"cargo test"}),
     });
     if let SegmentContent::ToolCard { started_at, .. } =
@@ -7725,6 +7727,7 @@ fn active_tool_phase_beats_runtime_thinking_in_tui() {
     app.handle_agent_event(AgentEvent::ToolStart {
         id: "tool-1".into(),
         name: "bash".into(),
+        provenance: omegon_traits::ToolProvenance::BuiltIn,
         args: serde_json::json!({"command": "pwd"}),
     });
 
@@ -7804,11 +7807,13 @@ fn selected_tool_segment_detail_pane_renders_full_tool_context() {
     app.handle_agent_event(AgentEvent::ToolStart {
         id: "tool-1".into(),
         name: "bash".into(),
+        provenance: omegon_traits::ToolProvenance::BuiltIn,
         args: serde_json::json!({"command": "cargo test"}),
     });
     app.handle_agent_event(AgentEvent::ToolEnd {
         id: "tool-1".into(),
         name: "bash".into(),
+        provenance: omegon_traits::ToolProvenance::BuiltIn,
         is_error: false,
         result: omegon_traits::ToolResult {
             content: vec![omegon_traits::ContentBlock::Text {
@@ -7836,11 +7841,13 @@ fn completed_live_tool_lingers_before_activity_clears() {
     app.handle_agent_event(AgentEvent::ToolStart {
         id: "tool-1".into(),
         name: "bash".into(),
+        provenance: omegon_traits::ToolProvenance::BuiltIn,
         args: serde_json::json!({"command": "pwd"}),
     });
     app.handle_agent_event(AgentEvent::ToolEnd {
         id: "tool-1".into(),
         name: "bash".into(),
+        provenance: omegon_traits::ToolProvenance::BuiltIn,
         is_error: false,
         result: omegon_traits::ToolResult {
             content: vec![omegon_traits::ContentBlock::Text { text: "ok".into() }],
@@ -7867,11 +7874,13 @@ fn expired_live_tool_linger_clears_activity_on_render() {
     app.handle_agent_event(AgentEvent::ToolStart {
         id: "tool-1".into(),
         name: "bash".into(),
+        provenance: omegon_traits::ToolProvenance::BuiltIn,
         args: serde_json::json!({"command": "pwd"}),
     });
     app.handle_agent_event(AgentEvent::ToolEnd {
         id: "tool-1".into(),
         name: "bash".into(),
+        provenance: omegon_traits::ToolProvenance::BuiltIn,
         is_error: false,
         result: omegon_traits::ToolResult {
             content: vec![omegon_traits::ContentBlock::Text { text: "ok".into() }],
@@ -7898,11 +7907,13 @@ fn activity_tool_start_refreshes_without_duplicate_entries() {
     app.handle_agent_event(AgentEvent::ToolStart {
         id: "tool-1".into(),
         name: "bash".into(),
+        provenance: omegon_traits::ToolProvenance::BuiltIn,
         args: serde_json::json!({"command": "cargo check"}),
     });
     app.handle_agent_event(AgentEvent::ToolStart {
         id: "tool-1".into(),
         name: "bash".into(),
+        provenance: omegon_traits::ToolProvenance::BuiltIn,
         args: serde_json::json!({"command": "cargo test"}),
     });
 
@@ -7927,11 +7938,13 @@ fn activity_tool_cap_preserves_running_entries_over_completed_entries() {
         app.handle_agent_event(AgentEvent::ToolStart {
             id: id.clone(),
             name: "read".into(),
+            provenance: omegon_traits::ToolProvenance::BuiltIn,
             args: serde_json::json!({"path": format!("file-{idx}.rs")}),
         });
         app.handle_agent_event(AgentEvent::ToolEnd {
             id,
             name: "read".into(),
+            provenance: omegon_traits::ToolProvenance::BuiltIn,
             is_error: false,
             result: omegon_traits::ToolResult {
                 content: vec![omegon_traits::ContentBlock::Text { text: "ok".into() }],
@@ -7943,6 +7956,7 @@ fn activity_tool_cap_preserves_running_entries_over_completed_entries() {
         app.handle_agent_event(AgentEvent::ToolStart {
             id: format!("run-{idx}"),
             name: "bash".into(),
+            provenance: omegon_traits::ToolProvenance::BuiltIn,
             args: serde_json::json!({"command": format!("cmd-{idx}")}),
         });
     }
@@ -7974,11 +7988,13 @@ fn activity_prune_removes_expired_completed_but_keeps_running_entries() {
     app.handle_agent_event(AgentEvent::ToolStart {
         id: "done".into(),
         name: "read".into(),
+        provenance: omegon_traits::ToolProvenance::BuiltIn,
         args: serde_json::json!({"path": "Cargo.toml"}),
     });
     app.handle_agent_event(AgentEvent::ToolEnd {
         id: "done".into(),
         name: "read".into(),
+        provenance: omegon_traits::ToolProvenance::BuiltIn,
         is_error: false,
         result: omegon_traits::ToolResult {
             content: vec![omegon_traits::ContentBlock::Text { text: "ok".into() }],
@@ -7988,6 +8004,7 @@ fn activity_prune_removes_expired_completed_but_keeps_running_entries() {
     app.handle_agent_event(AgentEvent::ToolStart {
         id: "running".into(),
         name: "bash".into(),
+        provenance: omegon_traits::ToolProvenance::BuiltIn,
         args: serde_json::json!({"command": "sleep 10"}),
     });
     if let Some(tool) = app
@@ -8019,6 +8036,7 @@ fn active_single_running_activity_tool_uses_full_live_card() {
     app.handle_agent_event(AgentEvent::ToolStart {
         id: "tool-1".into(),
         name: "bash".into(),
+        provenance: omegon_traits::ToolProvenance::BuiltIn,
         args: serde_json::json!({"command": "cargo check"}),
     });
 
@@ -8034,6 +8052,7 @@ fn om_single_running_activity_tool_stays_one_line() {
     app.handle_agent_event(AgentEvent::ToolStart {
         id: "tool-1".into(),
         name: "bash".into(),
+        provenance: omegon_traits::ToolProvenance::BuiltIn,
         args: serde_json::json!({"command": "cargo check"}),
     });
 
@@ -8049,11 +8068,13 @@ fn completed_tools_handoff_to_one_durable_outcome_without_activity_duplication()
     app.handle_agent_event(AgentEvent::ToolStart {
         id: "tool-1".into(),
         name: "read".into(),
+        provenance: omegon_traits::ToolProvenance::BuiltIn,
         args: serde_json::json!({"path": "Cargo.toml"}),
     });
     app.handle_agent_event(AgentEvent::ToolEnd {
         id: "tool-1".into(),
         name: "read".into(),
+        provenance: omegon_traits::ToolProvenance::BuiltIn,
         is_error: false,
         result: omegon_traits::ToolResult {
             content: vec![omegon_traits::ContentBlock::Text {
@@ -8065,11 +8086,13 @@ fn completed_tools_handoff_to_one_durable_outcome_without_activity_duplication()
     app.handle_agent_event(AgentEvent::ToolStart {
         id: "tool-2".into(),
         name: "bash".into(),
+        provenance: omegon_traits::ToolProvenance::BuiltIn,
         args: serde_json::json!({"command": "cargo check"}),
     });
     app.handle_agent_event(AgentEvent::ToolEnd {
         id: "tool-2".into(),
         name: "bash".into(),
+        provenance: omegon_traits::ToolProvenance::BuiltIn,
         is_error: false,
         result: omegon_traits::ToolResult {
             content: vec![omegon_traits::ContentBlock::Text {
@@ -8095,12 +8118,14 @@ fn tool_end_aggregates_all_text_blocks() {
     app.handle_agent_event(AgentEvent::ToolStart {
         id: "tool-1".into(),
         name: "codebase_search".into(),
+        provenance: omegon_traits::ToolProvenance::BuiltIn,
         args: serde_json::json!({"query": "foo"}),
     });
 
     app.handle_agent_event(AgentEvent::ToolEnd {
         id: "tool-1".into(),
         name: "codebase_search".into(),
+        provenance: omegon_traits::ToolProvenance::BuiltIn,
         is_error: false,
         result: omegon_traits::ToolResult {
             content: vec![

--- a/core/crates/omegon/src/web/mod.rs
+++ b/core/crates/omegon/src/web/mod.rs
@@ -651,10 +651,16 @@ impl WebState {
             return;
         };
         match event {
-            AgentEvent::ToolStart { id, name, args } => {
+            AgentEvent::ToolStart {
+                id,
+                name,
+                args,
+                provenance,
+            } => {
                 let redacted_args = self.redact_web_value(args);
                 if let Some(existing) = tools.iter_mut().find(|tool| tool.id == *id) {
                     existing.name = name.clone();
+                    existing.provenance = provenance.clone();
                     existing.status = "running".to_string();
                     existing.args = redacted_args;
                     existing.output_tail = None;
@@ -666,6 +672,7 @@ impl WebState {
                     tools.push_back(surfaces::WebToolRunSurface {
                         id: id.clone(),
                         name: name.clone(),
+                        provenance: provenance.clone(),
                         status: "running".to_string(),
                         args: redacted_args,
                         output_tail: None,
@@ -690,6 +697,7 @@ impl WebState {
                 name,
                 result,
                 is_error,
+                provenance,
             } => {
                 let summary = result
                     .content
@@ -699,6 +707,7 @@ impl WebState {
                     .map(|text| self.redact_web_text(&text.chars().take(240).collect::<String>()));
                 if let Some(tool) = tools.iter_mut().rev().find(|tool| tool.id == *id) {
                     tool.name = name.clone();
+                    tool.provenance = provenance.clone();
                     tool.status = if *is_error { "failed" } else { "completed" }.to_string();
                     tool.result_summary = summary;
                     tool.is_error = *is_error;
@@ -706,6 +715,7 @@ impl WebState {
                     tools.push_back(surfaces::WebToolRunSurface {
                         id: id.clone(),
                         name: name.clone(),
+                        provenance: provenance.clone(),
                         status: if *is_error { "failed" } else { "completed" }.to_string(),
                         args: serde_json::Value::Null,
                         output_tail: None,
@@ -2225,6 +2235,7 @@ mod tests {
         state.fold_conversation_event(&omegon_traits::AgentEvent::ToolStart {
             id: "tool-1".into(),
             name: "bash".into(),
+            provenance: omegon_traits::ToolProvenance::BuiltIn,
             args: serde_json::json!({"command":"pwd"}),
         });
         state.fold_conversation_event(&omegon_traits::AgentEvent::ToolUpdate {
@@ -2242,6 +2253,7 @@ mod tests {
         state.fold_conversation_event(&omegon_traits::AgentEvent::ToolEnd {
             id: "tool-1".into(),
             name: "bash".into(),
+            provenance: omegon_traits::ToolProvenance::BuiltIn,
             result: omegon_traits::ToolResult {
                 content: vec![omegon_traits::ContentBlock::Text {
                     text: "done".into(),
@@ -2277,6 +2289,7 @@ mod tests {
         state.fold_conversation_event(&omegon_traits::AgentEvent::ToolStart {
             id: "tool-secret".into(),
             name: "bash".into(),
+            provenance: omegon_traits::ToolProvenance::BuiltIn,
             args: serde_json::json!({"command":"curl -H 'Authorization: Bearer super-secret-token'"}),
         });
         state.fold_conversation_event(&omegon_traits::AgentEvent::ToolUpdate {
@@ -2290,6 +2303,7 @@ mod tests {
         state.fold_conversation_event(&omegon_traits::AgentEvent::ToolEnd {
             id: "tool-secret".into(),
             name: "bash".into(),
+            provenance: omegon_traits::ToolProvenance::BuiltIn,
             result: omegon_traits::ToolResult {
                 content: vec![omegon_traits::ContentBlock::Text {
                     text: "result contained super-secret-token".into(),
@@ -2316,6 +2330,7 @@ mod tests {
             state.fold_conversation_event(&omegon_traits::AgentEvent::ToolStart {
                 id: format!("tool-{idx}"),
                 name: "bash".into(),
+                provenance: omegon_traits::ToolProvenance::BuiltIn,
                 args: serde_json::json!({}),
             });
         }

--- a/core/crates/omegon/src/web/surface_stream.rs
+++ b/core/crates/omegon/src/web/surface_stream.rs
@@ -246,13 +246,18 @@ fn surface_stream_event(
             Some("conversation"),
             json!({ "text": text }),
         ),
-        AgentEvent::ToolStart { id, name, args } => {
+        AgentEvent::ToolStart {
+            id,
+            name,
+            args,
+            provenance,
+        } => {
             let args = state.redact_web_value(&args);
             WebSurfaceStreamEnvelope::default_session(
                 revision,
                 "tool_started",
                 Some("instruments"),
-                json!({ "id": id, "name": name, "args": args }),
+                json!({ "id": id, "name": name, "args": args, "provenance": provenance }),
             )
         }
         AgentEvent::ToolUpdate { id, partial } => {
@@ -266,12 +271,16 @@ fn surface_stream_event(
             )
         }
         AgentEvent::ToolEnd {
-            id, name, is_error, ..
+            id,
+            name,
+            is_error,
+            provenance,
+            ..
         } => WebSurfaceStreamEnvelope::default_session(
             revision,
             "tool_completed",
             Some("instruments"),
-            json!({ "id": id, "name": name, "is_error": is_error }),
+            json!({ "id": id, "name": name, "is_error": is_error, "provenance": provenance }),
         ),
         AgentEvent::PermissionRequest {
             tool_name,
@@ -518,6 +527,7 @@ mod tests {
             AgentEvent::ToolStart {
                 id: "t1".into(),
                 name: "bash".into(),
+                provenance: omegon_traits::ToolProvenance::BuiltIn,
                 args: serde_json::json!({"command":"pwd"}),
             },
         ))
@@ -538,6 +548,7 @@ mod tests {
             AgentEvent::ToolStart {
                 id: "t-secret".into(),
                 name: "bash".into(),
+                provenance: omegon_traits::ToolProvenance::BuiltIn,
                 args: serde_json::json!({"command":"echo super-secret-token"}),
             },
         ))

--- a/core/crates/omegon/src/web/surfaces.rs
+++ b/core/crates/omegon/src/web/surfaces.rs
@@ -104,6 +104,7 @@ pub struct WebInstrumentsSurface {
 pub struct WebToolRunSurface {
     pub id: String,
     pub name: String,
+    pub provenance: omegon_traits::ToolProvenance,
     pub status: String,
     pub args: Value,
     pub output_tail: Option<String>,
@@ -524,6 +525,7 @@ mod tests {
             tools.push_back(WebToolRunSurface {
                 id: "tool-1".into(),
                 name: "read".into(),
+                provenance: omegon_traits::ToolProvenance::BuiltIn,
                 status: "completed".into(),
                 args: serde_json::json!({"path": "src/lib.rs"}),
                 output_tail: None,
@@ -535,6 +537,7 @@ mod tests {
             tools.push_back(WebToolRunSurface {
                 id: "tool-2".into(),
                 name: "bash".into(),
+                provenance: omegon_traits::ToolProvenance::BuiltIn,
                 status: "running".into(),
                 args: serde_json::json!({"command": "cargo test"}),
                 output_tail: Some("running 8 tests".into()),
@@ -546,6 +549,7 @@ mod tests {
             tools.push_back(WebToolRunSurface {
                 id: "tool-3".into(),
                 name: "write".into(),
+                provenance: omegon_traits::ToolProvenance::BuiltIn,
                 status: "running".into(),
                 args: serde_json::json!({"path": "src/web.rs"}),
                 output_tail: None,

--- a/core/crates/omegon/src/web/ws.rs
+++ b/core/crates/omegon/src/web/ws.rs
@@ -2187,12 +2187,18 @@ fn serialize_agent_event(event: &AgentEvent) -> Value {
             "type": "message_abort",
             "reason": reason,
         }),
-        AgentEvent::ToolStart { id, name, args } => json!({
+        AgentEvent::ToolStart {
+            id,
+            name,
+            args,
+            provenance,
+        } => json!({
             "type": "tool_start",
             "event_name": "tool.started",
             "id": id,
             "name": name,
             "tool_name": name,
+            "provenance": provenance,
             "args": args,
         }),
         AgentEvent::ToolUpdate { id, partial } => {
@@ -2234,6 +2240,7 @@ fn serialize_agent_event(event: &AgentEvent) -> Value {
             name,
             result,
             is_error,
+            provenance,
         } => {
             // Serialize ALL content blocks, not just the first
             let texts: Vec<&str> = result.content.iter().filter_map(|c| c.as_text()).collect();
@@ -2244,6 +2251,7 @@ fn serialize_agent_event(event: &AgentEvent) -> Value {
                 "id": id,
                 "name": name,
                 "tool_name": name,
+                "provenance": provenance,
                 "result": escape_html(&result_text),
                 "is_error": is_error,
                 "block_count": result.content.len(),
@@ -3004,6 +3012,7 @@ mod tests {
         let event = AgentEvent::ToolEnd {
             id: "tc1".into(),
             name: "bash".into(),
+            provenance: omegon_traits::ToolProvenance::BuiltIn,
             result: omegon_traits::ToolResult {
                 content: vec![
                     omegon_traits::ContentBlock::Text {
@@ -3205,6 +3214,7 @@ mod tests {
             AgentEvent::ToolStart {
                 id: "1".into(),
                 name: "read".into(),
+                provenance: omegon_traits::ToolProvenance::BuiltIn,
                 args: serde_json::json!({}),
             },
             AgentEvent::ToolUpdate {
@@ -3214,6 +3224,7 @@ mod tests {
             AgentEvent::ToolEnd {
                 id: "1".into(),
                 name: "read".into(),
+                provenance: omegon_traits::ToolProvenance::BuiltIn,
                 result: omegon_traits::ToolResult {
                     content: vec![omegon_traits::ContentBlock::Text { text: "ok".into() }],
                     details: serde_json::json!(null),


### PR DESCRIPTION
## Summary

- carry the authoritative post-resolution tool owner through start/completion events instead of reconstructing provenance in presentation code
- render extension-owned tool calls as `tool (extension)` while preserving existing built-in labels and styling
- expose the same provenance through IPC, MQTT, web surface streams, WebSocket events, and web instrument projections
- add an opt-in cross-repository Recro COE host litmus using `OMEGON_RECRO_COE_DIR`

## Why

Omegon permits extensions to override tool names. An operator must be able to distinguish a built-in call from an extension-owned winner and identify which extension to disable when behavior is unexpected. The displayed owner therefore comes from the actual resolution result and is pinned by call ID through completion.

## Validation

- isolated Omegon test binary: 3,980 passed, 0 failed, 1 ignored
- `cargo test -p omegon-traits --locked -j 1`: 18 passed
- focused provenance, collision, TUI rendering, IPC, web, and lifecycle tests passed
- Recro extension: 7 tests passed
- Recro extension Clippy with warnings denied passed
- `cargo check -p omegon --bin omegon --locked -j 1` passed
- `just link` passed; installed binary matches commit `2215ba8`

## Cross-repository litmus

The Recro integration remains opt-in so the Omegon checkout does not acquire an unconditional sibling-repository dependency:

```bash
OMEGON_RECRO_COE_DIR=/absolute/path/to/omegon-recro-coe \
  cargo test -p omegon recro_coe_integration_tests --locked
```

## Notes

The macOS debug test link emits the existing non-fatal `__eh_frame section too large` linker warning. Release linking succeeds.
