### PR TITLE
feat(tui): improve live terminal preview navigation

### DIFF
--- a/core/crates/omegon/src/tui/input.rs
+++ b/core/crates/omegon/src/tui/input.rs
@@ -370,14 +370,48 @@ impl App {
                 // ── Structured menu intercepts navigation when open ────
                 if self.process_viewer.is_some() {
                     match key.code {
-                        KeyCode::Up | KeyCode::PageUp => {
+                        KeyCode::Up | KeyCode::Char('k') => {
                             if let Some(viewer) = self.process_viewer.as_mut() {
-                                viewer.scroll_up();
+                                viewer.scroll_up(1);
                             }
                         }
-                        KeyCode::Down | KeyCode::PageDown => {
+                        KeyCode::PageUp | KeyCode::Char('u') => {
+                            let page_size = crossterm::terminal::size()
+                                .map(|(width, height)| {
+                                    process_viewer::process_viewer_page_size(
+                                        ratatui::layout::Rect::new(0, 0, width, height),
+                                    )
+                                })
+                                .unwrap_or(10);
                             if let Some(viewer) = self.process_viewer.as_mut() {
-                                viewer.scroll_down();
+                                viewer.scroll_up(page_size);
+                            }
+                        }
+                        KeyCode::Down | KeyCode::Char('j') => {
+                            if let Some(viewer) = self.process_viewer.as_mut() {
+                                viewer.scroll_down(1);
+                            }
+                        }
+                        KeyCode::PageDown | KeyCode::Char('d') => {
+                            let page_size = crossterm::terminal::size()
+                                .map(|(width, height)| {
+                                    process_viewer::process_viewer_page_size(
+                                        ratatui::layout::Rect::new(0, 0, width, height),
+                                    )
+                                })
+                                .unwrap_or(10);
+                            if let Some(viewer) = self.process_viewer.as_mut() {
+                                viewer.scroll_down(page_size);
+                            }
+                        }
+                        KeyCode::Home => {
+                            if let Some(viewer) = self.process_viewer.as_mut() {
+                                viewer.jump_to_top();
+                            }
+                        }
+                        KeyCode::End | KeyCode::Char('f') | KeyCode::Char('F') => {
+                            if let Some(viewer) = self.process_viewer.as_mut() {
+                                viewer.follow_tail();
                             }
                         }
                         KeyCode::Left => {
@@ -388,11 +422,6 @@ impl App {
                         KeyCode::Right => {
                             if let Some(viewer) = self.process_viewer.as_mut() {
                                 viewer.switch_session(1);
-                            }
-                        }
-                        KeyCode::Char('f') | KeyCode::Char('F') => {
-                            if let Some(viewer) = self.process_viewer.as_mut() {
-                                viewer.toggle_follow();
                             }
                         }
                         KeyCode::Char('x') | KeyCode::Char('X') => {

--- a/core/crates/omegon/src/tui/process_viewer.rs
+++ b/core/crates/omegon/src/tui/process_viewer.rs
@@ -3,6 +3,8 @@
 use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, Clear, Paragraph, Wrap};
 
+use ansi_to_tui::IntoText as _;
+
 use super::theme::Theme;
 
 #[derive(Debug, Clone)]
@@ -88,27 +90,10 @@ pub(crate) fn render_process_viewer(
                 crate::tools::terminal::ExecutionSessionState::Exited => "exited",
                 crate::tools::terminal::ExecutionSessionState::Failed => "failed",
             };
-            let output = if snapshot.output.is_empty() {
-                "(no output yet)".to_string()
-            } else {
-                snapshot.output
-            };
+            let output = terminal_output_text(&snapshot.output, theme);
             (
                 format!(" Process · {} · {status} ", snapshot.name),
-                format!(
-                    "$ {}\n# cwd: {}\n# pid: {} · elapsed: {}s\n# transcript: {}{}\n\n{}",
-                    snapshot.command,
-                    snapshot.cwd.display(),
-                    snapshot.pid,
-                    snapshot.elapsed_secs,
-                    snapshot.transcript_path.display(),
-                    if snapshot.transcript_truncated {
-                        " · truncated"
-                    } else {
-                        ""
-                    },
-                    output,
-                ),
+                process_body(&snapshot, output, theme),
                 if state.confirm_stop {
                     "Press x again to stop this process · Esc cancel"
                 } else if snapshot.capabilities.stop {
@@ -120,7 +105,10 @@ pub(crate) fn render_process_viewer(
         }
         None => (
             " Process · unavailable ".to_string(),
-            format!("Session '{}' is no longer retained.", state.session_id),
+            Text::styled(
+                format!("Session '{}' is no longer retained.", state.session_id),
+                theme.style_muted(),
+            ),
             "Esc close",
         ),
     };
@@ -132,7 +120,7 @@ pub(crate) fn render_process_viewer(
         .title(title)
         .title_bottom(Line::from(footer).style(theme.style_dim()));
     let inner_height = popup.height.saturating_sub(2);
-    let body_lines = body.lines().count() as u16;
+    let body_lines = body.lines.len() as u16;
     let max_scroll = body_lines.saturating_sub(inner_height);
     let scroll = if state.follow {
         max_scroll
@@ -147,6 +135,72 @@ pub(crate) fn render_process_viewer(
             .scroll((scroll, 0)),
         popup,
     );
+}
+
+fn terminal_output_text(output: &str, theme: &dyn Theme) -> Text<'static> {
+    if output.is_empty() {
+        return Text::styled("(no output yet)", theme.style_dim());
+    }
+
+    match output.to_string().into_text() {
+        Ok(mut text) => {
+            for line in &mut text.lines {
+                for span in &mut line.spans {
+                    if span.style.fg.is_none() {
+                        span.style = span.style.fg(theme.muted());
+                    }
+                }
+            }
+            text
+        }
+        Err(_) => Text::styled(strip_terminal_controls(output), theme.style_muted()),
+    }
+}
+
+fn process_body(
+    snapshot: &crate::tools::terminal::ExecutionSessionSnapshot,
+    output: Text<'static>,
+    theme: &dyn Theme,
+) -> Text<'static> {
+    let mut lines = vec![
+        Line::from(vec![
+            Span::styled("$ ", theme.style_accent()),
+            Span::styled(strip_terminal_controls(&snapshot.command), theme.style_fg()),
+        ]),
+        Line::styled(
+            format!("cwd: {}", snapshot.cwd.display()),
+            theme.style_dim(),
+        ),
+        Line::styled(
+            format!(
+                "pid: {} · elapsed: {}s",
+                snapshot.pid, snapshot.elapsed_secs
+            ),
+            theme.style_dim(),
+        ),
+        Line::styled(
+            format!(
+                "transcript: {}{}",
+                snapshot.transcript_path.display(),
+                if snapshot.transcript_truncated {
+                    " · truncated"
+                } else {
+                    ""
+                }
+            ),
+            theme.style_dim(),
+        ),
+        Line::default(),
+    ];
+    lines.extend(output.lines);
+    Text::from(lines)
+}
+
+fn strip_terminal_controls(input: &str) -> String {
+    input
+        .chars()
+        .filter(|ch| matches!(ch, '\n' | '\r' | '\t') || !ch.is_control())
+        .collect()
 }
 
 #[cfg(test)]
@@ -175,5 +229,33 @@ mod tests {
         state.toggle_follow();
         assert!(state.follow);
         assert_eq!(state.scroll, 0);
+    }
+
+    #[test]
+    fn terminal_output_parses_ansi_without_rendering_escape_bytes() {
+        let theme = super::super::theme::Alpharius;
+        let text = terminal_output_text("plain\n\x1b[31mfailed\x1b[0m", &theme);
+
+        assert_eq!(text.lines.len(), 2);
+        assert_eq!(text.lines[0].spans[0].content, "plain");
+        assert_eq!(text.lines[1].spans[0].content, "failed");
+        assert_eq!(text.lines[1].spans[0].style.fg, Some(Color::Red));
+        assert!(
+            text.lines
+                .iter()
+                .flat_map(|line| &line.spans)
+                .all(|span| !span.content.contains('\x1b'))
+        );
+    }
+
+    #[test]
+    fn terminal_output_uses_theme_for_plain_and_empty_output() {
+        let theme = super::super::theme::Alpharius;
+        let plain = terminal_output_text("ordinary", &theme);
+        assert_eq!(plain.lines[0].spans[0].style.fg, Some(theme.muted()));
+
+        let empty = terminal_output_text("", &theme);
+        assert_eq!(empty.lines[0].spans[0].content, "(no output yet)");
+        assert_eq!(empty.style, theme.style_dim());
     }
 }

--- a/core/crates/omegon/src/tui/process_viewer.rs
+++ b/core/crates/omegon/src/tui/process_viewer.rs
@@ -91,8 +91,9 @@ pub(crate) fn render_process_viewer(
                 crate::tools::terminal::ExecutionSessionState::Failed => "failed",
             };
             let output = terminal_output_text(&snapshot.output, theme);
+            let safe_name = super::segments::strip_terminal_control(&snapshot.name);
             (
-                format!(" Process · {} · {status} ", snapshot.name),
+                format!(" Process · {safe_name} · {status} "),
                 process_body(&snapshot, output, theme),
                 if state.confirm_stop {
                     "Press x again to stop this process · Esc cancel"
@@ -103,14 +104,17 @@ pub(crate) fn render_process_viewer(
                 },
             )
         }
-        None => (
-            " Process · unavailable ".to_string(),
-            Text::styled(
-                format!("Session '{}' is no longer retained.", state.session_id),
-                theme.style_muted(),
-            ),
-            "Esc close",
-        ),
+        None => {
+            let safe_session_id = super::segments::strip_terminal_control(&state.session_id);
+            (
+                " Process · unavailable ".to_string(),
+                Text::styled(
+                    format!("Session '{safe_session_id}' is no longer retained."),
+                    theme.style_muted(),
+                ),
+                "Esc close",
+            )
+        }
     };
 
     let block = Block::default()
@@ -119,8 +123,9 @@ pub(crate) fn render_process_viewer(
         .border_style(theme.style_border())
         .title(title)
         .title_bottom(Line::from(footer).style(theme.style_dim()));
-    let inner_height = popup.height.saturating_sub(2);
-    let body_lines = body.lines.len() as u16;
+    let inner_height = popup.height.saturating_sub(2).max(1);
+    let inner_width = popup.width.saturating_sub(2).max(1);
+    let body_lines = wrapped_line_count(&body, inner_width);
     let max_scroll = body_lines.saturating_sub(inner_height);
     let scroll = if state.follow {
         max_scroll
@@ -135,6 +140,17 @@ pub(crate) fn render_process_viewer(
             .scroll((scroll, 0)),
         popup,
     );
+}
+
+fn wrapped_line_count(text: &Text<'_>, width: u16) -> u16 {
+    let width = usize::from(width.max(1));
+    text.lines
+        .iter()
+        .map(|line| {
+            let columns = line.width();
+            columns.max(1).div_ceil(width) as u16
+        })
+        .fold(0u16, u16::saturating_add)
 }
 
 fn terminal_output_text(output: &str, theme: &dyn Theme) -> Text<'static> {

--- a/core/crates/omegon/src/tui/process_viewer.rs
+++ b/core/crates/omegon/src/tui/process_viewer.rs
@@ -25,21 +25,33 @@ impl ProcessViewerState {
         }
     }
 
-    pub(crate) fn scroll_up(&mut self) {
+    /// Move away from the live tail by `lines` visual rows.
+    /// `scroll` is an offset from the bottom, so new output cannot move a
+    /// detached operator's viewport.
+    pub(crate) fn scroll_up(&mut self, lines: u16) {
         self.follow = false;
-        self.scroll = self.scroll.saturating_sub(1);
+        self.scroll = self.scroll.saturating_add(lines);
     }
 
-    pub(crate) fn scroll_down(&mut self) {
-        self.scroll = self.scroll.saturating_add(1);
-    }
-
-    pub(crate) fn toggle_follow(&mut self) {
-        self.confirm_stop = false;
-        self.follow = !self.follow;
-        if self.follow {
-            self.scroll = 0;
+    /// Move toward the live tail by `lines` visual rows. Reaching the tail
+    /// resumes follow mode so subsequent output remains visible.
+    pub(crate) fn scroll_down(&mut self, lines: u16) {
+        self.scroll = self.scroll.saturating_sub(lines);
+        if self.scroll == 0 {
+            self.follow = true;
         }
+    }
+
+    pub(crate) fn follow_tail(&mut self) {
+        self.confirm_stop = false;
+        self.follow = true;
+        self.scroll = 0;
+    }
+
+    pub(crate) fn jump_to_top(&mut self) {
+        self.confirm_stop = false;
+        self.follow = false;
+        self.scroll = u16::MAX;
     }
 
     pub(crate) fn switch_session(&mut self, delta: isize) {
@@ -73,6 +85,13 @@ impl ProcessViewerState {
     }
 }
 
+pub(crate) fn process_viewer_page_size(area: Rect) -> u16 {
+    super::command_surfaces::command_modal_area(area)
+        .height
+        .saturating_sub(4)
+        .max(1)
+}
+
 pub(crate) fn render_process_viewer(
     frame: &mut Frame,
     area: Rect,
@@ -98,9 +117,9 @@ pub(crate) fn render_process_viewer(
                 if state.confirm_stop {
                     "Press x again to stop this process · Esc cancel"
                 } else if snapshot.capabilities.stop {
-                    "←/→ switch · ↑/↓ scroll · f follow · x stop · Esc close · read-only"
+                    "←/→ switch · ↑/↓ line · PgUp/PgDn page · Home top · End/f follow · x stop · Esc close"
                 } else {
-                    "←/→ switch · ↑/↓ scroll · Esc close · completed"
+                    "←/→ switch · ↑/↓ line · PgUp/PgDn page · Home top · End/f follow · Esc close"
                 },
             )
         }
@@ -130,7 +149,7 @@ pub(crate) fn render_process_viewer(
     let scroll = if state.follow {
         max_scroll
     } else {
-        state.scroll.min(max_scroll)
+        max_scroll.saturating_sub(state.scroll.min(max_scroll))
     };
     frame.render_widget(
         Paragraph::new(body)
@@ -239,10 +258,10 @@ mod tests {
     fn viewer_state_disables_follow_when_scrolling_up() {
         let mut state = ProcessViewerState::new("session");
         state.scroll = 3;
-        state.scroll_up();
+        state.scroll_up(2);
         assert!(!state.follow);
-        assert_eq!(state.scroll, 2);
-        state.toggle_follow();
+        assert_eq!(state.scroll, 5);
+        state.follow_tail();
         assert!(state.follow);
         assert_eq!(state.scroll, 0);
     }


### PR DESCRIPTION
## Summary
- render ANSI-styled terminal output without exposing control bytes
- sanitize process metadata and compute wrapped visual scroll bounds
- add viewport-aware page navigation and deterministic live-tail follow controls

## Validation
- cargo test -p omegon --locked tui::process_viewer::tests:: -- --test-threads=1
- cargo check -p omegon
- just clippy-changed
- git diff --check