### PR TITLE
fix(tui): refresh idle timers without input events

### DIFF
--- a/core/crates/omegon/src/tui/frame_scheduler.rs
+++ b/core/crates/omegon/src/tui/frame_scheduler.rs
@@ -4,6 +4,7 @@ use std::time::{Duration, Instant};
 pub(crate) enum TuiDrawReason {
     OperatorInput,
     BackgroundEvent,
+    TimerTick,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -71,6 +72,13 @@ impl TuiFrameScheduler {
                 .min(self.max_idle_poll)
         } else {
             self.max_idle_poll
+                .saturating_sub(now.duration_since(self.last_draw))
+        }
+    }
+
+    pub(crate) fn mark_timer_due(&mut self, now: Instant) {
+        if !self.dirty && now.duration_since(self.last_draw) >= self.max_idle_poll {
+            self.mark_dirty(TuiDrawReason::TimerTick);
         }
     }
 }
@@ -126,6 +134,27 @@ mod tests {
         scheduler.after_draw(now);
 
         assert_eq!(scheduler.idle_poll_timeout(now), Duration::from_secs(1));
+        assert_eq!(
+            scheduler.idle_poll_timeout(now + Duration::from_millis(750)),
+            Duration::from_millis(250)
+        );
+        assert_eq!(
+            scheduler.idle_poll_timeout(now + Duration::from_secs(1)),
+            Duration::ZERO
+        );
+    }
+
+    #[test]
+    fn elapsed_idle_deadline_marks_timer_frame_due() {
+        let now = Instant::now();
+        let mut scheduler = TuiFrameScheduler::new(now);
+        scheduler.after_draw(now);
+
+        scheduler.mark_timer_due(now + Duration::from_millis(999));
+        assert!(!scheduler.should_draw(now + Duration::from_millis(999)));
+
+        scheduler.mark_timer_due(now + Duration::from_secs(1));
+        assert!(scheduler.should_draw(now + Duration::from_secs(1)));
     }
 
     #[test]

--- a/core/crates/omegon/src/tui/frame_scheduler.rs
+++ b/core/crates/omegon/src/tui/frame_scheduler.rs
@@ -59,10 +59,14 @@ impl TuiFrameScheduler {
         self.dirty && (self.urgent || now.duration_since(self.last_draw) >= self.min_frame_interval)
     }
 
-    pub(crate) fn after_draw(&mut self, now: Instant) {
+    pub(crate) fn is_urgent(&self) -> bool {
+        self.urgent
+    }
+
+    pub(crate) fn after_draw(&mut self, completed_at: Instant) {
         self.dirty = false;
         self.urgent = false;
-        self.last_draw = now;
+        self.last_draw = completed_at;
     }
 
     pub(crate) fn idle_poll_timeout(&self, now: Instant) -> Duration {
@@ -96,6 +100,31 @@ mod tests {
         scheduler.mark_dirty(TuiDrawReason::OperatorInput);
 
         assert!(scheduler.should_draw(now + Duration::from_millis(1)));
+    }
+
+    #[test]
+    fn operator_urgency_survives_until_the_draw() {
+        let now = Instant::now();
+        let mut scheduler = TuiFrameScheduler::new(now);
+        scheduler.after_draw(now);
+        scheduler.mark_dirty(TuiDrawReason::OperatorInput);
+        scheduler.mark_dirty(TuiDrawReason::BackgroundEvent);
+
+        assert!(scheduler.is_urgent());
+        scheduler.after_draw(now + Duration::from_millis(1));
+        assert!(!scheduler.is_urgent());
+    }
+
+    #[test]
+    fn draw_completion_restarts_idle_deadline() {
+        let now = Instant::now();
+        let mut scheduler = TuiFrameScheduler::new(now);
+        scheduler.after_draw(now + Duration::from_millis(40));
+
+        assert_eq!(
+            scheduler.idle_poll_timeout(now + Duration::from_millis(40)),
+            Duration::from_secs(1)
+        );
     }
 
     #[test]

--- a/core/crates/omegon/src/tui/mod.rs
+++ b/core/crates/omegon/src/tui/mod.rs
@@ -7563,7 +7563,7 @@ pub async fn run_tui(
         let now = std::time::Instant::now();
         scheduler.mark_timer_due(now);
         if scheduler.should_draw(now) {
-            let urgent = handled_input;
+            let urgent = scheduler.is_urgent();
             let draw_started = std::time::Instant::now();
             let mut callback_elapsed = Duration::ZERO;
             terminal.draw(|f| {
@@ -7590,7 +7590,7 @@ pub async fn run_tui(
                 });
                 trace.flush_if_due(draw_finished, runtime_contention_snapshot(&app));
             }
-            scheduler.after_draw(now);
+            scheduler.after_draw(draw_finished);
         } else if let Some(trace) = &mut runtime_trace {
             trace.record_dirty_without_draw();
             trace.flush_if_due(now, runtime_contention_snapshot(&app));

--- a/core/crates/omegon/src/tui/mod.rs
+++ b/core/crates/omegon/src/tui/mod.rs
@@ -7561,6 +7561,7 @@ pub async fn run_tui(
         // Coalesce background mutations to the frame interval. Operator input
         // remains urgent and draws immediately.
         let now = std::time::Instant::now();
+        scheduler.mark_timer_due(now);
         if scheduler.should_draw(now) {
             let urgent = handled_input;
             let draw_started = std::time::Instant::now();


### PR DESCRIPTION
## Summary

- trigger a bounded timer-driven redraw when the clean TUI idle deadline elapses
- preserve operator-input urgency until its frame is drawn
- restart idle deadlines at draw completion rather than draw start

This restores elapsed timers and other time-dependent status surfaces without returning to an unbounded render loop. Idle refresh remains capped at one frame per second, while operator input remains immediate and background traffic remains coalesced.

## Validation

- `cargo test -p omegon frame_scheduler::tests --locked`
- `just clippy-changed`
- `just test-commit`
- `git diff --check`

All passed.
