### PR TITLE
fix(tui): restore terminal after interrupted exit

### DIFF
--- a/core/crates/omegon/src/tui/mod.rs
+++ b/core/crates/omegon/src/tui/mod.rs
@@ -55,6 +55,7 @@ mod startup_splash;
 pub mod statusline;
 mod streaming_presentation;
 pub mod tab_bar;
+mod terminal_session;
 pub mod theme;
 pub mod tool_inspection;
 pub mod turn_tool_projection;
@@ -7323,6 +7324,7 @@ pub async fn run_tui(
             KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES,
         ))?;
     }
+    let terminal_guard = terminal_session::TerminalSessionGuard::new(has_keyboard_enhancement);
 
     let backend = CrosstermBackend::new(io::stdout());
     let mut terminal = Terminal::new(backend)?;
@@ -7330,13 +7332,7 @@ pub async fn run_tui(
     // Install panic hook that restores terminal
     let original_hook = std::panic::take_hook();
     std::panic::set_hook(Box::new(move |info| {
-        let _ = io::stdout().execute(crossterm::event::DisableBracketedPaste);
-        let _ = io::stdout().execute(DisableMouseCapture);
-        if has_keyboard_enhancement {
-            let _ = io::stdout().execute(PopKeyboardEnhancementFlags);
-        }
-        let _ = disable_raw_mode();
-        let _ = io::stdout().execute(LeaveAlternateScreen);
+        terminal_session::restore_terminal(has_keyboard_enhancement);
         original_hook(info);
     }));
 
@@ -7646,13 +7642,21 @@ pub async fn run_tui(
         } else {
             scheduler.idle_poll_timeout(std::time::Instant::now())
         };
-        if event::poll(poll_timeout)? {
-            let input_event = event::read()?;
-            let input_at = std::time::Instant::now();
-            let _ = app.handle_terminal_event(input_event, &command_tx).await;
-            scheduler.mark_dirty(TuiDrawReason::OperatorInput);
-            if let Some(trace) = &mut runtime_trace {
-                trace.record_input(1, input_at);
+        tokio::select! {
+            signal = terminal_session::termination_signal() => {
+                signal?;
+                break;
+            }
+            polled = async { event::poll(poll_timeout) } => {
+                if polled? {
+                    let input_event = event::read()?;
+                    let input_at = std::time::Instant::now();
+                    let _ = app.handle_terminal_event(input_event, &command_tx).await;
+                    scheduler.mark_dirty(TuiDrawReason::OperatorInput);
+                    if let Some(trace) = &mut runtime_trace {
+                        trace.record_input(1, input_at);
+                    }
+                }
             }
         }
     }
@@ -7664,14 +7668,9 @@ pub async fn run_tui(
     // Save history before restoring terminal
     app.save_history();
 
-    // Restore terminal
-    io::stdout().execute(crossterm::event::DisableBracketedPaste)?;
-    io::stdout().execute(DisableMouseCapture)?;
-    if app.keyboard_enhancement {
-        io::stdout().execute(PopKeyboardEnhancementFlags)?;
-    }
-    disable_raw_mode()?;
-    io::stdout().execute(LeaveAlternateScreen)?;
+    // Restore every terminal mode through the same idempotent path used for
+    // errors, panics, and signal-driven shutdown.
+    drop(terminal_guard);
     Ok(())
 }
 

--- a/core/crates/omegon/src/tui/mod.rs
+++ b/core/crates/omegon/src/tui/mod.rs
@@ -7286,13 +7286,16 @@ pub async fn run_tui(
     cancel: SharedCancel,
     settings: crate::settings::SharedSettings,
 ) -> io::Result<()> {
+    let terminal_guard = terminal_session::TerminalSessionGuard::new();
     enable_raw_mode()?;
+    terminal_guard.mark_raw();
 
     // Initialize image protocol detection AFTER raw mode (suppresses echo)
     // but BEFORE alt screen (picker queries need the primary screen).
     image::init_picker();
 
     io::stdout().execute(EnterAlternateScreen)?;
+    terminal_guard.mark_alternate_screen();
     // Set the terminal's own background color to our theme bg.
     // This ensures the alternate screen buffer is filled with our color,
     // not the user's terminal profile background. Without this, crossterm's
@@ -7311,7 +7314,9 @@ pub async fn run_tui(
     // `/mouse off` remains the guaranteed passthrough fallback for terminals
     // that do not implement the Shift override.
     io::stdout().execute(EnableMouseCapture)?;
+    terminal_guard.mark_mouse_capture();
     io::stdout().execute(crossterm::event::EnableBracketedPaste)?;
+    terminal_guard.mark_bracketed_paste();
 
     // Enable Kitty keyboard protocol when the terminal supports it.
     // This lets crossterm distinguish Shift+Enter from Enter, which is
@@ -7323,18 +7328,15 @@ pub async fn run_tui(
         io::stdout().execute(PushKeyboardEnhancementFlags(
             KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES,
         ))?;
+        terminal_guard.mark_keyboard_enhancement();
     }
-    let terminal_guard = terminal_session::TerminalSessionGuard::new(has_keyboard_enhancement);
 
     let backend = CrosstermBackend::new(io::stdout());
     let mut terminal = Terminal::new(backend)?;
 
-    // Install panic hook that restores terminal
-    let original_hook = std::panic::take_hook();
-    std::panic::set_hook(Box::new(move |info| {
-        terminal_session::restore_terminal(has_keyboard_enhancement);
-        original_hook(info);
-    }));
+    // Restore the terminal before forwarding any panic to the process hook.
+    // The hook guard reinstates the prior hook when this TUI session ends.
+    let panic_hook_guard = terminal_guard.install_panic_hook();
 
     // Initialise spinner: seed from process start time for variety across
     // sessions, and load user extras from ~/.config/omegon/spinner-verbs.txt.
@@ -7645,6 +7647,10 @@ pub async fn run_tui(
         tokio::select! {
             signal = terminal_session::termination_signal() => {
                 signal?;
+                // Terminal restoration alone must not leave the coordinator
+                // running headless while IPC/other sender clones keep the
+                // command channel open.
+                let _ = command_tx.send(TuiCommand::Quit).await;
                 break;
             }
             polled = async { event::poll(poll_timeout) } => {
@@ -7670,6 +7676,7 @@ pub async fn run_tui(
 
     // Restore every terminal mode through the same idempotent path used for
     // errors, panics, and signal-driven shutdown.
+    drop(panic_hook_guard);
     drop(terminal_guard);
     Ok(())
 }

--- a/core/crates/omegon/src/tui/terminal_session.rs
+++ b/core/crates/omegon/src/tui/terminal_session.rs
@@ -1,0 +1,77 @@
+use std::io::{self, Write};
+
+use crossterm::ExecutableCommand;
+use crossterm::event::{DisableBracketedPaste, DisableMouseCapture, PopKeyboardEnhancementFlags};
+use crossterm::terminal::{LeaveAlternateScreen, disable_raw_mode};
+
+/// Owns the terminal modes enabled by the TUI and restores them on every
+/// unwind/early-return path. Signal-driven shutdown is handled by `run_tui`,
+/// which lets this guard drop before the process exits.
+pub(super) struct TerminalSessionGuard {
+    keyboard_enhancement: bool,
+}
+
+impl TerminalSessionGuard {
+    pub(super) fn new(keyboard_enhancement: bool) -> Self {
+        Self {
+            keyboard_enhancement,
+        }
+    }
+
+    pub(super) fn restore(&self) {
+        restore_terminal(self.keyboard_enhancement);
+    }
+}
+
+impl Drop for TerminalSessionGuard {
+    fn drop(&mut self) {
+        self.restore();
+    }
+}
+
+pub(super) fn restore_terminal(keyboard_enhancement: bool) {
+    let mut stdout = io::stdout();
+    let _ = stdout.execute(DisableBracketedPaste);
+    let _ = stdout.execute(DisableMouseCapture);
+    if keyboard_enhancement {
+        let _ = stdout.execute(PopKeyboardEnhancementFlags);
+    }
+    let _ = disable_raw_mode();
+    let _ = stdout.execute(LeaveAlternateScreen);
+    let _ = stdout.flush();
+}
+
+pub(super) async fn termination_signal() -> io::Result<()> {
+    #[cfg(unix)]
+    {
+        use tokio::signal::unix::{SignalKind, signal};
+
+        let mut terminate = signal(SignalKind::terminate())?;
+        let mut hangup = signal(SignalKind::hangup())?;
+        let mut quit = signal(SignalKind::quit())?;
+        tokio::select! {
+            result = tokio::signal::ctrl_c() => result,
+            _ = terminate.recv() => Ok(()),
+            _ = hangup.recv() => Ok(()),
+            _ = quit.recv() => Ok(()),
+        }
+    }
+
+    #[cfg(not(unix))]
+    {
+        tokio::signal::ctrl_c().await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn guard_can_restore_repeatedly() {
+        let guard = TerminalSessionGuard::new(false);
+        guard.restore();
+        guard.restore();
+        drop(guard);
+    }
+}

--- a/core/crates/omegon/src/tui/terminal_session.rs
+++ b/core/crates/omegon/src/tui/terminal_session.rs
@@ -1,25 +1,78 @@
 use std::io::{self, Write};
+use std::sync::{Arc, Mutex};
 
 use crossterm::ExecutableCommand;
 use crossterm::event::{DisableBracketedPaste, DisableMouseCapture, PopKeyboardEnhancementFlags};
 use crossterm::terminal::{LeaveAlternateScreen, disable_raw_mode};
 
-/// Owns the terminal modes enabled by the TUI and restores them on every
-/// unwind/early-return path. Signal-driven shutdown is handled by `run_tui`,
-/// which lets this guard drop before the process exits.
-pub(super) struct TerminalSessionGuard {
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+struct TerminalModes {
+    raw: bool,
+    alternate_screen: bool,
+    mouse_capture: bool,
+    bracketed_paste: bool,
     keyboard_enhancement: bool,
 }
 
+/// Tracks each terminal mode as it is enabled so partial initialization,
+/// ordinary errors, and unwinding all restore exactly the modes Omegon owns.
+pub(super) struct TerminalSessionGuard {
+    modes: Arc<Mutex<TerminalModes>>,
+}
+
 impl TerminalSessionGuard {
-    pub(super) fn new(keyboard_enhancement: bool) -> Self {
+    pub(super) fn new() -> Self {
         Self {
-            keyboard_enhancement,
+            modes: Arc::new(Mutex::new(TerminalModes::default())),
+        }
+    }
+
+    pub(super) fn mark_raw(&self) {
+        self.update(|modes| modes.raw = true);
+    }
+
+    pub(super) fn mark_alternate_screen(&self) {
+        self.update(|modes| modes.alternate_screen = true);
+    }
+
+    pub(super) fn mark_mouse_capture(&self) {
+        self.update(|modes| modes.mouse_capture = true);
+    }
+
+    pub(super) fn mark_bracketed_paste(&self) {
+        self.update(|modes| modes.bracketed_paste = true);
+    }
+
+    pub(super) fn mark_keyboard_enhancement(&self) {
+        self.update(|modes| modes.keyboard_enhancement = true);
+    }
+
+    pub(super) fn install_panic_hook(&self) -> PanicHookGuard {
+        let original = Arc::<PanicHook>::from(std::panic::take_hook());
+        let chained = original.clone();
+        let modes = self.modes.clone();
+        std::panic::set_hook(Box::new(move |info| {
+            restore_snapshot(snapshot(&modes));
+            chained(info);
+        }));
+        PanicHookGuard {
+            original: Some(original),
         }
     }
 
     pub(super) fn restore(&self) {
-        restore_terminal(self.keyboard_enhancement);
+        let modes = self
+            .modes
+            .lock()
+            .map(|mut modes| std::mem::take(&mut *modes))
+            .unwrap_or_default();
+        restore_snapshot(modes);
+    }
+
+    fn update(&self, update: impl FnOnce(&mut TerminalModes)) {
+        if let Ok(mut modes) = self.modes.lock() {
+            update(&mut modes);
+        }
     }
 }
 
@@ -29,15 +82,41 @@ impl Drop for TerminalSessionGuard {
     }
 }
 
-pub(super) fn restore_terminal(keyboard_enhancement: bool) {
+type PanicHook = dyn Fn(&std::panic::PanicHookInfo<'_>) + Send + Sync + 'static;
+
+pub(super) struct PanicHookGuard {
+    original: Option<Arc<PanicHook>>,
+}
+
+impl Drop for PanicHookGuard {
+    fn drop(&mut self) {
+        if let Some(original) = self.original.take() {
+            std::panic::set_hook(Box::new(move |info| original(info)));
+        }
+    }
+}
+
+fn snapshot(modes: &Arc<Mutex<TerminalModes>>) -> TerminalModes {
+    modes.lock().map(|modes| *modes).unwrap_or_default()
+}
+
+fn restore_snapshot(modes: TerminalModes) {
     let mut stdout = io::stdout();
-    let _ = stdout.execute(DisableBracketedPaste);
-    let _ = stdout.execute(DisableMouseCapture);
-    if keyboard_enhancement {
+    if modes.bracketed_paste {
+        let _ = stdout.execute(DisableBracketedPaste);
+    }
+    if modes.mouse_capture {
+        let _ = stdout.execute(DisableMouseCapture);
+    }
+    if modes.keyboard_enhancement {
         let _ = stdout.execute(PopKeyboardEnhancementFlags);
     }
-    let _ = disable_raw_mode();
-    let _ = stdout.execute(LeaveAlternateScreen);
+    if modes.raw {
+        let _ = disable_raw_mode();
+    }
+    if modes.alternate_screen {
+        let _ = stdout.execute(LeaveAlternateScreen);
+    }
     let _ = stdout.flush();
 }
 
@@ -68,10 +147,33 @@ mod tests {
     use super::*;
 
     #[test]
-    fn guard_can_restore_repeatedly() {
-        let guard = TerminalSessionGuard::new(false);
+    fn restore_consumes_tracked_modes_and_is_idempotent() {
+        let guard = TerminalSessionGuard::new();
+        guard.mark_raw();
+        guard.mark_alternate_screen();
+        guard.mark_mouse_capture();
+        guard.mark_bracketed_paste();
+        guard.mark_keyboard_enhancement();
+
         guard.restore();
+        assert_eq!(snapshot(&guard.modes), TerminalModes::default());
         guard.restore();
-        drop(guard);
+    }
+
+    #[test]
+    fn partial_initialization_tracks_only_completed_modes() {
+        let guard = TerminalSessionGuard::new();
+        guard.mark_raw();
+        guard.mark_alternate_screen();
+
+        assert_eq!(
+            snapshot(&guard.modes),
+            TerminalModes {
+                raw: true,
+                alternate_screen: true,
+                ..TerminalModes::default()
+            }
+        );
+        guard.restore();
     }
 }


### PR DESCRIPTION
## Summary

- track terminal modes from the first successful TUI mutation so partial initialization is recoverable
- restore raw mode, alternate screen, mouse capture, bracketed paste, and keyboard enhancement on errors, panics, and catchable termination signals
- scope the panic hook to the TUI session and notify the coordinator to quit on signal-driven shutdown

## Validation

- `just test-crate omegon`
- `just clippy-changed`
- focused `tui::terminal_session::tests`
- `git diff --check`

## Boundary

`SIGKILL` cannot be intercepted by a process; all catchable termination signals are covered.
