### PR TITLE
fix(secrets): keep direct TUI entry in terminal

### DIFF
--- a/core/crates/omegon/src/tui/mod.rs
+++ b/core/crates/omegon/src/tui/mod.rs
@@ -5178,19 +5178,8 @@ warning: {warning}"
             // /secrets set NAME → enter hidden input mode for arbitrary operator secrets.
             "set" if parts.len() == 2 && !parts[1].trim().is_empty() => {
                 let name = parts[1].trim();
-                let acquisition = crate::capabilities::secrets::secret_console_url(name);
-                if let Some(url) = acquisition {
-                    let url = url.to_string();
-                    std::thread::spawn(move || {
-                        let _ = open::that(url);
-                    });
-                }
                 self.editor.start_secret_input(name);
-                SlashResult::Display(if acquisition.is_some() {
-                    format!("Paste {name} — input hidden; provider console opened")
-                } else {
-                    format!("Paste {name} — input hidden")
-                })
+                SlashResult::Display(format!("Paste {name} — input hidden"))
             }
             // /secrets configure and /secrets set with no name/value → open shared menu
             "configure" | "set" if parts.len() < 3 => {

--- a/core/crates/omegon/src/tui/tests.rs
+++ b/core/crates/omegon/src/tui/tests.rs
@@ -6554,6 +6554,23 @@ fn slash_secrets_set_name_enters_hidden_secret_input_without_command_panel() {
 }
 
 #[test]
+fn slash_secrets_set_provider_key_does_not_claim_or_trigger_browser_acquisition() {
+    let mut app = test_app();
+    let tx = test_tx();
+
+    let result = app.handle_slash_command("/secrets set BRAVE_API_KEY", &tx);
+    let SlashResult::Display(message) = result else {
+        panic!("secret entry should return compact guidance");
+    };
+
+    assert_eq!(message, "Paste BRAVE_API_KEY — input hidden");
+    assert_eq!(
+        app.editor.secret_display().map(|(label, _)| label),
+        Some("BRAVE_API_KEY")
+    );
+}
+
+#[test]
 fn secret_name_selector_confirm_starts_hidden_secret_input() {
     let mut app = test_app();
     let tx = test_tx();


### PR DESCRIPTION
## Summary
- stop `/secrets set <NAME>` from automatically opening provider consoles
- keep direct secret capture inside the TUI hidden-input flow
- retain browser acquisition as an explicit secrets-menu action
- add regression coverage for provider-backed secret names

## Validation
- `cargo check --message-format=short`
- `just clippy-changed`

## Test note
Focused `cargo test` invocations built successfully but the shared Omegon test binary stalled after launch; no assertion failure was emitted.
