### PR TITLE
fix(tui): keep live workspace affordances current

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [Semantic V
 
 ### Changed
 
+- Kept the TUI workbench branch affordance live after tool-driven repository mutations by refreshing workspace state at each completed tool event instead of retaining the startup snapshot.
 - Replaced the selected conversation row's width-shifting glyph rail with a stable full-row background highlight, and changed completed terminal rows from the stale `dbl-click copy` hint to `dbl-click process`.
 - Routed double-clicks on retained `terminal` result cards using the current `Started terminal 'name' (session-id)` output to the canonical managed-process viewer instead of the generic conversation-segment plaintext copy action.
 - Hardened extension detail navigation after adversarial review: keyed primary actions now respond to Space, Escape returns from an extension detail page to the extension inventory, and missing detail targets produce visible feedback instead of silently doing nothing.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [Semantic V
 
 ### Changed
 
+- Routed double-clicks on retained `terminal` result cards to the canonical managed-process viewer instead of the generic conversation-segment plaintext copy action.
 - Hardened extension detail navigation after adversarial review: keyed primary actions now respond to Space, Escape returns from an extension detail page to the extension inventory, and missing detail targets produce visible feedback instead of silently doing nothing.
 - Reworked the extension runtime menu interaction model: Space now toggles enabled/disabled state in place, Enter opens an extension-specific management page, and update/remove actions live on that detail page instead of the collection browser.
 - Reworked extension create, install, and search entry points as explicit inline menu-input actions that execute without closing into the global editor; installed extension rows now perform enable/disable on Enter and expose confirmed update/remove actions that refresh the inventory instead of defaulting to a plain-text inspect dump.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [Semantic V
 
 ### Changed
 
+- Replaced the selected conversation row's width-shifting glyph rail with a stable full-row background highlight, and changed completed terminal rows from the stale `dbl-click copy` hint to `dbl-click process`.
 - Routed double-clicks on retained `terminal` result cards using the current `Started terminal 'name' (session-id)` output to the canonical managed-process viewer instead of the generic conversation-segment plaintext copy action.
 - Hardened extension detail navigation after adversarial review: keyed primary actions now respond to Space, Escape returns from an extension detail page to the extension inventory, and missing detail targets produce visible feedback instead of silently doing nothing.
 - Reworked the extension runtime menu interaction model: Space now toggles enabled/disabled state in place, Enter opens an extension-specific management page, and update/remove actions live on that detail page instead of the collection browser.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [Semantic V
 
 ### Changed
 
-- Routed double-clicks on retained `terminal` result cards to the canonical managed-process viewer instead of the generic conversation-segment plaintext copy action.
+- Routed double-clicks on retained `terminal` result cards using the current `Started terminal 'name' (session-id)` output to the canonical managed-process viewer instead of the generic conversation-segment plaintext copy action.
 - Hardened extension detail navigation after adversarial review: keyed primary actions now respond to Space, Escape returns from an extension detail page to the extension inventory, and missing detail targets produce visible feedback instead of silently doing nothing.
 - Reworked the extension runtime menu interaction model: Space now toggles enabled/disabled state in place, Enter opens an extension-specific management page, and update/remove actions live on that detail page instead of the collection browser.
 - Reworked extension create, install, and search entry points as explicit inline menu-input actions that execute without closing into the global editor; installed extension rows now perform enable/disable on Enter and expose confirmed update/remove actions that refresh the inventory instead of defaulting to a plain-text inspect dump.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [Semantic V
 
 ### Added
 
+- Added `scripts/terminal_test_workload.py`, a deterministic long-running mixed-output workload with heartbeats, bursts, signal handling, natural completion, and interactive `status`, `burst`, `fail`, and `quit` commands for exercising managed terminal sessions and the process viewer.
 - Added design artifacts for authoritative extension tool provenance across conversation surfaces, and captured the remaining operator-visible terminal-session questions alongside the new managed process viewer.
 - Connected completed `terminal` conversation cards to the managed-process viewer: select a retained terminal result and press Enter to open its canonical live session instead of inspecting a stale text dump.
 - Expanded the managed-process viewer with previous/next session switching and a confirmed stop action while keeping terminal input disabled.

--- a/core/crates/omegon/src/tui/conv_widget.rs
+++ b/core/crates/omegon/src/tui/conv_widget.rs
@@ -221,6 +221,7 @@ impl ConvState {
                     segment.capabilities().detail_openable,
                     segment.capabilities().copyable,
                     is_collapsed_expandable_tool_card(segment),
+                    is_terminal_tool_card(segment),
                 )
                 .content_area(segment_area);
                 let available_height = viewport.bottom().saturating_sub(render_y);
@@ -456,6 +457,7 @@ impl<'a> StatefulWidget for ConversationWidget<'a> {
                     segment.capabilities().detail_openable,
                     segment.capabilities().copyable,
                     is_collapsed_expandable_tool_card(segment),
+                    is_terminal_tool_card(segment),
                 )
                 .render(seg_area, buf, self.theme, |content_area, buf| {
                     segment.render_in_context(content_area, buf, &render_ctx);
@@ -498,6 +500,7 @@ impl<'a> StatefulWidget for ConversationWidget<'a> {
                     segment.capabilities().detail_openable,
                     segment.capabilities().copyable,
                     is_collapsed_expandable_tool_card(segment),
+                    is_terminal_tool_card(segment),
                 )
                 .render(
                     temp_area,
@@ -593,6 +596,7 @@ fn measured_segment_height(
         segment.capabilities().detail_openable,
         segment.capabilities().copyable,
         is_collapsed_expandable_tool_card(segment),
+        is_terminal_tool_card(segment),
     );
     let content_width = frame.content_area(Rect::new(0, 0, width, 1)).width;
     let estimated = segment.height_in_context(content_width, ctx);
@@ -660,6 +664,13 @@ fn render_assistant_copy_affordance(
     Some(Rect::new(x, area.y, label_width, 1))
 }
 
+fn is_terminal_tool_card(segment: &Segment) -> bool {
+    matches!(
+        &segment.content,
+        super::segments::SegmentContent::ToolCard { name, complete: true, .. } if name == "terminal"
+    )
+}
+
 fn is_collapsed_expandable_tool_card(segment: &Segment) -> bool {
     matches!(
         &segment.content,
@@ -677,6 +688,7 @@ struct SelectedSegmentFrame {
     detail_openable: bool,
     copyable: bool,
     collapsed_expandable: bool,
+    opens_process_viewer: bool,
 }
 
 impl SelectedSegmentFrame {
@@ -685,12 +697,14 @@ impl SelectedSegmentFrame {
         detail_openable: bool,
         copyable: bool,
         collapsed_expandable: bool,
+        opens_process_viewer: bool,
     ) -> Self {
         Self {
             selected,
             detail_openable,
             copyable,
             collapsed_expandable,
+            opens_process_viewer,
         }
     }
 
@@ -709,16 +723,7 @@ impl SelectedSegmentFrame {
     }
 
     fn content_area(&self, area: Rect) -> Rect {
-        if self.selected && area.width > 1 {
-            Rect {
-                x: area.x.saturating_add(1),
-                y: area.y,
-                width: area.width.saturating_sub(1),
-                height: area.height,
-            }
-        } else {
-            area
-        }
+        area
     }
 
     fn render_chrome(&self, area: Rect, buf: &mut Buffer, theme: &dyn Theme) {
@@ -726,18 +731,14 @@ impl SelectedSegmentFrame {
             return;
         }
 
-        let style = Style::default()
-            .fg(theme.accent_bright())
-            .bg(theme.surface_bg())
-            .add_modifier(Modifier::BOLD);
-        for (row, y) in (area.top()..area.bottom()).enumerate() {
-            let marker = match (self.detail_openable, row == 0) {
-                (true, true) => '◆',
-                _ => '│',
-            };
-            if let Some(cell) = buf.cell_mut((area.x, y)) {
-                cell.set_char(marker);
-                cell.set_style(style);
+        // Selection must not alter row geometry: changing the content origin made
+        // one-line tool rows jump sideways and left a stray marker glyph. A quiet
+        // full-row surface tint is both more obvious and spatially stable.
+        for y in area.top()..area.bottom() {
+            for x in area.left()..area.right() {
+                if let Some(cell) = buf.cell_mut((x, y)) {
+                    cell.set_bg(theme.card_bg());
+                }
             }
         }
         self.render_hint(area, buf, theme);
@@ -747,7 +748,9 @@ impl SelectedSegmentFrame {
         if area.width < 24 || area.height == 0 {
             return;
         }
-        let label = if self.collapsed_expandable {
+        let label = if self.opens_process_viewer {
+            " dbl-click process "
+        } else if self.collapsed_expandable {
             " dbl-click expand "
         } else if self.copyable {
             " dbl-click copy "
@@ -865,6 +868,45 @@ mod tests {
                 .all(|cell| cell.fg != Alpharius.warning()),
             "detached navigation hint must not consume the attention color"
         );
+    }
+
+    #[test]
+    fn selected_terminal_row_uses_stable_highlight_and_process_hint() {
+        let segment = Segment {
+            meta: Default::default(),
+            content: SegmentContent::ToolCard {
+                id: "terminal-test".into(),
+                name: "terminal".into(),
+                provenance: Default::default(),
+                args_summary: Some("start".into()),
+                detail_args: Some("start".into()),
+                result_summary: Some("Started terminal 'test' (id) PID 1".into()),
+                detail_result: Some("Started terminal 'test' (id) PID 1".into()),
+                is_error: false,
+                complete: true,
+                expanded: false,
+                live_partial: None,
+                started_at: None,
+            },
+        };
+        let segments = vec![segment];
+        let widget = ConversationWidget::new(&segments, &Alpharius)
+            .with_mode(SegmentRenderMode::Slim)
+            .with_selected_segment(Some(0));
+        let area = Rect::new(0, 0, 80, 3);
+        let mut buf = Buffer::empty(area);
+        let mut state = ConvState::new();
+        widget.render(area, &mut buf, &mut state);
+
+        let rendered = buffer_text(&buf, area);
+        assert!(rendered.contains("dbl-click process"), "got {rendered}");
+        assert!(!rendered.contains("dbl-click copy"), "got {rendered}");
+        assert!(!rendered.contains('◆'), "got {rendered}");
+        assert!(!rendered.contains('│'), "got {rendered}");
+        let selected_row = (0..area.height)
+            .find(|&y| (0..area.width).any(|x| buf[(x, y)].symbol() != " "))
+            .expect("selected row");
+        assert_eq!(buf[(area.x, selected_row)].bg, Alpharius.card_bg());
     }
 
     #[test]
@@ -1377,7 +1419,7 @@ mod tests {
     }
 
     #[test]
-    fn selected_segment_height_uses_gutter_content_width() {
+    fn selected_segment_height_keeps_content_width_stable() {
         let segments = vec![Segment {
             meta: Default::default(),
             content: SegmentContent::AssistantText {
@@ -1393,7 +1435,7 @@ mod tests {
         assert_eq!(state.heights, vec![1]);
 
         state.ensure_heights_with_scroll_state(&segments, 9, &ctx, false, Some(0));
-        assert_eq!(state.heights, vec![2]);
+        assert_eq!(state.heights, vec![1]);
     }
 
     #[test]
@@ -1417,13 +1459,14 @@ mod tests {
 
         let rendered = buffer_text(&buf, area);
         assert!(
-            rendered.lines().any(|line| line.starts_with("◆inspect me")),
-            "selection frame should wrap plain prose instead of replacing the first character: {rendered}"
+            rendered.lines().any(|line| line.starts_with("inspect me")),
+            "selection highlight should preserve plain prose without adding a gutter: {rendered}"
         );
+        assert!(!rendered.contains('◆'), "{rendered}");
     }
 
     #[test]
-    fn selected_image_area_respects_selection_gutter() {
+    fn selected_image_area_keeps_geometry_stable() {
         let segments = vec![Segment::image("/tmp/example.png".into(), "example")];
         let viewport = Rect::new(10, 0, 20, 14);
         let mut state = ConvState::new();
@@ -1438,8 +1481,8 @@ mod tests {
         state.ensure_heights_with_scroll_state(&segments, viewport.width, &ctx, false, Some(0));
         let selected = state.visible_image_areas(&segments, viewport);
         assert_eq!(selected.len(), 1);
-        assert_eq!(selected[0].1.x, 12);
-        assert_eq!(selected[0].1.width, 17);
+        assert_eq!(selected[0].1.x, 11);
+        assert_eq!(selected[0].1.width, 18);
     }
 
     #[test]
@@ -1459,14 +1502,9 @@ mod tests {
             rendered.contains("dbl-click copy"),
             "selected copyable segment should advertise double-click copy: {rendered}"
         );
-        assert!(
-            rendered.lines().any(|line| line.starts_with('◆')),
-            "detail-openable selection should mark the segment start: {rendered}"
-        );
-        assert!(
-            rendered.contains("││ inspect me"),
-            "selection rail should not replace the first content character: {rendered}"
-        );
+        assert!(!rendered.contains('◆'), "{rendered}");
+        assert!(!rendered.contains("││ inspect me"), "{rendered}");
+        assert!(rendered.contains("│ inspect me"), "{rendered}");
     }
 
     #[test]
@@ -1482,11 +1520,10 @@ mod tests {
 
         let rendered = buffer_text(&buf, area);
         assert!(!rendered.contains("dbl-click copy"), "{rendered}");
+        assert!(!rendered.contains('◆'), "{rendered}");
         assert!(
-            rendered
-                .lines()
-                .any(|line| line.starts_with("│ ") || line.starts_with("│─")),
-            "selected non-openable segment should still show focus without replacing content: {rendered}"
+            (0..area.height).any(|y| buf[(area.x, y)].bg == Alpharius.card_bg()),
+            "selected non-openable segment should use a background highlight: {rendered}"
         );
     }
 

--- a/core/crates/omegon/src/tui/conversation.rs
+++ b/core/crates/omegon/src/tui/conversation.rs
@@ -1502,6 +1502,51 @@ impl ConversationView {
         self.segment_bounds_at(viewport, row).map(|(idx, _, _)| idx)
     }
 
+    /// Hit-test rows rendered from a conversation projection and return the
+    /// canonical segment index. The height cache belongs to the projected rows,
+    /// so it must not be indexed as if it described the canonical segment list.
+    pub fn projected_segment_at(
+        &self,
+        viewport: ratatui::prelude::Rect,
+        row: u16,
+        canonical_indices: &[usize],
+    ) -> Option<usize> {
+        let heights = &self.conv_state.heights;
+        if heights.len() != canonical_indices.len()
+            || row < viewport.y
+            || row >= viewport.bottom()
+        {
+            return None;
+        }
+
+        let viewport_height = viewport.height;
+        let total_height: u16 = heights.iter().copied().sum();
+        let top_offset = total_height.saturating_sub(viewport_height).saturating_sub(
+            self.conv_state
+                .scroll_offset
+                .min(total_height.saturating_sub(viewport_height)),
+        );
+        let viewport_origin_y = if total_height < viewport_height {
+            viewport.y.saturating_add(viewport_height - total_height)
+        } else {
+            viewport.y
+        };
+        if row < viewport_origin_y {
+            return None;
+        }
+
+        let target_y = top_offset + (row - viewport_origin_y);
+        let mut y_cursor = 0;
+        for (projected_idx, height) in heights.iter().copied().enumerate() {
+            let bottom = y_cursor + height;
+            if target_y >= y_cursor && target_y < bottom {
+                return canonical_indices.get(projected_idx).copied();
+            }
+            y_cursor = bottom;
+        }
+        None
+    }
+
     pub fn assistant_copy_button_at(
         &self,
         _viewport: ratatui::prelude::Rect,

--- a/core/crates/omegon/src/tui/mod.rs
+++ b/core/crates/omegon/src/tui/mod.rs
@@ -10036,11 +10036,23 @@ warning: {warning}"
     }
 
     fn open_selected_terminal_process_viewer(&mut self) -> bool {
-        let Some(session_id) = self.selected_terminal_session_id() else {
+        let Some(segment) = self.conversation.selected_segment() else {
             return false;
         };
+        let crate::tui::segments::SegmentContent::ToolCard { name, .. } = &segment.content else {
+            return false;
+        };
+        if name != "terminal" {
+            return false;
+        }
+
+        // A terminal card such as `list` may not carry a session id even when a
+        // later `start` result has been collapsed out of the Slim projection.
+        // Prefer the selected card's retained id, then use the same running/most-
+        // recent fallback as `/processes` rather than dropping into generic copy.
+        let session_id = self.selected_terminal_session_id().unwrap_or_default();
         self.open_process_viewer(&session_id);
-        true
+        self.process_viewer.is_some()
     }
 
     fn open_process_viewer(&mut self, session: &str) {
@@ -12571,6 +12583,11 @@ Scroll transcript:
                 is_error,
                 provenance,
             } => {
+                // Tool execution can mutate repository state (commit, checkout,
+                // merge, delegated worktrees). Refresh the branch affordance at
+                // the event boundary instead of retaining the startup snapshot.
+                self.workbench_state.workspace = self.current_workbench_workspace_context();
+
                 if name == crate::tool_registry::core::WAIT_FOR_OPERATOR
                     && self.pending_operator_wait.is_some()
                 {
@@ -14139,7 +14156,15 @@ pub async fn run_tui(
                                 // reflow short, bottom-aligned content. Prefer the semantic
                                 // target captured on that first press, rather than hit-testing
                                 // the second press against the newly shifted frame.
-                                let hit_idx = app.conversation.segment_at(area, mouse.row);
+                                let projection = conversation_projection::project_conversation(
+                                    app.conversation.segments(),
+                                    app.ui_presentation.level,
+                                );
+                                let hit_idx = app.conversation.projected_segment_at(
+                                    area,
+                                    mouse.row,
+                                    &projection.canonical_indices,
+                                );
                                 if let Some(idx) = prior_double_target.or(hit_idx) {
                                     let is_double = prior_double_target == Some(idx);
                                     let _ = app.handle_select_conversation_segment_action(

--- a/core/crates/omegon/src/tui/mod.rs
+++ b/core/crates/omegon/src/tui/mod.rs
@@ -10023,10 +10023,13 @@ warning: {warning}"
             return None;
         }
         let result = detail_result.as_deref()?;
-        let marker = "Terminal session '";
-        let after = result
-            .find(marker)
-            .map(|index| &result[index + marker.len()..])?;
+        let after = ["Started terminal '", "Terminal session '"]
+            .into_iter()
+            .find_map(|marker| {
+                result
+                    .find(marker)
+                    .map(|index| &result[index + marker.len()..])
+            })?;
         let (_, after_name) = after.split_once("' (")?;
         let (id, _) = after_name.split_once(')')?;
         crate::tools::terminal::execution_session_snapshot_by_id(id).map(|snapshot| snapshot.id)

--- a/core/crates/omegon/src/tui/mod.rs
+++ b/core/crates/omegon/src/tui/mod.rs
@@ -10032,6 +10032,14 @@ warning: {warning}"
         crate::tools::terminal::execution_session_snapshot_by_id(id).map(|snapshot| snapshot.id)
     }
 
+    fn open_selected_terminal_process_viewer(&mut self) -> bool {
+        let Some(session_id) = self.selected_terminal_session_id() else {
+            return false;
+        };
+        self.open_process_viewer(&session_id);
+        true
+    }
+
     fn open_process_viewer(&mut self, session: &str) {
         let requested = (!session.is_empty()).then(|| {
             crate::tools::terminal::execution_session_snapshot_by_id(session)
@@ -14137,7 +14145,9 @@ pub async fn run_tui(
                                         },
                                     );
                                     if is_double {
-                                        if app.conversation.toggle_image_attachments_at(idx) > 0 {
+                                        if app.open_selected_terminal_process_viewer()
+                                            || app.conversation.toggle_image_attachments_at(idx) > 0
+                                        {
                                             app.effects.pulse_conversation_action();
                                         } else if app
                                             .conversation

--- a/core/crates/omegon/src/tui/tests.rs
+++ b/core/crates/omegon/src/tui/tests.rs
@@ -5649,6 +5649,13 @@ fn selected_terminal_result_resolves_retained_process_session() {
         app.selected_terminal_session_id().as_deref(),
         Some(id.as_str())
     );
+    assert!(app.open_selected_terminal_process_viewer());
+    assert_eq!(
+        app.process_viewer
+            .as_ref()
+            .map(|viewer| viewer.session_id.as_str()),
+        Some(id.as_str())
+    );
 
     let _ = runtime.block_on(crate::tools::terminal::execute(
         "stop",

--- a/core/crates/omegon/src/tui/tests.rs
+++ b/core/crates/omegon/src/tui/tests.rs
@@ -2966,6 +2966,53 @@ fn conversation_segment_at_returns_clicked_segment() {
 }
 
 #[test]
+fn projected_conversation_hit_test_returns_canonical_segment() {
+    let mut cv = ConversationView::new();
+    cv.push_user("first");
+    cv.push_tool_start("t1", "terminal", Some("start session"), Some("start session"));
+    cv.push_tool_end(
+        "t1",
+        false,
+        Some("Started terminal 'session' (00000000-0000-0000-0000-000000000001) PID 1"),
+    );
+    cv.append_streaming("later assistant summary");
+    cv.finalize_message();
+
+    // Slim projection can omit or synthesize canonical rows. Reproduce the
+    // essential mismatch: projected row 1 is canonical terminal segment 1,
+    // while a later canonical segment still exists.
+    let projected = vec![cv.segments()[0].clone(), cv.segments()[1].clone()];
+    let canonical_indices = vec![0, 1];
+    let t = crate::tui::theme::Alpharius;
+    let area = Rect::new(0, 0, 100, 12);
+    let mut buf = Buffer::empty(area);
+    {
+        let (_, state) = cv.segments_and_state();
+        let widget = crate::tui::conv_widget::ConversationWidget::new(&projected, &t)
+            .with_mode(crate::tui::segments::SegmentRenderMode::Slim);
+        widget.render(area, &mut buf, state);
+    }
+
+    let terminal_row = (area.y..area.bottom())
+        .find(|&row| {
+            (area.x..area.right())
+                .map(|column| buf[(column, row)].symbol())
+                .collect::<String>()
+                .contains("terminal")
+        })
+        .expect("rendered terminal row");
+    assert_eq!(
+        cv.projected_segment_at(area, terminal_row, &canonical_indices),
+        Some(1)
+    );
+    assert_eq!(
+        cv.segment_at(area, terminal_row),
+        None,
+        "canonical hit-test must reject a projected height cache instead of selecting the wrong row"
+    );
+}
+
+#[test]
 fn toggle_pin_prefers_selected_tool_card() {
     let mut cv = ConversationView::new();
     cv.push_tool_start("t1", "bash", Some("echo one"), Some("echo one"));
@@ -5650,6 +5697,24 @@ fn selected_terminal_result_resolves_retained_process_session() {
         Some(id.as_str())
     );
     assert!(app.open_selected_terminal_process_viewer());
+    assert_eq!(
+        app.process_viewer
+            .as_ref()
+            .map(|viewer| viewer.session_id.as_str()),
+        Some(id.as_str())
+    );
+
+    app.process_viewer = None;
+    app.conversation
+        .push_tool_start("terminal-list-card", "terminal", Some("list"), None);
+    app.conversation
+        .push_tool_end("terminal-list-card", false, Some("No terminal sessions."));
+    let list_idx = app.conversation.segments().len() - 1;
+    app.conversation.select_segment(list_idx);
+    assert!(
+        app.open_selected_terminal_process_viewer(),
+        "a terminal card without an embedded id should open the retained running session"
+    );
     assert_eq!(
         app.process_viewer
             .as_ref()

--- a/core/crates/omegon/src/tui/tests.rs
+++ b/core/crates/omegon/src/tui/tests.rs
@@ -5639,7 +5639,7 @@ fn selected_terminal_result_resolves_retained_process_session() {
         "terminal-card",
         false,
         Some(&format!(
-            "Terminal session 'selected-card-viewer-test' ({id}) started."
+            "Started terminal 'selected-card-viewer-test' ({id}) PID 12345"
         )),
     );
     let idx = app.conversation.segments().len() - 1;

--- a/scripts/terminal_test_workload.py
+++ b/scripts/terminal_test_workload.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Deterministic long-running workload for exercising managed terminal sessions.
+
+The workload emits timestamped stdout/stderr heartbeats, accepts interactive
+commands over stdin, handles termination signals, and can exit naturally or
+fail on demand. It is intentionally dependency-free.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import select
+import signal
+import sys
+import time
+from dataclasses import dataclass
+from typing import TextIO
+
+
+@dataclass
+class State:
+    started: float
+    sequence: int = 0
+    stop_requested: bool = False
+    exit_code: int = 0
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--label", default="omegon-terminal-test", help="label included in every record")
+    parser.add_argument("--interval", type=float, default=1.0, help="seconds between heartbeats")
+    parser.add_argument("--duration", type=float, default=0.0, help="stop after N seconds; 0 runs until stopped")
+    parser.add_argument("--burst-every", type=int, default=10, help="emit a multi-line burst every N heartbeats; 0 disables")
+    parser.add_argument("--stderr-every", type=int, default=5, help="emit a stderr record every N heartbeats; 0 disables")
+    args = parser.parse_args(argv)
+    if args.interval <= 0:
+        parser.error("--interval must be greater than zero")
+    if args.duration < 0:
+        parser.error("--duration cannot be negative")
+    if args.burst_every < 0 or args.stderr_every < 0:
+        parser.error("--burst-every and --stderr-every cannot be negative")
+    return args
+
+
+def emit(stream: TextIO, kind: str, label: str, state: State, detail: str) -> None:
+    elapsed = time.monotonic() - state.started
+    print(
+        f"TERMINAL_TEST kind={kind} label={label} pid={os.getpid()} "
+        f"seq={state.sequence} elapsed={elapsed:.3f} {detail}",
+        file=stream,
+        flush=True,
+    )
+
+
+def handle_command(command: str, label: str, state: State) -> None:
+    normalized = command.strip().lower()
+    if not normalized:
+        return
+    if normalized in {"quit", "exit"}:
+        emit(sys.stdout, "command", label, state, "value=quit")
+        state.stop_requested = True
+    elif normalized == "fail":
+        emit(sys.stderr, "command", label, state, "value=fail exit_code=23")
+        state.exit_code = 23
+        state.stop_requested = True
+    elif normalized == "burst":
+        for index in range(8):
+            emit(sys.stdout, "burst", label, state, f"line={index + 1}/8 payload={'#' * (index + 1)}")
+    elif normalized == "status":
+        emit(sys.stdout, "status", label, state, "state=running stdin=responsive")
+    elif normalized == "help":
+        emit(sys.stdout, "help", label, state, "commands=help,status,burst,fail,quit")
+    else:
+        emit(sys.stderr, "unknown-command", label, state, f"value={normalized!r}")
+
+
+def poll_stdin(label: str, state: State) -> None:
+    try:
+        readable, _, _ = select.select([sys.stdin], [], [], 0)
+    except (OSError, ValueError):
+        return
+    if readable:
+        line = sys.stdin.readline()
+        if line:
+            handle_command(line, label, state)
+
+
+def run(args: argparse.Namespace) -> int:
+    state = State(started=time.monotonic())
+
+    def request_stop(signum: int, _frame: object) -> None:
+        emit(sys.stderr, "signal", args.label, state, f"number={signum}")
+        state.stop_requested = True
+
+    signal.signal(signal.SIGINT, request_stop)
+    signal.signal(signal.SIGTERM, request_stop)
+
+    emit(
+        sys.stdout,
+        "start",
+        args.label,
+        state,
+        f"interval={args.interval} duration={args.duration} cwd={os.getcwd()!r}",
+    )
+    emit(sys.stdout, "help", args.label, state, "commands=help,status,burst,fail,quit")
+
+    next_heartbeat = state.started
+    while not state.stop_requested:
+        now = time.monotonic()
+        if args.duration and now - state.started >= args.duration:
+            emit(sys.stdout, "duration", args.label, state, "state=complete")
+            break
+        poll_stdin(args.label, state)
+        if now >= next_heartbeat:
+            state.sequence += 1
+            emit(sys.stdout, "heartbeat", args.label, state, "state=running")
+            if args.stderr_every and state.sequence % args.stderr_every == 0:
+                emit(sys.stderr, "diagnostic", args.label, state, "stream=stderr level=notice")
+            if args.burst_every and state.sequence % args.burst_every == 0:
+                for index in range(4):
+                    emit(sys.stdout, "auto-burst", args.label, state, f"line={index + 1}/4")
+            next_heartbeat += args.interval
+        time.sleep(min(0.05, args.interval / 2))
+
+    emit(sys.stdout, "stop", args.label, state, f"exit_code={state.exit_code}")
+    return state.exit_code
+
+
+def main() -> int:
+    return run(parse_args())
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_terminal_test_workload.py
+++ b/scripts/tests/test_terminal_test_workload.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parents[1] / "terminal_test_workload.py"
+
+
+def run_workload(*args: str, stdin: str = "") -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *args],
+        input=stdin,
+        text=True,
+        capture_output=True,
+        timeout=5,
+        check=False,
+    )
+
+
+def test_duration_produces_lifecycle_and_mixed_streams() -> None:
+    result = run_workload(
+        "--label",
+        "duration-case",
+        "--interval",
+        "0.01",
+        "--duration",
+        "0.06",
+        "--stderr-every",
+        "2",
+        "--burst-every",
+        "3",
+    )
+
+    assert result.returncode == 0
+    assert "kind=start label=duration-case" in result.stdout
+    assert "kind=heartbeat label=duration-case" in result.stdout
+    assert "kind=auto-burst label=duration-case" in result.stdout
+    assert "kind=duration label=duration-case" in result.stdout
+    assert "kind=stop label=duration-case" in result.stdout
+    assert "kind=diagnostic label=duration-case" in result.stderr
+
+
+def test_interactive_status_burst_and_quit() -> None:
+    result = run_workload(
+        "--interval",
+        "0.01",
+        "--burst-every",
+        "0",
+        "--stderr-every",
+        "0",
+        stdin="status\nburst\nquit\n",
+    )
+
+    assert result.returncode == 0
+    assert "kind=status" in result.stdout
+    assert "stdin=responsive" in result.stdout
+    assert result.stdout.count("kind=burst") == 8
+    assert "kind=command" in result.stdout
+    assert "value=quit" in result.stdout
+
+
+def test_fail_command_returns_distinct_exit_code() -> None:
+    result = run_workload("--interval", "0.01", stdin="fail\n")
+
+    assert result.returncode == 23
+    assert "kind=command" in result.stderr
+    assert "value=fail exit_code=23" in result.stderr
+    assert "kind=stop" in result.stdout
+    assert "exit_code=23" in result.stdout
+
+
+if __name__ == "__main__":
+    tests = [value for name, value in sorted(globals().items()) if name.startswith("test_")]
+    for test in tests:
+        test()
+        print(f"ok {test.__name__}")


### PR DESCRIPTION
## Summary
- refresh the workbench branch affordance after tool-driven repository mutations instead of retaining startup state
- preserve canonical conversation hit targets through Slim projection
- route retained terminal cards to the live process viewer

## Integration target
Targets `feature/acp-integrations` so the TUI live-state fix can be reviewed and integrated with the ACP profile, context, and lifecycle affordances developed there.

## Validation
- `cargo check --message-format=short` passed
- `git diff --check` passed
- focused `cargo test -p omegon ...` compile was attempted but did not complete within the 10-minute harness limit; the lingering build was stopped
