### PR TITLE
refactor(tui): extract runtime boundaries and add wild-session tracing

### DIFF
--- a/core/crates/omegon/src/tui/frame_scheduler.rs
+++ b/core/crates/omegon/src/tui/frame_scheduler.rs
@@ -32,7 +32,7 @@ impl TuiFrameScheduler {
     pub(crate) fn new(now: Instant) -> Self {
         Self {
             min_frame_interval: Duration::from_millis(16),
-            max_idle_poll: Duration::from_millis(16),
+            max_idle_poll: Duration::from_secs(1),
             agent_budget: AgentDrainBudget {
                 max_events: 64,
                 max_duration: Duration::from_millis(4),
@@ -117,6 +117,15 @@ mod tests {
             scheduler.idle_poll_timeout(now + Duration::from_millis(16)),
             Duration::ZERO
         );
+    }
+
+    #[test]
+    fn clean_idle_uses_bounded_background_refresh() {
+        let now = Instant::now();
+        let mut scheduler = TuiFrameScheduler::new(now);
+        scheduler.after_draw(now);
+
+        assert_eq!(scheduler.idle_poll_timeout(now), Duration::from_secs(1));
     }
 
     #[test]

--- a/core/crates/omegon/src/tui/render.rs
+++ b/core/crates/omegon/src/tui/render.rs
@@ -423,7 +423,7 @@ impl App {
         if session_area.height > 0 {
             self.session_row.viewport_hint = if self.conversation.conv_state.scroll_offset > 0 {
                 Some(format!(
-                    "view detached ↑{} · End tail",
+                    "Detached · ↑{} · End: latest",
                     self.conversation.conv_state.scroll_offset
                 ))
             } else {

--- a/core/crates/omegon/src/tui/statusline.rs
+++ b/core/crates/omegon/src/tui/statusline.rs
@@ -182,35 +182,19 @@ impl SessionRow {
         let mut spans: Vec<Span<'static>> = Vec::new();
         let mut used = 0usize;
 
-        // Web-search liveness is persistent chrome, not a transient nag.
-        // Missing readiness data and an all-empty keyed set are both degraded:
-        // DDG scraping is a fallback floor, not an acceptable configured state.
-        let configured = self
-            .web_search_providers
-            .iter()
-            .filter(|(_, configured)| *configured)
-            .count();
-        let (label, color) = if configured == 0 {
-            ("WEB! ddg-only".to_string(), t.warning())
-        } else {
-            let ticks: String = self
-                .web_search_providers
-                .iter()
-                .map(|(_, configured)| if *configured { '●' } else { '○' })
-                .collect();
-            (format!("WEB {ticks}"), t.success())
-        };
-        let field = Span::styled(label, Style::default().fg(color));
-        let cost = sect.width() + field.width();
-        if used + cost < w {
-            spans.push(sect.clone());
-            spans.push(field);
-            used += cost;
+        // Explicit turn state is the primary compact-status signal. Operators
+        // should see what Omegon is doing before subsystem diagnostics.
+        if let Some(ref state) = self.turn_state {
+            let field = Span::styled(turn_state_field(state), Style::default().fg(t.warning()));
+            let cost = field.width();
+            if used + cost < w {
+                spans.push(field);
+                used += cost;
+            }
         }
 
-        // Detached conversation viewport. This is deliberately near the left
-        // pinned fields: when Slim auto-pins a long answer at its start, the
-        // operator must be able to tell that more transcript exists below.
+        // Detached transcript state requires operator awareness and therefore
+        // follows active turn state ahead of passive runtime health.
         if let Some(ref hint) = self.viewport_hint {
             let field = Span::styled(hint.clone(), Style::default().fg(t.warning()));
             let cost = sect.width() + field.width();
@@ -221,10 +205,9 @@ impl SessionRow {
             }
         }
 
-        // Explicit turn state: makes "done vs still running vs waiting"
-        // visible without requiring the operator to infer it from scrollback.
-        if let Some(ref state) = self.turn_state {
-            let field = Span::styled(turn_state_field(state), Style::default().fg(t.warning()));
+        // Contextual operator hints are actionable and outrank diagnostics.
+        if let Some(ref hint) = self.operator_hint {
+            let field = Span::styled(hint.clone(), Style::default().fg(t.accent_muted()));
             let cost = sect.width() + field.width();
             if used + cost < w {
                 spans.push(sect.clone());
@@ -233,13 +216,19 @@ impl SessionRow {
             }
         }
 
-        // Contextual operator hint. This is fed from real session/profile state
-        // in the TUI draw pass and sheds before activity metadata.
-        if let Some(ref hint) = self.operator_hint {
-            let field = Span::styled(hint.clone(), Style::default().fg(t.accent_muted()));
-            let cost = sect.width() + field.width();
+        // Search configuration is diagnostics, not permanent healthy chrome.
+        // Surface only explicit degraded keyed-provider state, and only once
+        // wider terminals have room after operator-relevant status.
+        let configured = self
+            .web_search_providers
+            .iter()
+            .filter(|(_, configured)| *configured)
+            .count();
+        if w >= 90 && !self.web_search_providers.is_empty() && configured == 0 {
+            let field = Span::styled("Search degraded", Style::default().fg(t.warning()));
+            let cost = sep.width() + field.width();
             if used + cost < w {
-                spans.push(sect.clone());
+                spans.push(sep.clone());
                 spans.push(field);
                 used += cost;
             }
@@ -480,6 +469,17 @@ fn file_activity_label(read: usize, modified: usize, width: usize) -> String {
 mod tests {
     use super::*;
 
+    fn render_session_row(row: &SessionRow, width: u16) -> String {
+        let backend = ratatui::backend::TestBackend::new(width, 1);
+        let mut terminal = ratatui::Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| row.render(frame.area(), frame, &super::super::theme::Alpharius))
+            .unwrap();
+        (0..width)
+            .map(|x| terminal.backend().buffer()[(x, 0)].symbol())
+            .collect()
+    }
+
     #[test]
     fn fmt_tokens_ranges() {
         assert_eq!(fmt_tokens(0), "0");
@@ -640,21 +640,15 @@ mod tests {
     }
 
     #[test]
-    fn unavailable_web_search_readiness_is_rendered_as_degraded() {
+    fn unavailable_web_search_readiness_is_hidden_without_inventory() {
         let sl = SessionRow {
             provider_connected: true,
             ..Default::default()
         };
 
-        let backend = ratatui::backend::TestBackend::new(160, 1);
-        let mut terminal = ratatui::Terminal::new(backend).unwrap();
-        terminal
-            .draw(|frame| sl.render(frame.area(), frame, &super::super::theme::Alpharius))
-            .unwrap();
-        let text = (0..160)
-            .map(|x| terminal.backend().buffer()[(x, 0)].symbol())
-            .collect::<String>();
-        assert!(text.contains("WEB! ddg-only"), "{text}");
+        let text = render_session_row(&sl, 160);
+        assert!(!text.contains("Search"), "{text}");
+        assert!(!text.contains("WEB"), "{text}");
     }
 
     #[test]
@@ -670,15 +664,8 @@ mod tests {
             ..Default::default()
         };
 
-        let backend = ratatui::backend::TestBackend::new(160, 1);
-        let mut terminal = ratatui::Terminal::new(backend).unwrap();
-        terminal
-            .draw(|frame| sl.render(frame.area(), frame, &super::super::theme::Alpharius))
-            .unwrap();
-        let text = (0..160)
-            .map(|x| terminal.backend().buffer()[(x, 0)].symbol())
-            .collect::<String>();
-        assert!(text.contains("WEB! ddg-only"), "{text}");
+        let text = render_session_row(&sl, 160);
+        assert!(text.contains("Search degraded"), "{text}");
     }
 
     #[test]
@@ -694,16 +681,9 @@ mod tests {
             ..Default::default()
         };
 
-        let backend = ratatui::backend::TestBackend::new(160, 1);
-        let mut terminal = ratatui::Terminal::new(backend).unwrap();
-        terminal
-            .draw(|frame| sl.render(frame.area(), frame, &super::super::theme::Alpharius))
-            .unwrap();
-        let text = (0..160)
-            .map(|x| terminal.backend().buffer()[(x, 0)].symbol())
-            .collect::<String>();
-        assert!(text.contains("WEB ○○●○"), "{text}");
-        assert!(!text.contains("ddg-only"), "{text}");
+        let text = render_session_row(&sl, 160);
+        assert!(!text.contains("WEB"), "{text}");
+        assert!(!text.contains("Search"), "{text}");
     }
 
     #[test]

--- a/core/crates/omegon/src/tui/tests.rs
+++ b/core/crates/omegon/src/tui/tests.rs
@@ -1887,7 +1887,7 @@ fn slim_status_line_marks_detached_conversation_viewport() {
     app.conversation.conv_state.user_scrolled = true;
 
     let text = render_app_to_string(&mut app, 120, 18);
-    assert!(text.contains("view detached ↑12 · End tail"), "{text}");
+    assert!(text.contains("Detached · ↑12 · End: latest"), "{text}");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- extract neutral operator/runtime command contracts and the interactive coordinator from the TUI monolith
- split menu effects, projections, history, tutorial state, and frame scheduling into focused modules
- enforce headless/interface dependency boundaries and add the stable external client API v1 contract fixtures
- prioritize operator input, coalesce background redraws, and compact the default status line while retaining detailed diagnostics
- add opt-in schema-v3 TUI performance tracing for wild-session diagnosis via `omegon --debug-tui`

## Review guide

1. `operator_commands.rs`, `runtime_commands.rs`, `interactive_coordinator.rs`
2. `tui/menu_effects.rs` and projection modules
3. `tui/frame_scheduler.rs`, `tui/mod.rs`, `tui/render.rs`
4. `ui_runtime/client_api.rs` and contract fixtures
5. boundary-check scripts and Cargo feature changes
6. `tui/runtime_trace.rs` and `docs/handoffs/live-tui-performance-run.md`

## Diagnostics privacy

`--debug-tui` records bounded five-second aggregate windows. It does not capture prompts, responses, terminal contents, tool arguments, command output, or extension payloads.

## Validation

- `just test-commit`
- `just clippy-changed`
- `just lint`
- `just test-rust`
- `python3 scripts/check_headless_dependency_boundary.py`
- `python3 scripts/check_interface_boundary_contract.py`
- `git diff --check`

All passed on the rebased branch.
