### PR TITLE
fix(tui): preserve ordered streaming presentation

### DIFF
--- a/core/crates/omegon/src/tui/agent_events.rs
+++ b/core/crates/omegon/src/tui/agent_events.rs
@@ -239,6 +239,9 @@ impl App {
             AgentEvent::MessageStart { .. } => {
                 self.slim_turn_state = SlimTurnState::OpeningStream;
             }
+            AgentEvent::MessageEnd => {
+                self.conversation.finalize_message();
+            }
             AgentEvent::MessageChunk { text } => {
                 self.slim_turn_state = SlimTurnState::Responding;
                 let was_streaming = self.conversation.is_streaming();

--- a/core/crates/omegon/src/tui/agent_events.rs
+++ b/core/crates/omegon/src/tui/agent_events.rs
@@ -102,6 +102,10 @@ impl App {
     }
 
     pub(super) fn handle_agent_event(&mut self, event: AgentEvent) {
+        let decision = self.stream_presentation.classify(event.clone());
+        if !decision.apply_now {
+            return;
+        }
         match event {
             AgentEvent::TurnStart { turn } => {
                 self.agent_active = true;

--- a/core/crates/omegon/src/tui/markdown_publication.rs
+++ b/core/crates/omegon/src/tui/markdown_publication.rs
@@ -1,0 +1,162 @@
+//! Stable Markdown publication boundaries for progressively streamed assistant text.
+//!
+//! Transport chunks are intentionally absent from this module. Projection is a
+//! pure function of canonical message text and completion state, so a chunking
+//! change cannot alter the rendered document boundary.
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct MarkdownPublication<'a> {
+    pub(crate) committed: &'a str,
+    pub(crate) provisional: &'a str,
+}
+
+pub(crate) fn project(text: &str, complete: bool) -> MarkdownPublication<'_> {
+    if complete || text.is_empty() {
+        return MarkdownPublication {
+            committed: text,
+            provisional: "",
+        };
+    }
+
+    let mut in_fence = false;
+    let mut fence_start = None;
+    let mut stable_end = 0;
+    let mut offset = 0;
+
+    for line_with_ending in text.split_inclusive('\n') {
+        let terminated = line_with_ending.ends_with('\n');
+        let line = line_with_ending
+            .strip_suffix('\n')
+            .unwrap_or(line_with_ending);
+        let trimmed = line.trim();
+        let line_end = offset + line_with_ending.len();
+
+        if trimmed.starts_with("```") {
+            if in_fence {
+                in_fence = false;
+                fence_start = None;
+                if terminated {
+                    stable_end = line_end;
+                }
+            } else {
+                in_fence = true;
+                fence_start = Some(offset);
+            }
+        } else if terminated
+            && !in_fence
+            && (trimmed.is_empty() || is_completed_standalone_block(trimmed))
+        {
+            stable_end = line_end;
+        }
+
+        offset = line_end;
+    }
+
+    // An open fence and everything after its opener must remain provisional,
+    // even if a prior scan observed boundary-looking lines inside the fence.
+    if let Some(start) = fence_start {
+        stable_end = stable_end.min(start);
+    }
+
+    MarkdownPublication {
+        committed: &text[..stable_end],
+        provisional: &text[stable_end..],
+    }
+}
+
+fn is_completed_standalone_block(trimmed: &str) -> bool {
+    is_atx_heading(trimmed) || is_horizontal_rule(trimmed)
+}
+
+fn is_atx_heading(trimmed: &str) -> bool {
+    let hashes = trimmed.bytes().take_while(|byte| *byte == b'#').count();
+    (1..=6).contains(&hashes)
+        && trimmed
+            .as_bytes()
+            .get(hashes)
+            .is_some_and(u8::is_ascii_whitespace)
+}
+
+fn is_horizontal_rule(trimmed: &str) -> bool {
+    let mut marker = None;
+    let mut count = 0;
+    for ch in trimmed.chars().filter(|ch| !ch.is_whitespace()) {
+        if !matches!(ch, '-' | '*' | '_') {
+            return false;
+        }
+        match marker {
+            Some(expected) if expected != ch => return false,
+            None => marker = Some(ch),
+            _ => {}
+        }
+        count += 1;
+    }
+    count >= 3
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unclosed_fence_and_its_body_remain_provisional() {
+        let text = "stable paragraph\n\n```rust\nfn main() {\n";
+        let projection = project(text, false);
+        assert_eq!(projection.committed, "stable paragraph\n\n");
+        assert_eq!(projection.provisional, "```rust\nfn main() {\n");
+    }
+
+    #[test]
+    fn closed_fence_is_a_stable_boundary() {
+        let text = "```rust\nfn main() {}\n```\ntrailing";
+        let projection = project(text, false);
+        assert_eq!(projection.committed, "```rust\nfn main() {}\n```\n");
+        assert_eq!(projection.provisional, "trailing");
+    }
+
+    #[test]
+    fn incomplete_table_remains_one_provisional_tail() {
+        let text = "intro\n\n| name | value |\n| --- | --- |\n| alpha";
+        let projection = project(text, false);
+        assert_eq!(projection.committed, "intro\n\n");
+        assert_eq!(
+            projection.provisional,
+            "| name | value |\n| --- | --- |\n| alpha"
+        );
+    }
+
+    #[test]
+    fn unterminated_heading_line_remains_provisional() {
+        let projection = project("stable\n\n## partial", false);
+        assert_eq!(projection.committed, "stable\n\n");
+        assert_eq!(projection.provisional, "## partial");
+    }
+
+    #[test]
+    fn closed_fence_without_terminal_newline_remains_provisional() {
+        let projection = project("intro\n\n```rust\nfn main() {}\n```", false);
+        assert_eq!(projection.committed, "intro\n\n");
+        assert_eq!(projection.provisional, "```rust\nfn main() {}\n```");
+    }
+
+    #[test]
+    fn completed_heading_line_is_a_stable_boundary() {
+        let projection = project("## stable heading\ntail", false);
+        assert_eq!(projection.committed, "## stable heading\n");
+        assert_eq!(projection.provisional, "tail");
+    }
+
+    #[test]
+    fn completion_commits_only_the_remaining_tail() {
+        let text = "intro\n\n| name | value |\n| --- | --- |\n| alpha | one |";
+        let streaming = project(text, false);
+        let completed = project(text, true);
+        assert_eq!(streaming.committed, "intro\n\n");
+        assert_eq!(completed.committed, text);
+        assert_eq!(completed.provisional, "");
+        assert_eq!(
+            &completed.committed[streaming.committed.len()..],
+            streaming.provisional
+        );
+    }
+}

--- a/core/crates/omegon/src/tui/mod.rs
+++ b/core/crates/omegon/src/tui/mod.rs
@@ -52,6 +52,7 @@ pub mod spinner;
 pub mod splash;
 mod startup_splash;
 pub mod statusline;
+mod streaming_presentation;
 pub mod tab_bar;
 pub mod theme;
 pub mod tool_inspection;
@@ -410,6 +411,7 @@ struct MenuInput {
 struct App {
     editor: Editor,
     conversation: ConversationView,
+    stream_presentation: streaming_presentation::StreamingPresentationController,
     agent_active: bool,
     should_quit: bool,
     turn: u32,
@@ -868,6 +870,7 @@ impl App {
         Self {
             editor: Editor::new(),
             conversation: ConversationView::new(),
+            stream_presentation: streaming_presentation::StreamingPresentationController::default(),
             agent_active: false,
             should_quit: false,
             turn: 0,
@@ -7553,6 +7556,16 @@ pub async fn run_tui(
         scheduler.mark_timer_due(now);
         if scheduler.should_draw(now) {
             let urgent = scheduler.is_urgent();
+            let publication_revision = app.stream_presentation.publish().map(|publication| {
+                if !publication.delta.is_empty() {
+                    let was_streaming = app.conversation.is_streaming();
+                    app.conversation.append_streaming(&publication.delta);
+                    if !was_streaming {
+                        app.conversation.stamp_meta(app.current_meta());
+                    }
+                }
+                publication.revision
+            });
             let draw_started = std::time::Instant::now();
             let mut callback_elapsed = Duration::ZERO;
             terminal.draw(|f| {
@@ -7560,6 +7573,13 @@ pub async fn run_tui(
                 app.draw(f);
                 callback_elapsed = callback_started.elapsed();
             })?;
+            if let Some(revision) = publication_revision {
+                app.stream_presentation.acknowledge_draw(revision);
+            }
+            if let Some(completion) = app.stream_presentation.take_drawn_completion() {
+                app.handle_agent_event(completion);
+                scheduler.mark_dirty(TuiDrawReason::BackgroundEvent);
+            }
             let draw_finished = std::time::Instant::now();
             if let Some(trace) = &mut runtime_trace {
                 let segments = app.conversation.segments().len();

--- a/core/crates/omegon/src/tui/mod.rs
+++ b/core/crates/omegon/src/tui/mod.rs
@@ -34,6 +34,7 @@ pub mod inline_render;
 mod input;
 pub mod instruments;
 pub mod layout_projection;
+mod markdown_publication;
 mod menu_effects;
 pub(crate) mod menu_surface;
 pub mod operation_lifecycle_projection;
@@ -5006,6 +5007,42 @@ warning: {warning}"
         }
     }
 
+    fn publish_stream_presentation(&mut self) -> Option<(u64, u64)> {
+        let publication = self.stream_presentation.publish()?;
+        for (kind, delta) in publication.deltas {
+            if delta.is_empty() {
+                continue;
+            }
+            let was_streaming = self.conversation.is_streaming();
+            match kind {
+                streaming_presentation::StreamContentKind::Assistant => {
+                    self.conversation.append_streaming(&delta);
+                    self.slim_turn_state = SlimTurnState::Responding;
+                }
+                streaming_presentation::StreamContentKind::Thinking => {
+                    self.conversation.append_thinking(&delta);
+                    self.slim_turn_state = SlimTurnState::Thinking;
+                    self.instrument_panel.note_thinking_activity();
+                }
+            }
+            if !was_streaming {
+                self.conversation.stamp_meta(self.current_meta());
+            }
+        }
+        Some((publication.generation, publication.revision))
+    }
+
+    fn acknowledge_stream_presentation_draw(&mut self, generation: u64, revision: u64) -> bool {
+        self.stream_presentation
+            .acknowledge_draw(generation, revision);
+        let mut released = false;
+        while let Some(event) = self.stream_presentation.take_drawn_event() {
+            self.handle_agent_event(event);
+            released = true;
+        }
+        released
+    }
+
     /// Read a snapshot of current settings (for display).
     fn settings(&self) -> crate::settings::Settings {
         self.settings.lock().unwrap().clone()
@@ -7556,16 +7593,7 @@ pub async fn run_tui(
         scheduler.mark_timer_due(now);
         if scheduler.should_draw(now) {
             let urgent = scheduler.is_urgent();
-            let publication_revision = app.stream_presentation.publish().map(|publication| {
-                if !publication.delta.is_empty() {
-                    let was_streaming = app.conversation.is_streaming();
-                    app.conversation.append_streaming(&publication.delta);
-                    if !was_streaming {
-                        app.conversation.stamp_meta(app.current_meta());
-                    }
-                }
-                publication.revision
-            });
+            let publication_revision = app.publish_stream_presentation();
             let draw_started = std::time::Instant::now();
             let mut callback_elapsed = Duration::ZERO;
             terminal.draw(|f| {
@@ -7573,11 +7601,9 @@ pub async fn run_tui(
                 app.draw(f);
                 callback_elapsed = callback_started.elapsed();
             })?;
-            if let Some(revision) = publication_revision {
-                app.stream_presentation.acknowledge_draw(revision);
-            }
-            if let Some(completion) = app.stream_presentation.take_drawn_completion() {
-                app.handle_agent_event(completion);
+            if let Some((generation, revision)) = publication_revision
+                && app.acknowledge_stream_presentation_draw(generation, revision)
+            {
                 scheduler.mark_dirty(TuiDrawReason::BackgroundEvent);
             }
             let draw_finished = std::time::Instant::now();

--- a/core/crates/omegon/src/tui/mod.rs
+++ b/core/crates/omegon/src/tui/mod.rs
@@ -5040,6 +5040,10 @@ warning: {warning}"
             self.handle_agent_event(event);
             released = true;
         }
+        debug_assert!(
+            !self.stream_presentation.has_blocked_events(),
+            "drawn deferred events must drain completely"
+        );
         released
     }
 

--- a/core/crates/omegon/src/tui/segment_components/assistant.rs
+++ b/core/crates/omegon/src/tui/segment_components/assistant.rs
@@ -327,10 +327,26 @@ fn push_answer_label<'a>(
 fn push_answer_body_lines<'a>(
     lines: &mut Vec<Line<'a>>,
     text: &'a str,
+    complete: bool,
     width: usize,
     theme: &dyn crate::tui::theme::Theme,
     bg: Color,
 ) {
+    let publication = super::super::markdown_publication::project(text, complete);
+    push_markdown_lines(lines, publication.committed, width, theme, bg);
+    push_provisional_lines(lines, publication.provisional, theme, bg);
+}
+
+fn push_markdown_lines<'a>(
+    lines: &mut Vec<Line<'a>>,
+    text: &'a str,
+    width: usize,
+    theme: &dyn crate::tui::theme::Theme,
+    bg: Color,
+) {
+    if text.is_empty() {
+        return;
+    }
     let text_lines: Vec<&str> = split_trimmed_trailing_empty_lines(text);
     let table_widths_per_line = compute_table_widths(&text_lines, width);
     let mut in_code_fence = false;
@@ -370,6 +386,23 @@ fn push_answer_body_lines<'a>(
                 .collect();
             lines.push(Line::from(spans));
         }
+    }
+}
+
+fn push_provisional_lines<'a>(
+    lines: &mut Vec<Line<'a>>,
+    text: &'a str,
+    theme: &dyn crate::tui::theme::Theme,
+    bg: Color,
+) {
+    if text.is_empty() {
+        return;
+    }
+    for line in split_trimmed_trailing_empty_lines(text) {
+        lines.push(Line::from(Span::styled(
+            line,
+            Style::default().fg(theme.fg()).bg(bg),
+        )));
     }
 }
 
@@ -448,6 +481,7 @@ pub fn render(
             push_answer_body_lines(
                 &mut lines,
                 props.text,
+                props.complete,
                 content_area.width as usize,
                 theme,
                 bg,

--- a/core/crates/omegon/src/tui/snapshots/omegon__tui__statusline__tests__statusline_compact_surface_priority.snap
+++ b/core/crates/omegon/src/tui/snapshots/omegon__tui__statusline__tests__statusline_compact_surface_priority.snap
@@ -1,0 +1,5 @@
+---
+source: core/crates/omegon/src/tui/statusline.rs
+expression: "render_session_row_at_level(&presentation_fixture(), 96,\ncrate::surfaces::layout::UiPresentationLevel::Om,)"
+---
+ om · working · omegon:feature/presentation                          v0.29.0-dev <build>

--- a/core/crates/omegon/src/tui/snapshots/omegon__tui__statusline__tests__statusline_compact_surface_priority.snap
+++ b/core/crates/omegon/src/tui/snapshots/omegon__tui__statusline__tests__statusline_compact_surface_priority.snap
@@ -2,4 +2,4 @@
 source: core/crates/omegon/src/tui/statusline.rs
 expression: "render_session_row_at_level(&presentation_fixture(), 96,\ncrate::surfaces::layout::UiPresentationLevel::Om,)"
 ---
- om · working · omegon:feature/presentation                          v0.29.0-dev <build>
+ om · working · omegon:feature/presentation                                           v<build>

--- a/core/crates/omegon/src/tui/snapshots/omegon__tui__statusline__tests__statusline_full_diagnostics.snap
+++ b/core/crates/omegon/src/tui/snapshots/omegon__tui__statusline__tests__statusline_full_diagnostics.snap
@@ -1,0 +1,5 @@
+---
+source: core/crates/omegon/src/tui/statusline.rs
+expression: "render_session_row_at_level(&presentation_fixture(), 160,\ncrate::surfaces::layout::UiPresentationLevel::Full,)"
+---
+working │ Detached · ↑12 · End: latest │ approval required · Search degraded · files: 15 touched · 3 changed · 12 read · oodA Act · @engineer     v0.29.0-dev <build>

--- a/core/crates/omegon/src/tui/snapshots/omegon__tui__statusline__tests__statusline_full_diagnostics.snap
+++ b/core/crates/omegon/src/tui/snapshots/omegon__tui__statusline__tests__statusline_full_diagnostics.snap
@@ -2,4 +2,4 @@
 source: core/crates/omegon/src/tui/statusline.rs
 expression: "render_session_row_at_level(&presentation_fixture(), 160,\ncrate::surfaces::layout::UiPresentationLevel::Full,)"
 ---
-working │ Detached · ↑12 · End: latest │ approval required · Search degraded · files: 15 touched · 3 changed · 12 read · oodA Act · @engineer     v0.29.0-dev <build>
+working │ Detached · ↑12 · End: latest │ approval required · Search degraded · files: 15 touched · 3 changed · 12 read · oodA Act · @engineer  v0.29.0-dev <build>

--- a/core/crates/omegon/src/tui/snapshots/omegon__tui__statusline__tests__statusline_full_diagnostics.snap
+++ b/core/crates/omegon/src/tui/snapshots/omegon__tui__statusline__tests__statusline_full_diagnostics.snap
@@ -2,4 +2,4 @@
 source: core/crates/omegon/src/tui/statusline.rs
 expression: "render_session_row_at_level(&presentation_fixture(), 160,\ncrate::surfaces::layout::UiPresentationLevel::Full,)"
 ---
-working │ Detached · ↑12 · End: latest │ approval required · Search degraded · files: 15 touched · 3 changed · 12 read · oodA Act · @engineer  v0.29.0-dev <build>
+working │ Detached · ↑12 · End: latest │ approval required · Search degraded · files: 15 touched · 3 changed · 12 read · oodA Act · @engineer

--- a/core/crates/omegon/src/tui/snapshots/omegon__tui__statusline__tests__statusline_runtime_warning_secondary_row.snap
+++ b/core/crates/omegon/src/tui/snapshots/omegon__tui__statusline__tests__statusline_runtime_warning_secondary_row.snap
@@ -1,0 +1,6 @@
+---
+source: core/crates/omegon/src/tui/statusline.rs
+expression: "render_session_row_at_level(&row, 120,\ncrate::surfaces::layout::UiPresentationLevel::Active,)"
+---
+working │ Detached · ↑12 · End: latest │ approval required · Search degraded · files: 15 touched · 3 changed · 12 read
+runtime · omegon · posture  · provider anthropic offline                    who operator · authz local · grade  · think

--- a/core/crates/omegon/src/tui/statusline.rs
+++ b/core/crates/omegon/src/tui/statusline.rs
@@ -516,18 +516,8 @@ mod tests {
             .find('\n')
             .map(|offset| suffix_start + offset)
             .unwrap_or(rendered.len());
-        let suffix = &rendered[suffix_start..line_end];
-        let normalized = if suffix.trim().is_empty() {
-            "v0.29.0-dev"
-        } else {
-            "v0.29.0-dev <build>"
-        };
-        format!(
-            "{}{}{}",
-            &rendered[..version_start],
-            normalized,
-            &rendered[line_end..]
-        )
+        let prefix = rendered[..version_start].trim_end();
+        format!("{prefix}  v0.29.0-dev <build>{}", &rendered[line_end..])
     }
 
     fn presentation_fixture() -> SessionRow {

--- a/core/crates/omegon/src/tui/statusline.rs
+++ b/core/crates/omegon/src/tui/statusline.rs
@@ -156,7 +156,7 @@ impl SessionRow {
     }
 
     pub fn render(&self, area: Rect, frame: &mut Frame, t: &dyn Theme) {
-        let height = Self::preferred_height(area.width).min(area.height);
+        let height = self.preferred_height_for(area.width).min(area.height);
         if height == 0 {
             return;
         }
@@ -470,14 +470,125 @@ mod tests {
     use super::*;
 
     fn render_session_row(row: &SessionRow, width: u16) -> String {
-        let backend = ratatui::backend::TestBackend::new(width, 1);
+        render_session_row_at_level(
+            row,
+            width,
+            crate::surfaces::layout::UiPresentationLevel::Active,
+        )
+    }
+
+    fn render_session_row_at_level(
+        row: &SessionRow,
+        width: u16,
+        level: crate::surfaces::layout::UiPresentationLevel,
+    ) -> String {
+        let height = if level == crate::surfaces::layout::UiPresentationLevel::Om {
+            u16::from(width >= 20)
+        } else {
+            row.preferred_height_for(width)
+        };
+        let backend = ratatui::backend::TestBackend::new(width, height);
         let mut terminal = ratatui::Terminal::new(backend).unwrap();
         terminal
-            .draw(|frame| row.render(frame.area(), frame, &super::super::theme::Alpharius))
+            .draw(|frame| {
+                row.render_for_level(level, frame.area(), frame, &super::super::theme::Alpharius)
+            })
             .unwrap();
-        (0..width)
-            .map(|x| terminal.backend().buffer()[(x, 0)].symbol())
-            .collect()
+        let rendered = (0..height)
+            .map(|y| {
+                (0..width)
+                    .map(|x| terminal.backend().buffer()[(x, y)].symbol())
+                    .collect::<String>()
+                    .trim_end()
+                    .to_string()
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        normalize_snapshot_version(&rendered)
+    }
+
+    fn normalize_snapshot_version(rendered: &str) -> String {
+        let Some(version_start) = rendered.find("v0.29.0-dev") else {
+            return rendered.to_string();
+        };
+        let suffix_start = version_start + "v0.29.0-dev".len();
+        let line_end = rendered[suffix_start..]
+            .find('\n')
+            .map(|offset| suffix_start + offset)
+            .unwrap_or(rendered.len());
+        let suffix = &rendered[suffix_start..line_end];
+        let normalized = if suffix.trim().is_empty() {
+            "v0.29.0-dev"
+        } else {
+            "v0.29.0-dev <build>"
+        };
+        format!(
+            "{}{}{}",
+            &rendered[..version_start],
+            normalized,
+            &rendered[line_end..]
+        )
+    }
+
+    fn presentation_fixture() -> SessionRow {
+        SessionRow {
+            provider_connected: true,
+            turn_state: Some("working".into()),
+            viewport_hint: Some("Detached · ↑12 · End: latest".into()),
+            operator_hint: Some("approval required".into()),
+            web_search_providers: vec![("brave".into(), false)],
+            session_input_tokens: 32_000,
+            session_output_tokens: 4_000,
+            cwd_basename: "omegon".into(),
+            git_branch: Some("feature/presentation".into()),
+            files_read: 12,
+            files_modified: 3,
+            phase: Some(OodaPhase::Act),
+            persona: Some("engineer".into()),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn compact_status_row_snapshots_surface_priority_at_constrained_width() {
+        insta::assert_snapshot!(
+            "statusline_compact_surface_priority",
+            render_session_row_at_level(
+                &presentation_fixture(),
+                96,
+                crate::surfaces::layout::UiPresentationLevel::Om,
+            )
+        );
+    }
+
+    #[test]
+    fn full_status_row_snapshots_expanded_diagnostics() {
+        insta::assert_snapshot!(
+            "statusline_full_diagnostics",
+            render_session_row_at_level(
+                &presentation_fixture(),
+                160,
+                crate::surfaces::layout::UiPresentationLevel::Full,
+            )
+        );
+    }
+
+    #[test]
+    fn runtime_warning_row_snapshots_below_primary_status() {
+        let mut row = presentation_fixture();
+        row.provider_connected = false;
+        row.runtime_brand = "omegon".into();
+        row.model_provider = "anthropic".into();
+        row.principal_id = "operator".into();
+        row.authorization = "local".into();
+        insta::assert_snapshot!(
+            "statusline_runtime_warning_secondary_row",
+            render_session_row_at_level(
+                &row,
+                120,
+                crate::surfaces::layout::UiPresentationLevel::Active,
+            )
+        );
     }
 
     #[test]

--- a/core/crates/omegon/src/tui/statusline.rs
+++ b/core/crates/omegon/src/tui/statusline.rs
@@ -447,10 +447,18 @@ fn web_readiness_glyph(configured: bool) -> &'static str {
 }
 
 fn omegon_version_label() -> String {
-    if env!("OMEGON_GIT_DESCRIBE").is_empty() && !env!("OMEGON_GIT_SHA").contains("-dirty") {
-        concat!("v", env!("CARGO_PKG_VERSION")).to_string()
-    } else {
-        format!("v{} {}", env!("CARGO_PKG_VERSION"), env!("OMEGON_GIT_SHA"))
+    #[cfg(test)]
+    {
+        "v<build>".to_string()
+    }
+
+    #[cfg(not(test))]
+    {
+        if env!("OMEGON_GIT_DESCRIBE").is_empty() && !env!("OMEGON_GIT_SHA").contains("-dirty") {
+            concat!("v", env!("CARGO_PKG_VERSION")).to_string()
+        } else {
+            format!("v{} {}", env!("CARGO_PKG_VERSION"), env!("OMEGON_GIT_SHA"))
+        }
     }
 }
 
@@ -494,7 +502,7 @@ mod tests {
                 row.render_for_level(level, frame.area(), frame, &super::super::theme::Alpharius)
             })
             .unwrap();
-        let rendered = (0..height)
+        (0..height)
             .map(|y| {
                 (0..width)
                     .map(|x| terminal.backend().buffer()[(x, y)].symbol())
@@ -503,21 +511,7 @@ mod tests {
                     .to_string()
             })
             .collect::<Vec<_>>()
-            .join("\n");
-        normalize_snapshot_version(&rendered)
-    }
-
-    fn normalize_snapshot_version(rendered: &str) -> String {
-        let Some(version_start) = rendered.find("v0.29.0-dev") else {
-            return rendered.to_string();
-        };
-        let suffix_start = version_start + "v0.29.0-dev".len();
-        let line_end = rendered[suffix_start..]
-            .find('\n')
-            .map(|offset| suffix_start + offset)
-            .unwrap_or(rendered.len());
-        let prefix = rendered[..version_start].trim_end();
-        format!("{prefix}  v0.29.0-dev <build>{}", &rendered[line_end..])
+            .join("\n")
     }
 
     fn presentation_fixture() -> SessionRow {

--- a/core/crates/omegon/src/tui/streaming_presentation.rs
+++ b/core/crates/omegon/src/tui/streaming_presentation.rs
@@ -2,18 +2,33 @@ use std::collections::VecDeque;
 
 use omegon_traits::AgentEvent;
 
+/// The kind of progressive content represented by a published delta.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum StreamContentKind {
+    Assistant,
+    Thinking,
+}
+
 /// TUI-local stream publication state. Runtime events remain authoritative; this
-/// controller only decides when accumulated progressive content becomes a
-/// presentation revision and when visual completion may follow it.
+/// controller preserves their order while deciding when progressive content
+/// becomes a presentation revision and when later events may overtake it.
 #[derive(Debug, Default)]
 pub(super) struct StreamingPresentationController {
+    generation: u64,
     accumulated_revision: u64,
     published_revision: u64,
     drawn_revision: u64,
     unpublished_content: bool,
-    pending_completions: VecDeque<AgentEvent>,
+    blocked_events: VecDeque<AgentEvent>,
     authoritative_text: String,
-    published_text: String,
+    published_len: usize,
+    pending_deltas: Vec<StreamDelta>,
+}
+
+#[derive(Debug, Clone)]
+struct StreamDelta {
+    kind: StreamContentKind,
+    text: String,
 }
 
 #[derive(Debug, Default, PartialEq, Eq)]
@@ -23,30 +38,59 @@ pub(super) struct StreamIngestDecision {
 }
 
 pub(super) struct StreamPublication {
+    pub(super) generation: u64,
     pub(super) revision: u64,
-    pub(super) delta: String,
+    pub(super) deltas: Vec<(StreamContentKind, String)>,
 }
 
 impl StreamingPresentationController {
     pub(super) fn classify(&mut self, event: AgentEvent) -> StreamIngestDecision {
+        // Session reset is an out-of-band lifecycle boundary. It cancels the
+        // current presentation generation and must not queue behind content
+        // that the reset is explicitly discarding.
+        if matches!(event, AgentEvent::SessionReset) {
+            self.reset_generation();
+            return StreamIngestDecision {
+                apply_now: true,
+                publication_due: false,
+            };
+        }
+
+        // Once an event is blocked behind unpublished content, every later
+        // event must remain behind it. Replaying the front event after a draw
+        // re-enters this method only after it has been removed from the queue.
+        if !self.blocked_events.is_empty() {
+            self.blocked_events.push_back(event);
+            return StreamIngestDecision {
+                apply_now: false,
+                publication_due: self.unpublished_content,
+            };
+        }
+
         match event {
-            AgentEvent::MessageChunk { ref text } => {
-                self.authoritative_text.push_str(text);
-                self.accumulated_revision = self.accumulated_revision.saturating_add(1);
-                self.unpublished_content = true;
+            AgentEvent::MessageStart { .. } => {
+                self.start_generation();
+                StreamIngestDecision {
+                    apply_now: true,
+                    publication_due: false,
+                }
+            }
+            AgentEvent::MessageChunk { text } => {
+                self.accumulate(StreamContentKind::Assistant, text);
                 StreamIngestDecision {
                     apply_now: false,
                     publication_due: true,
                 }
             }
-            AgentEvent::ThinkingChunk { .. } => StreamIngestDecision {
-                apply_now: true,
-                publication_due: true,
-            },
-            AgentEvent::MessageEnd | AgentEvent::MessageAbort { .. } | AgentEvent::TurnEnd(_)
-                if self.unpublished_content =>
-            {
-                self.pending_completions.push_back(event);
+            AgentEvent::ThinkingChunk { text } => {
+                self.accumulate(StreamContentKind::Thinking, text);
+                StreamIngestDecision {
+                    apply_now: false,
+                    publication_due: true,
+                }
+            }
+            event if self.unpublished_content => {
+                self.blocked_events.push_back(event);
                 StreamIngestDecision {
                     apply_now: false,
                     publication_due: true,
@@ -59,17 +103,50 @@ impl StreamingPresentationController {
         }
     }
 
+    fn reset_generation(&mut self) {
+        self.start_generation();
+        self.blocked_events.clear();
+    }
+
+    fn start_generation(&mut self) {
+        self.generation = self.generation.saturating_add(1);
+        self.accumulated_revision = 0;
+        self.published_revision = 0;
+        self.drawn_revision = 0;
+        self.unpublished_content = false;
+        self.authoritative_text.clear();
+        self.published_len = 0;
+        self.pending_deltas.clear();
+    }
+
+    fn accumulate(&mut self, kind: StreamContentKind, text: String) {
+        self.authoritative_text.push_str(&text);
+        if let Some(last) = self.pending_deltas.last_mut()
+            && last.kind == kind
+        {
+            last.text.push_str(&text);
+        } else {
+            self.pending_deltas.push(StreamDelta { kind, text });
+        }
+        self.accumulated_revision = self.accumulated_revision.saturating_add(1);
+        self.unpublished_content = true;
+    }
+
     pub(super) fn publish(&mut self) -> Option<StreamPublication> {
         if !self.unpublished_content {
             return None;
         }
-        let published_len = self.published_text.len();
         self.published_revision = self.accumulated_revision;
-        self.published_text.clone_from(&self.authoritative_text);
+        self.published_len = self.authoritative_text.len();
         self.unpublished_content = false;
         Some(StreamPublication {
+            generation: self.generation,
             revision: self.published_revision,
-            delta: self.published_text[published_len..].to_string(),
+            deltas: self
+                .pending_deltas
+                .drain(..)
+                .map(|delta| (delta.kind, delta.text))
+                .collect(),
         })
     }
 
@@ -78,21 +155,22 @@ impl StreamingPresentationController {
     }
 
     pub(super) fn published_text(&self) -> &str {
-        &self.published_text
+        &self.authoritative_text[..self.published_len]
     }
 
-    pub(super) fn acknowledge_draw(&mut self, revision: u64) {
-        self.drawn_revision = self
-            .drawn_revision
-            .max(revision.min(self.published_revision));
+    pub(super) fn acknowledge_draw(&mut self, generation: u64, revision: u64) {
+        if generation == self.generation {
+            self.drawn_revision = self
+                .drawn_revision
+                .max(revision.min(self.published_revision));
+        }
     }
 
-    pub(super) fn take_drawn_completion(&mut self) -> Option<AgentEvent> {
-        if !self.pending_completions.is_empty()
-            && self.drawn_revision == self.accumulated_revision
+    pub(super) fn take_drawn_event(&mut self) -> Option<AgentEvent> {
+        if self.drawn_revision == self.accumulated_revision
             && self.published_revision == self.accumulated_revision
         {
-            self.pending_completions.pop_front()
+            self.blocked_events.pop_front()
         } else {
             None
         }
@@ -103,38 +181,38 @@ impl StreamingPresentationController {
 mod tests {
     use super::*;
 
+    fn publish_and_draw(controller: &mut StreamingPresentationController) -> StreamPublication {
+        let publication = controller.publish().expect("stream publication");
+        controller.acknowledge_draw(publication.generation, publication.revision);
+        publication
+    }
+
     #[test]
     fn completion_waits_for_latest_published_revision_to_be_drawn() {
         let mut controller = StreamingPresentationController::default();
-        assert!(
-            !controller
-                .classify(AgentEvent::MessageChunk { text: "one".into() })
-                .apply_now
-        );
-        assert!(
-            !controller
-                .classify(AgentEvent::MessageChunk {
-                    text: " two".into(),
-                })
-                .apply_now
-        );
-
+        controller.classify(AgentEvent::MessageStart {
+            role: "assistant".into(),
+        });
+        controller.classify(AgentEvent::MessageChunk { text: "one".into() });
+        controller.classify(AgentEvent::MessageChunk {
+            text: " two".into(),
+        });
         let completion = controller.classify(AgentEvent::MessageEnd);
         assert!(!completion.apply_now);
         assert!(completion.publication_due);
-        assert!(controller.take_drawn_completion().is_none());
+        assert!(controller.take_drawn_event().is_none());
 
         let publication = controller.publish().expect("stream publication");
-        assert!(controller.take_drawn_completion().is_none());
-        controller.acknowledge_draw(publication.revision);
+        assert!(controller.take_drawn_event().is_none());
+        controller.acknowledge_draw(publication.generation, publication.revision);
         assert!(matches!(
-            controller.take_drawn_completion(),
+            controller.take_drawn_event(),
             Some(AgentEvent::MessageEnd)
         ));
     }
 
     #[test]
-    fn deferred_message_and_turn_completion_preserve_event_order() {
+    fn later_events_remain_ordered_behind_unpublished_content() {
         let mut controller = StreamingPresentationController::default();
         controller.classify(AgentEvent::MessageChunk {
             text: "done".into(),
@@ -144,47 +222,149 @@ mod tests {
             reason: Some("after-end sentinel".into()),
         });
 
-        let publication = controller.publish().expect("publication");
-        controller.acknowledge_draw(publication.revision);
+        publish_and_draw(&mut controller);
         assert!(matches!(
-            controller.take_drawn_completion(),
+            controller.take_drawn_event(),
             Some(AgentEvent::MessageEnd)
         ));
         assert!(matches!(
-            controller.take_drawn_completion(),
+            controller.take_drawn_event(),
             Some(AgentEvent::MessageAbort { reason })
                 if reason.as_deref() == Some("after-end sentinel")
         ));
     }
 
     #[test]
-    fn chunk_burst_coalesces_into_one_publication_revision() {
+    fn abort_waits_for_unpublished_content_and_preserves_reason() {
         let mut controller = StreamingPresentationController::default();
-        for text in ["a", "b", "c"] {
-            controller.classify(AgentEvent::MessageChunk { text: text.into() });
-        }
+        controller.classify(AgentEvent::MessageChunk {
+            text: "before abort".into(),
+        });
+        controller.classify(AgentEvent::MessageAbort {
+            reason: Some("provider disconnected".into()),
+        });
+        assert!(controller.take_drawn_event().is_none());
+
         let publication = controller.publish().expect("publication");
-        assert_eq!(publication.revision, 3);
-        assert_eq!(publication.delta, "abc");
-        assert_eq!(controller.authoritative_text(), "abc");
-        assert_eq!(controller.published_text(), "abc");
-        assert!(controller.publish().is_none());
+        controller.acknowledge_draw(publication.generation, publication.revision);
+        assert!(matches!(
+            controller.take_drawn_event(),
+            Some(AgentEvent::MessageAbort { reason })
+                if reason.as_deref() == Some("provider disconnected")
+        ));
     }
 
     #[test]
-    fn unpublished_chunks_do_not_change_the_published_projection() {
+    fn absent_and_stale_draw_acknowledgements_do_not_release_events() {
+        let mut controller = StreamingPresentationController::default();
+        controller.classify(AgentEvent::MessageChunk {
+            text: "final".into(),
+        });
+        controller.classify(AgentEvent::MessageEnd);
+        let publication = controller.publish().expect("publication");
+
+        assert!(controller.take_drawn_event().is_none());
+        controller.acknowledge_draw(
+            publication.generation.saturating_add(1),
+            publication.revision,
+        );
+        assert!(controller.take_drawn_event().is_none());
+        controller.acknowledge_draw(publication.generation, publication.revision);
+        assert!(matches!(
+            controller.take_drawn_event(),
+            Some(AgentEvent::MessageEnd)
+        ));
+    }
+
+    #[test]
+    fn reset_generation_discards_pending_content_and_deferred_events() {
+        let mut controller = StreamingPresentationController::default();
+        controller.classify(AgentEvent::MessageChunk {
+            text: "stale".into(),
+        });
+        controller.classify(AgentEvent::MessageEnd);
+
+        let decision = controller.classify(AgentEvent::SessionReset);
+        assert!(decision.apply_now);
+        assert!(!decision.publication_due);
+        assert!(controller.publish().is_none());
+        assert!(controller.take_drawn_event().is_none());
+    }
+
+    #[test]
+    fn deferred_events_release_in_exact_ingestion_order() {
+        let mut controller = StreamingPresentationController::default();
+        controller.classify(AgentEvent::MessageChunk {
+            text: "ordered".into(),
+        });
+        controller.classify(AgentEvent::MessageEnd);
+        controller.classify(AgentEvent::MessageAbort {
+            reason: Some("second".into()),
+        });
+        let publication = controller.publish().expect("publication");
+        controller.acknowledge_draw(publication.generation, publication.revision);
+
+        assert!(matches!(
+            controller.take_drawn_event(),
+            Some(AgentEvent::MessageEnd)
+        ));
+        assert!(matches!(
+            controller.take_drawn_event(),
+            Some(AgentEvent::MessageAbort { reason }) if reason.as_deref() == Some("second")
+        ));
+        assert!(controller.take_drawn_event().is_none());
+    }
+
+    #[test]
+    fn assistant_and_thinking_deltas_coalesce_without_losing_order() {
+        let mut controller = StreamingPresentationController::default();
+        controller.classify(AgentEvent::ThinkingChunk { text: "a".into() });
+        controller.classify(AgentEvent::ThinkingChunk { text: "b".into() });
+        controller.classify(AgentEvent::MessageChunk { text: "c".into() });
+        let publication = controller.publish().expect("publication");
+        assert_eq!(publication.revision, 3);
+        assert_eq!(
+            publication.deltas,
+            vec![
+                (StreamContentKind::Thinking, "ab".into()),
+                (StreamContentKind::Assistant, "c".into())
+            ]
+        );
+        assert_eq!(controller.authoritative_text(), "abc");
+        assert_eq!(controller.published_text(), "abc");
+    }
+
+    #[test]
+    fn message_start_begins_a_bounded_generation() {
         let mut controller = StreamingPresentationController::default();
         controller.classify(AgentEvent::MessageChunk {
             text: "first".into(),
         });
-        assert_eq!(controller.authoritative_text(), "first");
-        assert_eq!(controller.published_text(), "");
-
-        controller.publish();
-        controller.classify(AgentEvent::MessageChunk {
-            text: " second".into(),
+        publish_and_draw(&mut controller);
+        controller.classify(AgentEvent::MessageStart {
+            role: "assistant".into(),
         });
-        assert_eq!(controller.authoritative_text(), "first second");
-        assert_eq!(controller.published_text(), "first");
+        controller.classify(AgentEvent::MessageChunk {
+            text: "second".into(),
+        });
+        let publication = controller.publish().expect("second publication");
+        assert_eq!(publication.generation, 1);
+        assert_eq!(controller.authoritative_text(), "second");
+    }
+
+    #[test]
+    fn stale_draw_acknowledgement_cannot_release_current_generation() {
+        let mut controller = StreamingPresentationController::default();
+        controller.classify(AgentEvent::MessageStart {
+            role: "assistant".into(),
+        });
+        controller.classify(AgentEvent::MessageChunk { text: "new".into() });
+        controller.classify(AgentEvent::MessageEnd);
+        let publication = controller.publish().expect("publication");
+        controller.acknowledge_draw(
+            publication.generation.saturating_sub(1),
+            publication.revision,
+        );
+        assert!(controller.take_drawn_event().is_none());
     }
 }

--- a/core/crates/omegon/src/tui/streaming_presentation.rs
+++ b/core/crates/omegon/src/tui/streaming_presentation.rs
@@ -175,6 +175,10 @@ impl StreamingPresentationController {
             None
         }
     }
+
+    pub(super) fn has_blocked_events(&self) -> bool {
+        !self.blocked_events.is_empty()
+    }
 }
 
 #[cfg(test)]
@@ -313,6 +317,29 @@ mod tests {
             Some(AgentEvent::MessageAbort { reason }) if reason.as_deref() == Some("second")
         ));
         assert!(controller.take_drawn_event().is_none());
+        assert!(!controller.has_blocked_events());
+    }
+
+    #[test]
+    fn released_event_does_not_overtake_the_remaining_backlog() {
+        let mut controller = StreamingPresentationController::default();
+        controller.classify(AgentEvent::MessageChunk {
+            text: "first".into(),
+        });
+        controller.classify(AgentEvent::MessageEnd);
+        controller.classify(AgentEvent::MessageAbort {
+            reason: Some("second".into()),
+        });
+        publish_and_draw(&mut controller);
+
+        let released = controller.take_drawn_event().expect("released completion");
+        assert!(matches!(released, AgentEvent::MessageEnd));
+        assert!(controller.has_blocked_events());
+        assert!(matches!(
+            controller.take_drawn_event(),
+            Some(AgentEvent::MessageAbort { reason }) if reason.as_deref() == Some("second")
+        ));
+        assert!(!controller.has_blocked_events());
     }
 
     #[test]

--- a/core/crates/omegon/src/tui/streaming_presentation.rs
+++ b/core/crates/omegon/src/tui/streaming_presentation.rs
@@ -1,0 +1,190 @@
+use std::collections::VecDeque;
+
+use omegon_traits::AgentEvent;
+
+/// TUI-local stream publication state. Runtime events remain authoritative; this
+/// controller only decides when accumulated progressive content becomes a
+/// presentation revision and when visual completion may follow it.
+#[derive(Debug, Default)]
+pub(super) struct StreamingPresentationController {
+    accumulated_revision: u64,
+    published_revision: u64,
+    drawn_revision: u64,
+    unpublished_content: bool,
+    pending_completions: VecDeque<AgentEvent>,
+    authoritative_text: String,
+    published_text: String,
+}
+
+#[derive(Debug, Default, PartialEq, Eq)]
+pub(super) struct StreamIngestDecision {
+    pub(super) apply_now: bool,
+    pub(super) publication_due: bool,
+}
+
+pub(super) struct StreamPublication {
+    pub(super) revision: u64,
+    pub(super) delta: String,
+}
+
+impl StreamingPresentationController {
+    pub(super) fn classify(&mut self, event: AgentEvent) -> StreamIngestDecision {
+        match event {
+            AgentEvent::MessageChunk { ref text } => {
+                self.authoritative_text.push_str(text);
+                self.accumulated_revision = self.accumulated_revision.saturating_add(1);
+                self.unpublished_content = true;
+                StreamIngestDecision {
+                    apply_now: false,
+                    publication_due: true,
+                }
+            }
+            AgentEvent::ThinkingChunk { .. } => StreamIngestDecision {
+                apply_now: true,
+                publication_due: true,
+            },
+            AgentEvent::MessageEnd | AgentEvent::MessageAbort { .. } | AgentEvent::TurnEnd(_)
+                if self.unpublished_content =>
+            {
+                self.pending_completions.push_back(event);
+                StreamIngestDecision {
+                    apply_now: false,
+                    publication_due: true,
+                }
+            }
+            _ => StreamIngestDecision {
+                apply_now: true,
+                publication_due: false,
+            },
+        }
+    }
+
+    pub(super) fn publish(&mut self) -> Option<StreamPublication> {
+        if !self.unpublished_content {
+            return None;
+        }
+        let published_len = self.published_text.len();
+        self.published_revision = self.accumulated_revision;
+        self.published_text.clone_from(&self.authoritative_text);
+        self.unpublished_content = false;
+        Some(StreamPublication {
+            revision: self.published_revision,
+            delta: self.published_text[published_len..].to_string(),
+        })
+    }
+
+    pub(super) fn authoritative_text(&self) -> &str {
+        &self.authoritative_text
+    }
+
+    pub(super) fn published_text(&self) -> &str {
+        &self.published_text
+    }
+
+    pub(super) fn acknowledge_draw(&mut self, revision: u64) {
+        self.drawn_revision = self
+            .drawn_revision
+            .max(revision.min(self.published_revision));
+    }
+
+    pub(super) fn take_drawn_completion(&mut self) -> Option<AgentEvent> {
+        if !self.pending_completions.is_empty()
+            && self.drawn_revision == self.accumulated_revision
+            && self.published_revision == self.accumulated_revision
+        {
+            self.pending_completions.pop_front()
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn completion_waits_for_latest_published_revision_to_be_drawn() {
+        let mut controller = StreamingPresentationController::default();
+        assert!(
+            !controller
+                .classify(AgentEvent::MessageChunk { text: "one".into() })
+                .apply_now
+        );
+        assert!(
+            !controller
+                .classify(AgentEvent::MessageChunk {
+                    text: " two".into(),
+                })
+                .apply_now
+        );
+
+        let completion = controller.classify(AgentEvent::MessageEnd);
+        assert!(!completion.apply_now);
+        assert!(completion.publication_due);
+        assert!(controller.take_drawn_completion().is_none());
+
+        let publication = controller.publish().expect("stream publication");
+        assert!(controller.take_drawn_completion().is_none());
+        controller.acknowledge_draw(publication.revision);
+        assert!(matches!(
+            controller.take_drawn_completion(),
+            Some(AgentEvent::MessageEnd)
+        ));
+    }
+
+    #[test]
+    fn deferred_message_and_turn_completion_preserve_event_order() {
+        let mut controller = StreamingPresentationController::default();
+        controller.classify(AgentEvent::MessageChunk {
+            text: "done".into(),
+        });
+        controller.classify(AgentEvent::MessageEnd);
+        controller.classify(AgentEvent::MessageAbort {
+            reason: Some("after-end sentinel".into()),
+        });
+
+        let publication = controller.publish().expect("publication");
+        controller.acknowledge_draw(publication.revision);
+        assert!(matches!(
+            controller.take_drawn_completion(),
+            Some(AgentEvent::MessageEnd)
+        ));
+        assert!(matches!(
+            controller.take_drawn_completion(),
+            Some(AgentEvent::MessageAbort { reason })
+                if reason.as_deref() == Some("after-end sentinel")
+        ));
+    }
+
+    #[test]
+    fn chunk_burst_coalesces_into_one_publication_revision() {
+        let mut controller = StreamingPresentationController::default();
+        for text in ["a", "b", "c"] {
+            controller.classify(AgentEvent::MessageChunk { text: text.into() });
+        }
+        let publication = controller.publish().expect("publication");
+        assert_eq!(publication.revision, 3);
+        assert_eq!(publication.delta, "abc");
+        assert_eq!(controller.authoritative_text(), "abc");
+        assert_eq!(controller.published_text(), "abc");
+        assert!(controller.publish().is_none());
+    }
+
+    #[test]
+    fn unpublished_chunks_do_not_change_the_published_projection() {
+        let mut controller = StreamingPresentationController::default();
+        controller.classify(AgentEvent::MessageChunk {
+            text: "first".into(),
+        });
+        assert_eq!(controller.authoritative_text(), "first");
+        assert_eq!(controller.published_text(), "");
+
+        controller.publish();
+        controller.classify(AgentEvent::MessageChunk {
+            text: " second".into(),
+        });
+        assert_eq!(controller.authoritative_text(), "first second");
+        assert_eq!(controller.published_text(), "first");
+    }
+}

--- a/core/crates/omegon/src/tui/tests.rs
+++ b/core/crates/omegon/src/tui/tests.rs
@@ -134,6 +134,22 @@ fn render_app_to_string(app: &mut App, width: u16, height: u16) -> String {
     text
 }
 
+fn draw_published_stream(app: &mut App, width: u16, height: u16) -> String {
+    let publication = app.publish_stream_presentation();
+    let rendered = render_app_to_string(app, width, height);
+    if let Some((generation, revision)) = publication {
+        app.acknowledge_stream_presentation_draw(generation, revision);
+    }
+    rendered
+}
+
+fn nonblank_row(rendered: &str, needle: &str) -> usize {
+    rendered
+        .lines()
+        .position(|line| line.contains(needle))
+        .unwrap_or_else(|| panic!("needle {needle:?} not found in rendered buffer\n{rendered}"))
+}
+
 fn rendered_cell_styles_for_text(
     app: &mut App,
     width: u16,
@@ -299,6 +315,173 @@ fn cleave_decomposition_event_still_renders_cleave() {
 }
 
 #[test]
+fn published_short_assistant_stream_remains_adjacent_to_composer() {
+    let mut app = active_test_app();
+    app.handle_agent_event(AgentEvent::TurnStart { turn: 1 });
+    app.handle_agent_event(AgentEvent::MessageStart {
+        role: "assistant".into(),
+    });
+    app.handle_agent_event(AgentEvent::MessageChunk {
+        text: "streaming answer sentinel".into(),
+    });
+
+    let rendered = draw_published_stream(&mut app, 100, 32);
+    let content_row = nonblank_row(&rendered, "streaming answer sentinel");
+    assert!(
+        content_row >= 20,
+        "short attached stream should be bottom anchored\n{rendered}"
+    );
+}
+
+#[test]
+fn published_short_reasoning_stream_remains_adjacent_to_composer() {
+    let mut app = active_test_app();
+    app.handle_agent_event(AgentEvent::TurnStart { turn: 1 });
+    app.handle_agent_event(AgentEvent::ThinkingChunk {
+        text: "reasoning sentinel".into(),
+    });
+
+    let rendered = draw_published_stream(&mut app, 100, 32);
+    let reasoning_row = nonblank_row(&rendered, "reasoning sentinel");
+    assert!(
+        reasoning_row >= 20,
+        "short attached reasoning should be bottom anchored\n{rendered}"
+    );
+}
+
+#[test]
+fn reasoning_to_assistant_transition_preserves_order_and_tail_geometry() {
+    let mut app = active_test_app();
+    app.handle_agent_event(AgentEvent::TurnStart { turn: 1 });
+    app.handle_agent_event(AgentEvent::ThinkingChunk {
+        text: "reasoning transition sentinel".into(),
+    });
+    app.handle_agent_event(AgentEvent::MessageChunk {
+        text: "assistant transition sentinel".into(),
+    });
+
+    let rendered = draw_published_stream(&mut app, 100, 32);
+    let reasoning_row = nonblank_row(&rendered, "reasoning transition sentinel");
+    let answer_row = nonblank_row(&rendered, "assistant transition sentinel");
+    assert!(reasoning_row < answer_row, "{rendered}");
+    assert!(
+        answer_row >= 20,
+        "latest content should remain tail-adjacent\n{rendered}"
+    );
+}
+
+#[test]
+fn attached_stream_remains_tail_anchored_across_resize() {
+    let mut app = active_test_app();
+    app.handle_agent_event(AgentEvent::MessageChunk {
+        text: "resize sentinel one two three four five six seven eight nine ten".into(),
+    });
+
+    let wide = draw_published_stream(&mut app, 120, 32);
+    let narrow = render_app_to_string(&mut app, 54, 22);
+    assert!(nonblank_row(&wide, "resize sentinel") >= 20, "{wide}");
+    assert!(nonblank_row(&narrow, "resize sentinel") >= 10, "{narrow}");
+    assert_eq!(app.conversation.conv_state.scroll_offset, 0);
+    assert!(!app.conversation.conv_state.user_scrolled);
+}
+
+#[test]
+fn detached_viewport_preserves_anchor_during_stream_publication_and_can_return_to_tail() {
+    let mut app = active_test_app();
+    let initial = (1..=28)
+        .map(|line| format!("anchor line {line:02}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    app.handle_agent_event(AgentEvent::MessageChunk { text: initial });
+    let _ = draw_published_stream(&mut app, 80, 18);
+    app.conversation.scroll_up(6);
+    let detached_before = render_app_to_string(&mut app, 80, 18);
+    let anchor = detached_before
+        .lines()
+        .find(|line| line.contains("anchor line"))
+        .map(str::trim)
+        .expect("visible detached anchor")
+        .to_string();
+
+    app.handle_agent_event(AgentEvent::MessageChunk {
+        text: "\nnew revision 29\nnew revision 30".into(),
+    });
+    let detached_after = draw_published_stream(&mut app, 80, 18);
+    assert!(app.conversation.conv_state.user_scrolled);
+    assert!(
+        detached_after.contains(&anchor),
+        "anchor {anchor:?} moved\n{detached_after}"
+    );
+    assert!(detached_after.contains("Detached"), "{detached_after}");
+
+    app.conversation.conv_state.force_scroll_to_bottom();
+    let attached = render_app_to_string(&mut app, 80, 18);
+    assert!(attached.contains("new revision 30"), "{attached}");
+    assert!(!attached.contains("Detached"), "{attached}");
+}
+
+#[test]
+fn compact_interaction_surfaces_remain_visible_during_publication() {
+    let mut app = active_test_app();
+    app.handle_agent_event(AgentEvent::TurnStart { turn: 1 });
+    app.handle_agent_event(AgentEvent::MessageChunk {
+        text: "interaction surface sentinel".into(),
+    });
+
+    let rendered = draw_published_stream(&mut app, 90, 18);
+    assert!(
+        rendered.contains("interaction surface sentinel"),
+        "{rendered}"
+    );
+    assert!(
+        rendered.contains("active turn"),
+        "status line missing\n{rendered}"
+    );
+    assert!(
+        rendered.contains("Ask anything, or type / for commands"),
+        "composer missing\n{rendered}"
+    );
+    assert!(
+        nonblank_row(&rendered, "interaction surface sentinel") >= 8,
+        "{rendered}"
+    );
+}
+
+#[test]
+fn completion_in_same_burst_waits_for_published_draw() {
+    let mut app = active_test_app();
+    app.handle_agent_event(AgentEvent::MessageChunk {
+        text: "final burst sentinel".into(),
+    });
+    app.handle_agent_event(AgentEvent::MessageEnd);
+    assert!(!app.conversation.is_streaming());
+
+    let rendered = draw_published_stream(&mut app, 100, 24);
+    assert!(rendered.contains("final burst sentinel"), "{rendered}");
+    assert!(!app.conversation.is_streaming());
+}
+
+#[test]
+fn assistant_to_tool_transition_cannot_overtake_published_text() {
+    let mut app = active_test_app();
+    app.handle_agent_event(AgentEvent::MessageChunk {
+        text: "answer before tool sentinel".into(),
+    });
+    app.handle_agent_event(AgentEvent::ToolStart {
+        id: "ordered-tool".into(),
+        name: "read".into(),
+        provenance: omegon_traits::ToolProvenance::BuiltIn,
+        args: serde_json::json!({"path": "README.md"}),
+    });
+    assert!(app.conversation.segments().is_empty());
+
+    let first = draw_published_stream(&mut app, 100, 24);
+    assert!(first.contains("answer before tool sentinel"), "{first}");
+    let second = render_app_to_string(&mut app, 100, 24);
+    assert!(second.contains("read"), "{second}");
+}
+
+#[test]
 fn session_reset_clears_instrument_panel_tool_activity() {
     let mut app = full_test_app();
     let waiting = render_app_to_string(&mut app, 140, 18);
@@ -323,7 +506,7 @@ fn session_reset_clears_instrument_panel_tool_activity() {
     app.handle_agent_event(AgentEvent::MessageChunk {
         text: "hello".into(),
     });
-    let responding = render_app_to_string(&mut app, 140, 18);
+    let responding = draw_published_stream(&mut app, 140, 18);
     assert!(
         responding.contains("streaming answer")
             || responding.contains("transcript live")
@@ -7883,6 +8066,7 @@ fn thinking_chunk_marks_runtime_phase_as_thinking() {
     app.handle_agent_event(AgentEvent::ThinkingChunk {
         text: "deliberating".into(),
     });
+    let _ = draw_published_stream(&mut app, 100, 18);
 
     app.instrument_panel
         .update_telemetry(40.0, 200_000, "high", None, true, 0.016);
@@ -7904,6 +8088,7 @@ fn active_tool_phase_beats_runtime_thinking_in_tui() {
     app.handle_agent_event(AgentEvent::ThinkingChunk {
         text: "deliberating".into(),
     });
+    let _ = draw_published_stream(&mut app, 100, 18);
     app.handle_agent_event(AgentEvent::ToolStart {
         id: "tool-1".into(),
         name: "bash".into(),

--- a/docs/tui-streaming-presentation.md
+++ b/docs/tui-streaming-presentation.md
@@ -1,0 +1,129 @@
+# Streaming presentation revisions
+
+## Problem
+
+Provider chunks are transport units, not presentation units. Applying every `MessageChunk` directly to the rendered conversation lets transport cadence control layout work. It also allows queued completion events to finalize a message before any accumulated streaming state is drawn.
+
+Markdown makes direct chunk rendering especially unstable: an arbitrary prefix can contain an open fence, partial table, unclosed inline delimiter, incomplete link, or list whose eventual structure is not yet known.
+
+## Contract
+
+The TUI separates four states:
+
+1. **Authoritative text** — every accepted runtime delta, retained losslessly for transcript and copying.
+2. **Accumulated presentation** — content observed since the last publication.
+3. **Published revision** — a coherent presentation snapshot eligible for drawing.
+4. **Drawn revision** — the newest published revision acknowledged by a completed terminal draw.
+
+A completion transition may become visual only when:
+
+```text
+published_revision == accumulated_revision == drawn_revision
+```
+
+This prevents `MessageEnd`, `MessageAbort`, or `TurnEnd` from overtaking visible content.
+
+## Markdown projection
+
+A published assistant presentation is conceptually:
+
+```text
+committed markdown blocks + provisional streaming tail
+```
+
+Committed blocks use the normal Markdown renderer and may be cached. The provisional tail uses conservative rendering so incomplete syntax does not repeatedly reinterpret earlier content.
+
+Initial stable-boundary policy should be conservative:
+
+- blank line outside a fence;
+- closed fenced-code block;
+- completed ATX heading or horizontal-rule line;
+- end of message.
+
+Tables, nested lists, incomplete links, and unbalanced inline delimiters remain provisional until a stable boundary or completion. This bounds reflow to the tail rather than the entire response.
+
+## Ownership
+
+- Runtime events remain authoritative and presentation-neutral.
+- `ConversationView` owns canonical message text and lifecycle.
+- `StreamingPresentationController` owns revision, publication, and completion gating.
+- Conversation projection owns stable-block/provisional-tail derivation.
+- The widget owns width/theme-specific rendering caches.
+- The frame scheduler knows only that a revision is due or drawn; it does not parse Markdown.
+
+## Publication policy
+
+Publication may occur when:
+
+- the normal frame interval elapses;
+- a stable Markdown block boundary is crossed;
+- a bounded byte/grapheme threshold is reached;
+- completion requires a final publication;
+- an operator-visible interaction makes the update urgent.
+
+Detached or hidden views may publish less frequently, but canonical text accumulation never pauses.
+
+## Known regression: active conversation separated by a blank viewport
+
+A currently observed failure mode leaves a large, unexplained vertical void between the latest conversation content and the active-turn/status/composer surfaces. A short active transcript may remain near the top of the conversation area while an `active turn` row and composer remain at the bottom. The empty region can occupy most of the terminal height.
+
+This is not acceptable spacing and must not be treated as intentional bottom anchoring. It creates three presentation failures:
+
+- the latest reasoning or assistant output appears disconnected from the controls for the same turn;
+- competing progress projections can remain visible at opposite ends of the viewport;
+- the operator cannot tell whether output stalled, the viewport detached, or content was omitted.
+
+### Reproduction shape
+
+The observed state has these characteristics:
+
+1. The conversation is shorter than the available viewport.
+2. A turn is active and has emitted reasoning or assistant content.
+3. The conversation content is rendered near the top of the viewport.
+4. The active-turn/status and composer surfaces are rendered at the bottom.
+5. The intervening rows are blank even though the operator did not detach or scroll.
+
+Streaming, reflow, completion gating, terminal resize, and transitions between reasoning and assistant content are all suspected triggers. The exact trigger is not yet proven. The visual invariant below applies regardless of trigger.
+
+### Required viewport invariant
+
+When the viewport is attached to the tail:
+
+- the newest published conversation content MUST remain visually adjacent to the bottom interaction surfaces, subject only to deliberate section spacing;
+- short transcripts MUST NOT leave a large blank region between the newest content and active-turn/composer surfaces;
+- publication or Markdown reflow MUST preserve tail attachment;
+- an attached viewport MUST NOT silently acquire a stale scroll offset or false detached anchor;
+- only explicit operator scrolling may enter detached mode.
+
+When the viewport is detached:
+
+- the TUI MUST show an unambiguous detached indicator;
+- publication MUST preserve the operator-selected semantic anchor;
+- returning to the tail MUST restore the attached invariant on the next draw.
+
+### Verification scenarios
+
+Visual regression coverage for the new presentation path must include terminal-buffer snapshots or equivalent row-position assertions for:
+
+- a short active reasoning stream in a tall terminal;
+- a short assistant stream after one or more publication revisions;
+- final chunk and completion arriving in the same ingestion burst;
+- reasoning-to-assistant and assistant-to-tool transitions;
+- terminal resize while attached;
+- detached scrolling during streaming and explicit return to tail;
+- an active stream with compact status and composer surfaces visible.
+
+For attached cases, tests must assert geometry, not merely text presence. At minimum, they must bound the number of blank rows between the final nonblank conversation row and the first active-turn/status/composer row. A snapshot containing the expected strings but retaining the large void does not satisfy this regression.
+
+The blank-space regression is considered quashed only when these tests pass through the published-revision rendering path and a live debug session no longer reproduces the discontinuity.
+
+## Required regressions
+
+- queued chunks and completion require an intermediate drawn revision;
+- chunk bursts coalesce into one revision;
+- unclosed code fences remain provisional;
+- tables do not repeatedly resize while incomplete;
+- tool interleaving creates separate assistant presentation streams;
+- detached viewports retain their anchor;
+- final canonical text exactly equals all accepted deltas;
+- final completion reparses only the provisional tail.


### PR DESCRIPTION
## Summary

- add a generation-scoped TUI presentation controller that coalesces assistant/reasoning chunks and prevents lifecycle or tool events from overtaking unpublished content
- publish revisions before terminal draws, acknowledge only successful draws, and finalize messages after their latest content is visible
- project streaming Markdown as committed blocks plus a conservative provisional tail, including open-fence and incomplete-table handling
- preserve attached/detached viewport geometry across streaming, resize, reasoning/assistant transitions, and return-to-tail actions
- add status-line snapshots and terminal-buffer regression coverage for the streaming presentation matrix

## Validation

- `CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1 just test-crate omegon`
- `CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1 just clippy-changed`
- `cargo fmt --all -- --check`
- `git diff --check`

Serialized non-incremental Cargo gates were used because parallel/incremental `omegon` test builds repeatedly stalled in the final rustc/link stage; the serialized full crate gate completed successfully.
