### PR TITLE
fix(link): select freshest checkout binary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [Semantic V
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed checkout-local launcher resolution when both optimized build profiles exist. The stable launcher now selects the most recently built executable instead of always preferring `target/release`, preventing an old linked release artifact from shadowing a fresh `just run` development build.
+
 ## [0.29.0] - 2026-08-08
 
 ### Added

--- a/scripts/omegon-launcher.sh
+++ b/scripts/omegon-launcher.sh
@@ -28,15 +28,23 @@ target_for_root() {
     local root="$1"
     local rel="$root/target/release/omegon"
     local dev="$root/target/dev-release/omegon"
+    local rel_mtime=0 dev_mtime=0
+
     if is_executable_target "$rel"; then
-        printf '%s\n' "$rel"
-        return 0
+        rel_mtime="$(stat -c %Y "$rel" 2>/dev/null || stat -f %m "$rel")"
     fi
     if is_executable_target "$dev"; then
-        printf '%s\n' "$dev"
-        return 0
+        dev_mtime="$(stat -c %Y "$dev" 2>/dev/null || stat -f %m "$dev")"
     fi
-    return 1
+
+    if (( rel_mtime == 0 && dev_mtime == 0 )); then
+        return 1
+    fi
+    if (( dev_mtime > rel_mtime )); then
+        printf '%s\n' "$dev"
+    else
+        printf '%s\n' "$rel"
+    fi
 }
 
 resolve_target() {

--- a/scripts/omegon-launcher.sh
+++ b/scripts/omegon-launcher.sh
@@ -30,6 +30,9 @@ target_for_root() {
     local dev="$root/target/dev-release/omegon"
     local rel_mtime=0 dev_mtime=0
 
+    # `just link` builds release while `just run` builds dev-release. When both
+    # artifacts remain in one checkout, recency is the only profile-neutral
+    # indication of which build the operator most recently requested.
     if is_executable_target "$rel"; then
         rel_mtime="$(stat -c %Y "$rel" 2>/dev/null || stat -f %m "$rel")"
     fi

--- a/scripts/tests/test_omegon_launcher.py
+++ b/scripts/tests/test_omegon_launcher.py
@@ -138,6 +138,41 @@ def test_paths_with_spaces_work_for_dev_root_and_channel():
         assert same_target(res.stdout, channel / "target/release/omegon")
 
 
+def test_newer_dev_release_wins_over_stale_release_under_checkout():
+    with tempfile.TemporaryDirectory() as td:
+        base = Path(td); home = base / "home"; home.mkdir()
+        checkout = base / "checkout"; nested = checkout / "nested"; nested.mkdir(parents=True)
+        (checkout / "core/crates/omegon").mkdir(parents=True); (checkout / "Cargo.toml").write_text("[workspace]\n")
+        release = checkout / "target/release/omegon"
+        dev_release = checkout / "target/dev-release/omegon"
+        make_bin(release, "stale release")
+        os.utime(release, (1, 1))
+        make_bin(dev_release, "fresh dev-release")
+        os.utime(dev_release, (2, 2))
+        res = run(["--which"], nested, home)
+        assert res.returncode == 0, res.stderr
+        assert "reason: nearest-checkout" in res.stdout
+        assert same_target(res.stdout, dev_release)
+        assert "omegon test fresh dev-release" in res.stdout
+
+
+def test_newer_release_wins_over_stale_dev_release_under_checkout():
+    with tempfile.TemporaryDirectory() as td:
+        base = Path(td); home = base / "home"; home.mkdir()
+        checkout = base / "checkout"; nested = checkout / "nested"; nested.mkdir(parents=True)
+        (checkout / "core/crates/omegon").mkdir(parents=True); (checkout / "Cargo.toml").write_text("[workspace]\n")
+        release = checkout / "target/release/omegon"
+        dev_release = checkout / "target/dev-release/omegon"
+        make_bin(dev_release, "stale dev-release")
+        os.utime(dev_release, (1, 1))
+        make_bin(release, "fresh release")
+        os.utime(release, (2, 2))
+        res = run(["--which"], nested, home)
+        assert res.returncode == 0, res.stderr
+        assert same_target(res.stdout, release)
+        assert "omegon test fresh release" in res.stdout
+
+
 def test_dev_release_fallback_under_checkout():
     with tempfile.TemporaryDirectory() as td:
         base = Path(td); home = base / "home"; home.mkdir()

--- a/scripts/tests/test_omegon_launcher.py
+++ b/scripts/tests/test_omegon_launcher.py
@@ -173,6 +173,23 @@ def test_newer_release_wins_over_stale_dev_release_under_checkout():
         assert "omegon test fresh release" in res.stdout
 
 
+def test_equal_mtimes_prefer_release_under_checkout():
+    with tempfile.TemporaryDirectory() as td:
+        base = Path(td); home = base / "home"; home.mkdir()
+        checkout = base / "checkout"; nested = checkout / "nested"; nested.mkdir(parents=True)
+        (checkout / "core/crates/omegon").mkdir(parents=True); (checkout / "Cargo.toml").write_text("[workspace]\n")
+        release = checkout / "target/release/omegon"
+        dev_release = checkout / "target/dev-release/omegon"
+        make_bin(release, "release tie winner")
+        make_bin(dev_release, "dev-release tie loser")
+        os.utime(release, (1, 1))
+        os.utime(dev_release, (1, 1))
+        res = run(["--which"], nested, home)
+        assert res.returncode == 0, res.stderr
+        assert same_target(res.stdout, release)
+        assert "omegon test release tie winner" in res.stdout
+
+
 def test_dev_release_fallback_under_checkout():
     with tempfile.TemporaryDirectory() as td:
         base = Path(td); home = base / "home"; home.mkdir()


### PR DESCRIPTION
## Summary
- choose the freshest executable when both `target/release/omegon` and `target/dev-release/omegon` exist in a checkout
- preserve release as the deterministic tie-breaker
- cover stale release, stale dev-release, and equal-mtime cases
- document the launcher fix in the changelog

## Product defect
`just link` leaves a release artifact while `just run` builds the dev-release profile. The launcher previously preferred release by existence alone, so an old 0.27.1 release binary could shadow a current development build in `omegon-secundus`.

## Validation
- `just test-dev-scripts`
- `bash -n scripts/omegon-launcher.sh`
- `git diff --check origin/main...HEAD`