### PR TITLE
fix(ci): isolate secret tests from host keyring

### DIFF
--- a/core/crates/omegon-secrets/src/lib.rs
+++ b/core/crates/omegon-secrets/src/lib.rs
@@ -172,6 +172,20 @@ impl SecretsManager {
         Ok(mgr)
     }
 
+    /// Create a secrets manager with an already initialized managed store.
+    ///
+    /// This is primarily an injection seam for tests and embedded runtimes that
+    /// cannot access the host keyring. Normal applications should use [`Self::new`].
+    #[doc(hidden)]
+    pub fn new_with_managed_store(
+        config_dir: &std::path::Path,
+        managed_store: SecretStore,
+    ) -> anyhow::Result<Self> {
+        let manager = Self::new(config_dir)?;
+        *manager.managed_store.lock().unwrap() = Some(managed_store);
+        Ok(manager)
+    }
+
     /// Initialize Vault client if configuration is found.
     ///
     /// **Fail-closed**: only stores `Some(client)` when authentication succeeds.

--- a/core/crates/omegon/src/control/variables.rs
+++ b/core/crates/omegon/src/control/variables.rs
@@ -207,7 +207,7 @@ mod variables_tests {
         let output = list.output.unwrap();
         assert!(output.contains(&name));
         assert!(output.contains("staging"));
-        assert!(output.contains("non-secret"));
+        assert!(output.contains("printable process-local control-plane values"));
 
         let delete = variables_delete_response(&name).await;
         assert!(delete.accepted);

--- a/core/crates/omegon/src/features/cleave.rs
+++ b/core/crates/omegon/src/features/cleave.rs
@@ -2705,10 +2705,19 @@ mod tests {
     use super::*;
     use omegon_traits::OperationKind;
 
+    fn test_secrets_manager(config_dir: &std::path::Path) -> omegon_secrets::SecretsManager {
+        let store = omegon_secrets::SecretStore::init_passphrase(
+            &config_dir.join("secrets.db"),
+            "cleave-test-passphrase",
+        )
+        .expect("test managed store");
+        omegon_secrets::SecretsManager::new_with_managed_store(config_dir, store).expect("manager")
+    }
+
     #[test]
     fn cleave_child_secret_env_reads_live_manager_state() {
         let temp = tempfile::tempdir().expect("tempdir");
-        let secrets = Arc::new(omegon_secrets::SecretsManager::new(temp.path()).expect("manager"));
+        let secrets = Arc::new(test_secrets_manager(temp.path()));
         let feature = CleaveFeature::new(temp.path(), vec![], false).with_secrets(secrets.clone());
 
         assert!(feature.child_secret_env().is_empty());

--- a/core/crates/omegon/src/features/delegate.rs
+++ b/core/crates/omegon/src/features/delegate.rs
@@ -2761,10 +2761,19 @@ mod tests {
     use super::*;
     use tempfile::TempDir;
 
+    fn test_secrets_manager(config_dir: &std::path::Path) -> omegon_secrets::SecretsManager {
+        let store = omegon_secrets::SecretStore::init_passphrase(
+            &config_dir.join("secrets.db"),
+            "delegate-test-passphrase",
+        )
+        .expect("test managed store");
+        omegon_secrets::SecretsManager::new_with_managed_store(config_dir, store).expect("manager")
+    }
+
     #[test]
     fn delegate_runner_reads_live_secret_environment() {
         let temp = tempfile::tempdir().expect("tempdir");
-        let secrets = Arc::new(omegon_secrets::SecretsManager::new(temp.path()).expect("manager"));
+        let secrets = Arc::new(test_secrets_manager(temp.path()));
         let runner = DelegateRunner::new_with_safety(
             temp.path().to_path_buf(),
             Arc::new(DelegateResultStore::new()),

--- a/core/crates/omegon/src/tools/secret_tools.rs
+++ b/core/crates/omegon/src/tools/secret_tools.rs
@@ -178,20 +178,17 @@ impl ToolProvider for SecretToolsProvider {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::Once;
-
-    static SUPPRESS_HOST_KEYRING: Once = Once::new();
 
     fn provider() -> SecretToolsProvider {
-        SUPPRESS_HOST_KEYRING.call_once(|| {
-            // Tests in this crate compile omegon-secrets as a normal dependency,
-            // so its #[cfg(test)] in-memory keyring backend is not active. Force
-            // runtime suppression before constructing SecretsManager so validation
-            // never prompts the operator's real macOS Keychain.
-            unsafe { std::env::set_var("OMEGON_NO_KEYRING", "1") };
-        });
         let dir = tempfile::tempdir().unwrap();
-        let secrets = Arc::new(omegon_secrets::SecretsManager::new(dir.path()).unwrap());
+        let store = omegon_secrets::SecretStore::init_passphrase(
+            &dir.path().join("secrets.db"),
+            "secret-tools-test-passphrase",
+        )
+        .unwrap();
+        let secrets = Arc::new(
+            omegon_secrets::SecretsManager::new_with_managed_store(dir.path(), store).unwrap(),
+        );
         SecretToolsProvider::new(secrets)
     }
 


### PR DESCRIPTION
## Summary
- inject a passphrase-backed managed store into tests that exercise managed secret writes
- remove process-global keyring suppression from secret tool tests
- update the variables assertion to the current operator-facing contract
- preserve the production guarantee that suppressed keyring writes fail rather than reporting false persistence

## Validation
- four previously failing focused tests
- `just test-secrets`
- `just test-crate omegon` (4183 unit tests plus integration tests)
- `just clippy-changed`
- `cargo fmt --all`
- `git diff --check`