### PR TITLE
fix(variables): clarify and harden runtime contract

### DIFF
--- a/core/crates/omegon/src/control/variables.rs
+++ b/core/crates/omegon/src/control/variables.rs
@@ -10,10 +10,16 @@ fn session_variables()
     SESSION_VARIABLES.get_or_init(|| std::sync::Mutex::new(std::collections::BTreeMap::new()))
 }
 
+pub const MAX_VARIABLE_NAME_BYTES: usize = 128;
+pub const MAX_VARIABLE_VALUE_BYTES: usize = 16 * 1024;
+pub const MAX_VARIABLE_ENTRIES: usize = 256;
+
 fn valid_variable_name(name: &str) -> bool {
-    let mut chars = name.chars();
-    matches!(chars.next(), Some(c) if c == '_' || c.is_ascii_alphabetic())
-        && chars.all(|c| c == '_' || c.is_ascii_alphanumeric())
+    !name.is_empty() && name.len() <= MAX_VARIABLE_NAME_BYTES && {
+        let mut chars = name.chars();
+        matches!(chars.next(), Some(c) if c == '_' || c.is_ascii_alphabetic())
+            && chars.all(|c| c == '_' || c.is_ascii_alphanumeric())
+    }
 }
 
 fn variable_name_looks_secret(name: &str) -> bool {
@@ -66,7 +72,10 @@ pub async fn variables_view_response() -> SlashCommandResponse {
     if vars.is_empty() {
         out.push_str("No session variables set.\n");
     } else {
-        out.push_str(&format!("⚙ Variables ({}) — session scope\n\n", vars.len()));
+        out.push_str(&format!(
+            "⚙ Variables ({}) — process-local control-plane scope\n\n",
+            vars.len()
+        ));
         for (name, record) in vars.iter() {
             let warning = if variable_name_looks_secret(name) {
                 "  ⚠ name looks sensitive; consider /secrets"
@@ -80,7 +89,7 @@ pub async fn variables_view_response() -> SlashCommandResponse {
             ));
         }
     }
-    out.push_str("\nVariables are non-secret runtime config and may be displayed. Use /secrets for sensitive values.\n");
+    out.push_str("\nVariables are printable process-local control-plane values. They are not injected into commands or child processes unless a consumer explicitly binds them. Use /secrets for sensitive values.\n");
     out.push_str(
         "Commands:\n  /variables set NAME VALUE\n  /variables get NAME\n  /variables delete NAME",
     );
@@ -99,6 +108,14 @@ pub async fn variables_set_response(name: &str, value: &str) -> SlashCommandResp
             )),
         };
     }
+    if value.len() > MAX_VARIABLE_VALUE_BYTES {
+        return SlashCommandResponse {
+            accepted: false,
+            output: Some(format!(
+                "Variable value is too large (maximum {MAX_VARIABLE_VALUE_BYTES} bytes)."
+            )),
+        };
+    }
     let warning = if variable_name_looks_secret(name) {
         format!(
             "
@@ -107,14 +124,23 @@ pub async fn variables_set_response(name: &str, value: &str) -> SlashCommandResp
     } else {
         String::new()
     };
-    session_variables().lock().expect("variables lock").insert(
+    let mut variables = session_variables().lock().expect("variables lock");
+    if !variables.contains_key(name) && variables.len() >= MAX_VARIABLE_ENTRIES {
+        return SlashCommandResponse {
+            accepted: false,
+            output: Some(format!(
+                "Variable store is full (maximum {MAX_VARIABLE_ENTRIES} entries)."
+            )),
+        };
+    }
+    variables.insert(
         name.to_string(),
         crate::value_context::ValueRecord::public_control_plane(name, value),
     );
     SlashCommandResponse {
         accepted: true,
         output: Some(format!(
-            "✓ Variable {name} set in session scope.\n  Value: {value}{warning}"
+            "✓ Variable {name} set in process-local control-plane scope.\n  Value: {value}{warning}"
         )),
     }
 }
@@ -155,7 +181,7 @@ pub async fn variables_delete_response(name: &str) -> SlashCommandResponse {
     SlashCommandResponse {
         accepted: true,
         output: Some(if removed {
-            format!("✓ Variable '{name}' deleted from session scope.")
+            format!("✓ Variable '{name}' deleted from process-local control-plane scope.")
         } else {
             format!("Variable '{name}' was not set.")
         }),
@@ -213,5 +239,20 @@ mod variables_tests {
         let response = variables_set_response("1BAD", "value").await;
         assert!(!response.accepted);
         assert!(response.output.unwrap().contains("Invalid variable name"));
+    }
+
+    #[tokio::test]
+    async fn variables_reject_oversized_values() {
+        let value = "x".repeat(MAX_VARIABLE_VALUE_BYTES + 1);
+        let response = variables_set_response("OVERSIZED_VALUE", &value).await;
+        assert!(!response.accepted);
+        assert!(response.output.unwrap().contains("too large"));
+    }
+
+    #[tokio::test]
+    async fn variables_view_states_non_propagating_contract() {
+        let output = variables_view_response().await.output.unwrap();
+        assert!(output.contains("process-local control-plane"));
+        assert!(output.contains("not injected into commands or child processes"));
     }
 }

--- a/core/crates/omegon/src/control_actions.rs
+++ b/core/crates/omegon/src/control_actions.rs
@@ -449,6 +449,15 @@ pub fn classify_slash_command(name: &str, args: &str) -> ClassifiedAction {
         },
         "login" => (CanonicalAction::AuthLogin, ControlRole::Admin, false),
         "logout" => (CanonicalAction::AuthLogout, ControlRole::Admin, false),
+        "variables" | "vars" => match args.split_whitespace().next().unwrap_or("") {
+            "" | "list" | "status" | "get" => {
+                (CanonicalAction::StatusView, ControlRole::Read, true)
+            }
+            "set" | "delete" | "remove" | "rm" => {
+                (CanonicalAction::RuntimeModeSet, ControlRole::Edit, true)
+            }
+            _ => (CanonicalAction::Unknown, ControlRole::Admin, false),
+        },
         "secrets" => match args.split_whitespace().next().unwrap_or("") {
             "" | "list" => (CanonicalAction::SecretsView, ControlRole::Edit, false),
             "set" => (CanonicalAction::SecretsSet, ControlRole::Edit, false),

--- a/core/crates/omegon/src/runtime_commands.rs
+++ b/core/crates/omegon/src/runtime_commands.rs
@@ -724,24 +724,25 @@ pub(crate) fn canonical_slash_command(cmd: &str, args: &str) -> Option<Canonical
         }
 
         "variables" | "vars" => {
-            let parts: Vec<&str> = args.splitn(3, ' ').collect();
-            match parts.first().copied().unwrap_or("") {
-                "" | "list" | "status" => Some(CanonicalSlashCommand::VariablesView),
-                "set" if parts.len() >= 3 && !parts[1].trim().is_empty() => {
-                    Some(CanonicalSlashCommand::VariablesSet {
-                        name: parts[1].trim().to_string(),
-                        value: parts[2].trim().to_string(),
-                    })
-                }
-                "get" if parts.len() >= 2 && !parts[1].trim().is_empty() => Some(
-                    CanonicalSlashCommand::VariablesGet(parts[1].trim().to_string()),
-                ),
-                "delete" | "remove" | "rm" if parts.len() >= 2 && !parts[1].trim().is_empty() => {
-                    Some(CanonicalSlashCommand::VariablesDelete(
-                        parts[1].trim().to_string(),
-                    ))
-                }
-                _ => None,
+            let args = args.trim();
+            if args.is_empty() || matches!(args, "list" | "status") {
+                Some(CanonicalSlashCommand::VariablesView)
+            } else if let Some(rest) = args.strip_prefix("set").and_then(strip_command_separator) {
+                let (name, value) = split_name_and_remainder(rest)?;
+                Some(CanonicalSlashCommand::VariablesSet {
+                    name: name.to_string(),
+                    value: value.to_string(),
+                })
+            } else if let Some(rest) = args.strip_prefix("get").and_then(strip_command_separator) {
+                single_name(rest).map(|name| CanonicalSlashCommand::VariablesGet(name.to_string()))
+            } else if let Some(rest) = ["delete", "remove", "rm"]
+                .into_iter()
+                .find_map(|verb| args.strip_prefix(verb).and_then(strip_command_separator))
+            {
+                single_name(rest)
+                    .map(|name| CanonicalSlashCommand::VariablesDelete(name.to_string()))
+            } else {
+                None
             }
         }
         "secrets" => {
@@ -797,10 +798,51 @@ pub(crate) fn canonical_slash_command(cmd: &str, args: &str) -> Option<Canonical
     }
 }
 
+fn strip_command_separator(value: &str) -> Option<&str> {
+    value
+        .chars()
+        .next()
+        .is_some_and(char::is_whitespace)
+        .then(|| value.trim_start())
+}
+
+fn split_name_and_remainder(value: &str) -> Option<(&str, &str)> {
+    let separator = value.find(char::is_whitespace)?;
+    let name = &value[..separator];
+    let remainder = value[separator..].trim();
+    (!name.is_empty() && !remainder.is_empty()).then_some((name, remainder))
+}
+
+fn single_name(value: &str) -> Option<&str> {
+    let mut parts = value.split_whitespace();
+    let name = parts.next()?;
+    (parts.next().is_none()).then_some(name)
+}
+
 fn split_plan_items(raw: &str) -> Vec<String> {
     raw.split('|')
         .map(str::trim)
         .filter(|item| !item.is_empty())
         .map(ToString::to_string)
         .collect()
+}
+
+#[cfg(test)]
+mod variable_command_tests {
+    use super::*;
+
+    #[test]
+    fn variables_parser_accepts_general_whitespace_and_preserves_value_words() {
+        assert!(matches!(
+            canonical_slash_command("vars", "set\tPROJECT_ENV\tlocal dev"),
+            Some(CanonicalSlashCommand::VariablesSet { name, value })
+                if name == "PROJECT_ENV" && value == "local dev"
+        ));
+    }
+
+    #[test]
+    fn variables_parser_rejects_trailing_arguments_for_single_name_commands() {
+        assert!(canonical_slash_command("vars", "get ONE TWO").is_none());
+        assert!(canonical_slash_command("variables", "delete ONE TWO").is_none());
+    }
 }

--- a/core/crates/omegon/src/tool_registry.rs
+++ b/core/crates/omegon/src/tool_registry.rs
@@ -161,10 +161,11 @@ pub mod secrets {
     pub const SECRET_DELETE: &str = "secret_delete";
 }
 
-/// Printable session variable management — owned by `tools::variable_tools::VariableToolsProvider`
+/// Printable process-local control-plane variable management — owned by `tools::variable_tools::VariableToolsProvider`
 pub mod variables {
     pub const VARIABLE_SET: &str = "variable_set";
     pub const VARIABLE_LIST: &str = "variable_list";
+    pub const VARIABLE_GET: &str = "variable_get";
     pub const VARIABLE_DELETE: &str = "variable_delete";
 }
 
@@ -194,7 +195,7 @@ pub mod loop_jobs {
 /// **Maintenance rule**: every `pub const` above MUST appear here.
 /// The `registry_count_is_current` test will catch omissions.
 /// Number of statically registered tools (for splash screen display).
-pub const TOOL_COUNT: usize = 80;
+pub const TOOL_COUNT: usize = 81;
 
 pub fn all_static_names() -> Vec<&'static str> {
     vec![
@@ -286,9 +287,10 @@ pub fn all_static_names() -> Vec<&'static str> {
         secrets::SECRET_SET,
         secrets::SECRET_LIST,
         secrets::SECRET_DELETE,
-        // variables (3)
+        // variables (4)
         variables::VARIABLE_SET,
         variables::VARIABLE_LIST,
+        variables::VARIABLE_GET,
         variables::VARIABLE_DELETE,
         // mutation (4)
         mutation::MUTATION_REVIEW,

--- a/core/crates/omegon/src/tools/variable_tools.rs
+++ b/core/crates/omegon/src/tools/variable_tools.rs
@@ -1,6 +1,6 @@
-//! Agent-callable printable session variable tools.
+//! Agent-callable printable process-local control-plane variable tools.
 //!
-//! Variables are non-secret runtime configuration. Values are intentionally
+//! Variables are non-secret control-plane configuration. Values are intentionally
 //! visible in tool output; sensitive values belong in `/secrets` instead.
 
 use async_trait::async_trait;
@@ -17,7 +17,7 @@ impl ToolProvider for VariableToolsProvider {
             ToolDefinition {
                 name: crate::tool_registry::variables::VARIABLE_SET.into(),
                 label: "Variable Set".into(),
-                description: "Set a printable session-scoped runtime variable. Values are visible in outputs; use secret_set for credentials.".into(),
+                description: "Set a printable process-local control-plane variable. Values are visible in outputs, are not automatically injected into child processes, and credentials must use secret_set.".into(),
                 parameters: json!({
                     "type": "object",
                     "properties": {
@@ -32,7 +32,7 @@ impl ToolProvider for VariableToolsProvider {
             ToolDefinition {
                 name: crate::tool_registry::variables::VARIABLE_LIST.into(),
                 label: "Variable List".into(),
-                description: "List printable session variables and values.".into(),
+                description: "List printable process-local control-plane variables and values.".into(),
                 parameters: json!({
                     "type": "object",
                     "properties": {},
@@ -41,9 +41,23 @@ impl ToolProvider for VariableToolsProvider {
                 capabilities: vec![ToolCapability::Orientation],
             },
             ToolDefinition {
+                name: crate::tool_registry::variables::VARIABLE_GET.into(),
+                label: "Variable Get".into(),
+                description: "Read one printable process-local control-plane variable without disclosing every variable.".into(),
+                parameters: json!({
+                    "type": "object",
+                    "properties": {
+                        "name": { "type": "string", "description": "Variable name to read" }
+                    },
+                    "required": ["name"],
+                    "additionalProperties": false
+                }),
+                capabilities: vec![ToolCapability::Orientation],
+            },
+            ToolDefinition {
                 name: crate::tool_registry::variables::VARIABLE_DELETE.into(),
                 label: "Variable Delete".into(),
-                description: "Delete a printable session-scoped runtime variable.".into(),
+                description: "Delete a printable process-local control-plane variable.".into(),
                 parameters: json!({
                     "type": "object",
                     "properties": {
@@ -74,6 +88,16 @@ impl ToolProvider for VariableToolsProvider {
                     .get("value")
                     .and_then(|v| v.as_str())
                     .ok_or_else(|| anyhow::anyhow!("missing 'value' argument"))?;
+                if crate::control::variables::variable_name_has_sensitive_hint(name) {
+                    return Ok(ToolResult {
+                        content: vec![ContentBlock::Text {
+                            text: format!(
+                                "'{name}' looks like a secret name; use secret_set for credentials"
+                            ),
+                        }],
+                        details: json!({ "error": true }),
+                    });
+                }
                 let response = crate::control::variables::variables_set_response(name, value).await;
                 Ok(response_to_tool_result(
                     response,
@@ -94,6 +118,29 @@ impl ToolProvider for VariableToolsProvider {
                         })).collect::<Vec<_>>()
                     }),
                 ))
+            }
+            crate::tool_registry::variables::VARIABLE_GET => {
+                let name = args
+                    .get("name")
+                    .and_then(|v| v.as_str())
+                    .ok_or_else(|| anyhow::anyhow!("missing 'name' argument"))?;
+                let value = crate::control::variables::variables_snapshot()
+                    .into_iter()
+                    .find_map(|(candidate, value)| (candidate == name).then_some(value));
+                match value {
+                    Some(value) => Ok(ToolResult {
+                        content: vec![ContentBlock::Text {
+                            text: format!("{name}={value}"),
+                        }],
+                        details: json!({ "name": name, "value": value }),
+                    }),
+                    None => Ok(ToolResult {
+                        content: vec![ContentBlock::Text {
+                            text: format!("Variable '{name}' is not set."),
+                        }],
+                        details: json!({ "error": true }),
+                    }),
+                }
             }
             crate::tool_registry::variables::VARIABLE_DELETE => {
                 let name = args


### PR DESCRIPTION
## Summary
- describe variables accurately as printable process-local control-plane values, not session environment
- harden variable name/value/count bounds and whitespace parsing
- add least-disclosure `variable_get` and reject credential-shaped names from agent `variable_set`
- classify `/vars` reads and mutations explicitly for RBAC

## Validation
- `cargo test -p omegon variable_command_tests -- --test-threads=1`
- `cargo check -p omegon`
- `just clippy-changed`

Note: the broad `variables_` filter intersects unrelated long-running tests, so focused parser tests were used instead.