### PR TITLE
Fix plan and cleave approval UX binding

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,7 +43,7 @@ Omegon is a Rust-native agent loop and lifecycle engine. You are working on the 
 ## Key conventions
 
 - **Conventional commits** — `feat:`, `fix:`, `refactor:`, `chore:`, `docs:`. See `skills/git/SKILL.md`.
-- **Internal branch policy** — focused maintainer/agent changes may commit directly to `main`; use feature branches for multi-session work. External contributors work on branches in forks and open pull requests. Release hardening happens on `release/X.Y`; stable fixes merge forward with `just merge-release-forward`.
+- **Internal branch policy** — do not start maintainer/agent implementation work directly on `main`. Create a focused feature/fix branch before editing code or docs, even for small changes. External contributors work on branches in forks and open pull requests. Release hardening happens on `release/X.Y`; stable fixes merge forward with `just merge-release-forward`.
 - **Read before editing** — `edit` requires an exact current-text match. Read the target first and make the smallest justified replacement.
 - **Test after changes** — run the narrowest relevant test while iterating, then the landing gate appropriate to the change. Do not claim a full gate passed unless it actually ran.
 - **Cargo test filters** — Cargo accepts only one positional test-name filter per invocation. Use one shared substring, separate invocations, or a loop such as `for f in test_one test_two; do cargo test -p omegon "$f" --locked || exit 1; done`.

--- a/core/crates/omegon/src/conversation.rs
+++ b/core/crates/omegon/src/conversation.rs
@@ -230,6 +230,13 @@ pub struct IntentDocument {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub completion_ledger: Vec<CompletionLedgerEntry>,
 
+    /// Current continuation target for bare operator approvals such as
+    /// "continue", "proceed", or "make it so". This binds approval to a
+    /// concrete action identity instead of allowing stale plan state to capture
+    /// an ambiguous continuance.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pending_action: Option<PendingAction>,
+
     pub constraints_discovered: Vec<String>,
     pub failed_approaches: Vec<FailedApproach>,
     pub open_questions: Vec<String>,
@@ -360,6 +367,43 @@ impl EvidenceLedger {
     }
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(default)]
+pub struct PendingAction {
+    pub id: String,
+    pub source_turn: u32,
+    pub directive_digest: String,
+    pub summary: String,
+    pub repo_root: Option<PathBuf>,
+    pub branch: Option<String>,
+    pub created_at_ms: u64,
+    pub kind: PendingActionKind,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default, Hash)]
+#[serde(rename_all = "snake_case")]
+pub enum PendingActionKind {
+    #[default]
+    Continuation,
+    PlanExecution,
+    ToolApproval,
+    Other,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PendingActionResolution {
+    Ready(PendingAction),
+    Missing,
+    BranchMismatch {
+        action: PendingAction,
+        current_branch: Option<String>,
+    },
+    RepoMismatch {
+        action: PendingAction,
+        current_repo_root: Option<PathBuf>,
+    },
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct WorkItem {
     pub description: String,
@@ -480,8 +524,8 @@ impl PlanMode {
             Self::Planning => {
                 "Planning gate active: keep work to read/search/design until /plan approve."
             }
-            Self::Approved => "Plan approved: use /plan execute before mutation-heavy work.",
-            Self::Executing => "Plan executing: update progress with /plan advance or /plan skip.",
+            Self::Approved => "Plan approved: the agent may begin the bound action.",
+            Self::Executing => "Plan executing: keep Workbench progress current.",
             Self::Complete => "Plan complete: use /plan clear or set a new plan.",
         }
     }
@@ -613,7 +657,10 @@ impl IntentDocument {
                     self.apply_plan_action(PlanAction::Complete { index });
                 }
                 "skip" => self.apply_plan_action(PlanAction::Skip),
-                "clear" => self.apply_plan_action(PlanAction::Clear),
+                "clear" => {
+                    self.apply_plan_action(PlanAction::Clear);
+                    self.clear_pending_action();
+                }
                 "list" | "status" => self.apply_plan_action(PlanAction::View),
                 _ => {}
             }
@@ -631,6 +678,13 @@ impl IntentDocument {
 
     /// Auto-populate current_task from the first user message if not set.
     pub fn set_task_from_prompt(&mut self, prompt: &str) {
+        // Bare continuance approvals are authority grants against the pending
+        // action, not replacement task directives. Keeping the prior task here
+        // prevents "proceed" from erasing the directive it is approving.
+        if is_continuance_approval(prompt) {
+            return;
+        }
+
         // Always update to the latest user prompt — the user's most recent
         // instruction supersedes whatever was set before. Stale current_task
         // caused the first prompt to be delegated verbatim for the entire session.
@@ -668,6 +722,27 @@ impl IntentDocument {
             self.open_questions.push(normalized.to_string());
         }
     }
+}
+
+pub fn is_continuance_approval(text: &str) -> bool {
+    let lower = text.trim().to_ascii_lowercase();
+    matches!(
+        lower.as_str(),
+        "continue"
+            | "proceed"
+            | "please proceed"
+            | "go ahead"
+            | "do it"
+            | "do it already"
+            | "make it so"
+            | "get moving"
+            | "get it done"
+            | "stop talking"
+            | "stop talking and do it"
+    ) || lower.starts_with("continue on ")
+        || lower.starts_with("go ahead and ")
+        || lower.starts_with("please proceed with ")
+        || lower.starts_with("make it so: ")
 }
 
 const SESSION_SNAPSHOT_SCHEMA_VERSION: u16 = 1;
@@ -953,6 +1028,15 @@ impl ConversationState {
         }
         if let Some(approach) = &intent.approach {
             lines.push(format!("Approach: {approach}"));
+        }
+        if let Some(action) = &intent.pending_action {
+            lines.push(format!(
+                "Pending action: {} [{}] from turn {}",
+                action.summary, action.id, action.source_turn
+            ));
+            if let Some(branch) = &action.branch {
+                lines.push(format!("Pending action branch: {branch}"));
+            }
         }
         if !intent.files_modified.is_empty() {
             let files: Vec<_> = intent
@@ -4577,6 +4661,30 @@ mod tests {
     }
 
     #[test]
+    fn continuance_approval_does_not_replace_current_task() {
+        let mut intent = IntentDocument::default();
+        intent.set_task_from_prompt("Open PR #167 from feature branch");
+        intent.set_task_from_prompt("proceed");
+
+        assert_eq!(
+            intent.current_task.as_deref(),
+            Some("Open PR #167 from feature branch")
+        );
+    }
+
+    #[test]
+    fn continuance_approval_detection_avoids_substring_false_positives() {
+        assert!(is_continuance_approval("please proceed"));
+        assert!(is_continuance_approval("go ahead and patch it"));
+        assert!(!is_continuance_approval(
+            "Before we go ahead, inspect the diff"
+        ));
+        assert!(!is_continuance_approval(
+            "Do not proceed until validation finishes"
+        ));
+    }
+
+    #[test]
     fn work_plan_set_and_advance() {
         let mut intent = IntentDocument::default();
         intent.set_work_plan(vec!["Read code".into(), "Patch".into(), "Implement".into()]);
@@ -4672,6 +4780,87 @@ mod tests {
         intent.clear_work_plan();
         assert_eq!(intent.plan_mode, PlanMode::Off);
         assert!(intent.work_plan.is_empty());
+    }
+
+    #[test]
+    fn approving_work_plan_binds_pending_plan_execution_action() {
+        let mut intent = IntentDocument::default();
+        intent.stats.turns = 12;
+        intent.set_work_plan(vec![
+            "Inspect plan system".into(),
+            "Patch authority binding".into(),
+        ]);
+
+        intent.approve_work_plan();
+
+        let action = intent
+            .pending_action
+            .as_ref()
+            .expect("pending action bound");
+        assert_eq!(action.source_turn, 12);
+        assert_eq!(action.summary, "Inspect plan system");
+        assert_eq!(action.kind, PendingActionKind::PlanExecution);
+        assert_eq!(intent.plan_mode, PlanMode::Approved);
+    }
+
+    #[test]
+    fn executing_work_plan_consumes_pending_plan_action() {
+        let mut intent = IntentDocument::default();
+        intent.set_work_plan(vec!["Inspect".into()]);
+        intent.approve_work_plan();
+        assert!(intent.pending_action.is_some());
+
+        intent.execute_work_plan();
+
+        assert_eq!(intent.plan_mode, PlanMode::Executing);
+        assert!(intent.pending_action.is_none());
+    }
+
+    #[test]
+    fn pending_action_resolution_enforces_branch_affinity() {
+        let mut intent = IntentDocument::default();
+        let repo = PathBuf::from("/repo");
+        let action = intent.bind_pending_action(
+            7,
+            "Open PR #167",
+            Some(repo.clone()),
+            Some("feature/pr".into()),
+            PendingActionKind::Continuation,
+        );
+
+        assert_eq!(
+            intent.resolve_pending_action(Some(&repo), Some("feature/pr")),
+            PendingActionResolution::Ready(action.clone())
+        );
+        assert_eq!(
+            intent.resolve_pending_action(Some(&repo), Some("main")),
+            PendingActionResolution::BranchMismatch {
+                action,
+                current_branch: Some("main".into()),
+            }
+        );
+    }
+
+    #[test]
+    fn pending_action_resolution_enforces_repo_affinity() {
+        let mut intent = IntentDocument::default();
+        let repo = PathBuf::from("/repo");
+        let other = PathBuf::from("/other");
+        let action = intent.bind_pending_action(
+            3,
+            "Continue current task",
+            Some(repo),
+            Some("feature/work".into()),
+            PendingActionKind::PlanExecution,
+        );
+
+        assert_eq!(
+            intent.resolve_pending_action(Some(&other), Some("feature/work")),
+            PendingActionResolution::RepoMismatch {
+                action,
+                current_repo_root: Some(other),
+            }
+        );
     }
 
     #[test]

--- a/core/crates/omegon/src/features/cleave.rs
+++ b/core/crates/omegon/src/features/cleave.rs
@@ -315,7 +315,7 @@ fn cleave_assessment_approval(legacy_decision: &str, strategy: &Value) -> Value 
         "surface": Value::Null,
         "workbench_role": Value::Null,
         "reason": if recommended {
-            "Assessment recommends cleave. Invoke cleave_run to create a pending operator approval request; no approval menu exists yet."
+            "Assessment recommends cleave. Invoke cleave_run to create a pending operator approval request in the approval menu/action backend."
         } else {
             "Assessment does not recommend cleave execution; no approval request exists."
         },
@@ -2734,7 +2734,7 @@ mod tests {
             assessment["reason"]
                 .as_str()
                 .unwrap()
-                .contains("no approval menu exists yet")
+                .contains("approval menu/action backend")
         );
     }
 
@@ -3030,6 +3030,7 @@ mod tests {
         })));
     }
 
+    #[test]
     fn cleave_modify_records_change_request_and_evidence_reports_it() {
         let dir = tempfile::tempdir().unwrap();
         let mut feature = CleaveFeature::new(dir.path(), vec![], false);

--- a/core/crates/omegon/src/features/cleave.rs
+++ b/core/crates/omegon/src/features/cleave.rs
@@ -1562,6 +1562,21 @@ impl CleaveFeature {
         }))
     }
 
+    fn resolve_run_args_from_approval_id(&self, args: &Value, background: bool) -> Option<Value> {
+        if args.get("directive").is_some() || args.get("plan_json").is_some() {
+            return None;
+        }
+        let approval_id = args.get("approval_id")?.as_str()?.trim();
+        if approval_id.is_empty() {
+            return None;
+        }
+        let mut approved_args = self.approved_run_args_for_pending_approval(approval_id)?;
+        if let Some(map) = approved_args.as_object_mut() {
+            map.insert("background".into(), Value::Bool(background));
+        }
+        Some(approved_args)
+    }
+
     fn approval_command_response(&self, action: &str, rest: &str) -> CommandResult {
         let (id, tail) = rest.split_once(' ').unwrap_or((rest, ""));
         let id = id.trim();
@@ -1680,6 +1695,14 @@ Directive: {}{}",
             .get("background")
             .and_then(|v| v.as_bool())
             .unwrap_or(true);
+        let approved_args;
+        let args = if let Some(resolved) = self.resolve_run_args_from_approval_id(args, background)
+        {
+            approved_args = resolved;
+            &approved_args
+        } else {
+            args
+        };
         if !background {
             return self.execute_run_attached(args, cancel, None).await;
         }
@@ -2299,7 +2322,7 @@ impl Feature for CleaveFeature {
                             "description": "Pending cleave approval identifier from the menu gate, when available"
                         }
                     },
-                    "required": ["directive", "plan_json"]
+                    "required": []
                 }),
                 capabilities: vec![
                     omegon_traits::ToolCapability::StateChanging,
@@ -3090,6 +3113,49 @@ mod tests {
             "plan_json": plan_json,
             "max_parallel": 1
         })));
+    }
+
+    #[test]
+    fn approved_approval_id_resolves_exact_run_payload() {
+        let dir = tempfile::tempdir().unwrap();
+        let feature = CleaveFeature::new(dir.path(), vec![], false);
+        let plan_json = r#"{"children":[{"label":"one","description":"first","scope":["a.rs"]}]}"#;
+        feature.record_pending_approval("cleave_resume", "do resumable work", plan_json, 1, 1);
+        feature.update_pending_approval_state("cleave_resume", CleaveApprovalState::Approved);
+
+        let args = feature
+            .resolve_run_args_from_approval_id(&json!({"approval_id": "cleave_resume"}), true)
+            .expect("approved approval id should resolve to run args");
+
+        assert_eq!(args["directive"], "do resumable work");
+        assert_eq!(args["plan_json"], plan_json);
+        assert_eq!(args["max_parallel"], 1);
+        assert_eq!(args["background"], true);
+        assert_eq!(args["approved"], true);
+        assert_eq!(args["approval_id"], "cleave_resume");
+        assert!(feature.cleave_run_has_approved_gate(&args));
+    }
+
+    #[test]
+    fn approval_id_only_resume_rejects_unapproved_or_ambiguous_payloads() {
+        let dir = tempfile::tempdir().unwrap();
+        let feature = CleaveFeature::new(dir.path(), vec![], false);
+        let plan_json = r#"{"children":[{"label":"one","description":"first","scope":["a.rs"]}]}"#;
+        feature.record_pending_approval("cleave_blocked", "do blocked work", plan_json, 1, 1);
+
+        assert!(
+            feature
+                .resolve_run_args_from_approval_id(&json!({"approval_id": "cleave_blocked"}), true)
+                .is_none()
+        );
+        assert!(
+            feature
+                .resolve_run_args_from_approval_id(
+                    &json!({"approval_id": "cleave_blocked", "directive": "changed"}),
+                    true
+                )
+                .is_none()
+        );
     }
 
     #[test]

--- a/core/crates/omegon/src/loop.rs
+++ b/core/crates/omegon/src/loop.rs
@@ -549,6 +549,14 @@ pub async fn run(
             conversation.push_user(operator_correction_recovery_message());
         }
 
+        if crate::conversation::is_continuance_approval(conversation.last_user_prompt()) {
+            let (repo_root, branch) = current_repo_identity(&config.cwd);
+            let resolution = conversation
+                .intent
+                .resolve_pending_action(repo_root.as_deref(), branch.as_deref());
+            conversation.push_user(continuation_resolution_message(resolution));
+        }
+
         let _ = events.send(AgentEvent::TurnStart { turn });
         bus.emit(&omegon_traits::BusEvent::TurnStart { turn });
 
@@ -4065,6 +4073,47 @@ fn counts_as_real_work_for_dead_mouse(call: &ToolCall) -> bool {
                 .unwrap_or(false))
 }
 
+fn continuation_resolution_message(
+    resolution: crate::conversation::PendingActionResolution,
+) -> String {
+    match resolution {
+        crate::conversation::PendingActionResolution::Ready(action) => format!(
+            "[System: Operator continuance approval is bound to pending_action_id={} from turn {}: {}. Execute that bound action now; do not resume any older Workbench plan item unless it matches this pending action.]",
+            action.id, action.source_turn, action.summary
+        ),
+        crate::conversation::PendingActionResolution::Missing =>
+            "[System: The operator used continuance approval language, but there is no bound pending_action_id. Resolve the latest explicit operator directive from the live conversation; do not resume stale Workbench plan state.]"
+                .to_string(),
+        crate::conversation::PendingActionResolution::BranchMismatch {
+            action,
+            current_branch,
+        } => format!(
+            "[System: Continuance approval rejected for pending_action_id={}: branch mismatch. Pending action was bound to branch {:?}, current branch is {:?}. Do not mutate until the action is explicitly rebound or the checkout is reconciled.]",
+            action.id, action.branch, current_branch
+        ),
+        crate::conversation::PendingActionResolution::RepoMismatch {
+            action,
+            current_repo_root,
+        } => format!(
+            "[System: Continuance approval rejected for pending_action_id={}: repository mismatch. Pending action was bound to repo {:?}, current repo is {:?}. Do not mutate until the action is explicitly rebound or the workspace is reconciled.]",
+            action.id, action.repo_root, current_repo_root
+        ),
+    }
+}
+
+fn current_repo_identity(cwd: &std::path::Path) -> (Option<std::path::PathBuf>, Option<String>) {
+    let Ok(repo) = git2::Repository::discover(cwd) else {
+        return (None, None);
+    };
+    let repo_root = repo.workdir().map(std::path::Path::to_path_buf);
+    let branch = repo.head().ok().and_then(|head| {
+        head.is_branch()
+            .then(|| head.shorthand().map(str::to_string))
+            .flatten()
+    });
+    (repo_root, branch)
+}
+
 fn should_continue_text_only_turn(
     automation_level: crate::settings::AutomationLevel,
     user_prompt: &str,
@@ -4183,16 +4232,7 @@ fn looks_like_continuation_request(text: &str) -> bool {
 }
 
 fn user_prompt_is_continue_or_proceed(text: &str) -> bool {
-    let lower = text.trim().to_ascii_lowercase();
-    matches!(
-        lower.as_str(),
-        "continue" | "proceed" | "go ahead" | "do it" | "make it so"
-    ) || lower.contains("get it done")
-        || lower.contains("do it already")
-        || lower.contains("stop talking")
-        || lower.contains("make it so")
-        || lower.contains("go ahead")
-        || lower.contains("continue on")
+    crate::conversation::is_continuance_approval(text)
 }
 
 fn user_prompt_expects_concrete_action(text: &str) -> bool {
@@ -6917,6 +6957,90 @@ mod tests {
         ));
         assert!(!looks_like_completion("I'll write the fix next."));
         assert!(!looks_like_completion("short")); // too short
+    }
+
+    #[test]
+    fn continuation_resolution_message_binds_ready_action() {
+        let action = crate::conversation::PendingAction {
+            id: "pending-action-4-abcd".into(),
+            source_turn: 4,
+            directive_digest: "abcd".into(),
+            summary: "Open PR #167".into(),
+            repo_root: None,
+            branch: None,
+            created_at_ms: 1,
+            kind: crate::conversation::PendingActionKind::Continuation,
+        };
+
+        let message = continuation_resolution_message(
+            crate::conversation::PendingActionResolution::Ready(action),
+        );
+
+        assert!(message.contains("pending_action_id=pending-action-4-abcd"));
+        assert!(message.contains("Open PR #167"));
+        assert!(message.contains("do not resume any older Workbench plan item"));
+    }
+
+    #[test]
+    fn continuation_resolution_message_blocks_branch_mismatch() {
+        let action = crate::conversation::PendingAction {
+            id: "pending-action-9-deadbeef".into(),
+            source_turn: 9,
+            directive_digest: "deadbeef".into(),
+            summary: "Merge PR".into(),
+            repo_root: None,
+            branch: Some("feature/pr".into()),
+            created_at_ms: 1,
+            kind: crate::conversation::PendingActionKind::PlanExecution,
+        };
+
+        let message = continuation_resolution_message(
+            crate::conversation::PendingActionResolution::BranchMismatch {
+                action,
+                current_branch: Some("main".into()),
+            },
+        );
+
+        assert!(message.contains("branch mismatch"));
+        assert!(message.contains("Do not mutate"));
+        assert!(message.contains("feature/pr"));
+        assert!(message.contains("main"));
+    }
+
+    #[test]
+    fn continuation_resolution_message_blocks_repo_mismatch() {
+        let action = crate::conversation::PendingAction {
+            id: "pending-action-10-feedface".into(),
+            source_turn: 10,
+            directive_digest: "feedface".into(),
+            summary: "Finish release prep".into(),
+            repo_root: Some(std::path::PathBuf::from("/repo/a")),
+            branch: Some("release/0.29".into()),
+            created_at_ms: 1,
+            kind: crate::conversation::PendingActionKind::PlanExecution,
+        };
+
+        let message = continuation_resolution_message(
+            crate::conversation::PendingActionResolution::RepoMismatch {
+                action,
+                current_repo_root: Some(std::path::PathBuf::from("/repo/b")),
+            },
+        );
+
+        assert!(message.contains("repository mismatch"));
+        assert!(message.contains("Do not mutate"));
+        assert!(message.contains("/repo/a"));
+        assert!(message.contains("/repo/b"));
+    }
+
+    #[test]
+    fn continuation_resolution_message_handles_missing_action() {
+        let message =
+            continuation_resolution_message(crate::conversation::PendingActionResolution::Missing);
+
+        assert!(message.contains("no bound pending_action_id"));
+        assert!(message.contains("live conversation"));
+        assert!(message.contains("stale Workbench plan state"));
     }
 
     #[test]

--- a/core/crates/omegon/src/plan.rs
+++ b/core/crates/omegon/src/plan.rs
@@ -673,6 +673,20 @@ pub enum PlanAction {
     Clear,
 }
 
+fn current_repo_identity_for_plan() -> (Option<std::path::PathBuf>, Option<String>) {
+    let cwd = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
+    let Ok(repo) = git2::Repository::discover(cwd) else {
+        return (None, None);
+    };
+    let repo_root = repo.workdir().map(std::path::Path::to_path_buf);
+    let branch = repo.head().ok().and_then(|head| {
+        head.is_branch()
+            .then(|| head.shorthand().map(str::to_string))
+            .flatten()
+    });
+    (repo_root, branch)
+}
+
 impl crate::conversation::IntentDocument {
     fn next_ephemeral_plan_id(&mut self) -> String {
         self.next_plan_index = self.next_plan_index.saturating_add(1);
@@ -747,6 +761,74 @@ impl crate::conversation::IntentDocument {
         self.sync_visible_plan_from_legacy();
     }
 
+    pub fn bind_pending_action(
+        &mut self,
+        source_turn: u32,
+        summary: impl Into<String>,
+        repo_root: Option<std::path::PathBuf>,
+        branch: Option<String>,
+        kind: crate::conversation::PendingActionKind,
+    ) -> crate::conversation::PendingAction {
+        use std::hash::{Hash, Hasher};
+
+        let summary = summary.into();
+        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        source_turn.hash(&mut hasher);
+        summary.hash(&mut hasher);
+        repo_root.hash(&mut hasher);
+        branch.hash(&mut hasher);
+        kind.hash(&mut hasher);
+        let digest = format!("{:016x}", hasher.finish());
+        let created_at_ms = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|duration| duration.as_millis() as u64)
+            .unwrap_or_default();
+        let action = crate::conversation::PendingAction {
+            id: format!("pending-action-{source_turn}-{digest}"),
+            source_turn,
+            directive_digest: digest,
+            summary,
+            repo_root,
+            branch,
+            created_at_ms,
+            kind,
+        };
+        self.pending_action = Some(action.clone());
+        action
+    }
+
+    pub fn resolve_pending_action(
+        &self,
+        current_repo_root: Option<&std::path::Path>,
+        current_branch: Option<&str>,
+    ) -> crate::conversation::PendingActionResolution {
+        let Some(action) = self.pending_action.clone() else {
+            return crate::conversation::PendingActionResolution::Missing;
+        };
+        if let Some(bound_repo) = action.repo_root.as_deref() {
+            let repo_matches = current_repo_root.is_some_and(|current| current == bound_repo);
+            if !repo_matches {
+                return crate::conversation::PendingActionResolution::RepoMismatch {
+                    action,
+                    current_repo_root: current_repo_root.map(std::path::Path::to_path_buf),
+                };
+            }
+        }
+        if let Some(bound_branch) = action.branch.as_deref()
+            && current_branch != Some(bound_branch)
+        {
+            return crate::conversation::PendingActionResolution::BranchMismatch {
+                action,
+                current_branch: current_branch.map(str::to_string),
+            };
+        }
+        crate::conversation::PendingActionResolution::Ready(action)
+    }
+
+    pub fn clear_pending_action(&mut self) {
+        self.pending_action = None;
+    }
+
     fn set_work_plan_inner(&mut self, items: Vec<String>) {
         let replacing_session = self
             .visible_plan
@@ -791,6 +873,25 @@ impl crate::conversation::IntentDocument {
     fn approve_work_plan_inner(&mut self) {
         if !self.work_plan.is_empty() && !self.work_plan_complete() {
             self.plan_mode = PlanMode::Approved;
+            let summary = self
+                .work_plan
+                .iter()
+                .find(|item| item.status == WorkItemStatus::Active)
+                .or_else(|| {
+                    self.work_plan
+                        .iter()
+                        .find(|item| item.status == WorkItemStatus::Pending)
+                })
+                .map(|item| item.description.clone())
+                .unwrap_or_else(|| "Execute approved work plan".to_string());
+            let (repo_root, branch) = current_repo_identity_for_plan();
+            self.bind_pending_action(
+                self.stats.turns,
+                summary,
+                repo_root,
+                branch,
+                crate::conversation::PendingActionKind::PlanExecution,
+            );
         }
     }
 
@@ -802,6 +903,7 @@ impl crate::conversation::IntentDocument {
     fn execute_work_plan_inner(&mut self) {
         if !self.work_plan.is_empty() && !self.work_plan_complete() {
             self.plan_mode = PlanMode::Executing;
+            self.clear_pending_action();
             if !self
                 .work_plan
                 .iter()


### PR DESCRIPTION
## Summary
- bind bare continuance approvals to explicit pending actions with repo/branch affinity checks
- update approved plan execution guidance so Workbench state cannot capture stale continuations
- complete cleave approval UX backend flow with approval-id resume, payload drift checks, high-cost confirmation, and tested modify/evidence coverage
- document that agent implementation work should start on focused branches

## Validation
- cargo check --message-format=short on edited Rust files
- just test-filter continuance_approval
- just test-filter continuation_resolution_message
- just test-filter pending_action_resolution
- just test-filter approving_work_plan_binds_pending_plan_execution_action
- just test-filter executing_work_plan_consumes_pending_plan_action
- just test-filter approved_approval_id_resolves_exact_run_payload
- just test-filter approval_id_only_resume_rejects_unapproved_or_ambiguous_payloads
- just test-filter approved_gate_rejects_non_approved_states_and_payload_drift
- just test-filter high_cost_gate_rejects_approved_state_without_confirmation
- just test-filter cleave_approval_commands_update_pending_state
- just test-filter cleave_approval_commands_cover_alternate_states_and_missing_ids
- just test-filter cleave_modify_records_change_request_and_evidence_reports_it
- just clippy-changed

## Notes
- clippy/test runs report an existing future-incompat warning for proc-macro-error2 v2.0.1.