### PR TITLE
Fix active worker channel starvation

### DIFF
--- a/core/crates/omegon/src/active_worker_channel.rs
+++ b/core/crates/omegon/src/active_worker_channel.rs
@@ -1,0 +1,117 @@
+//! Liveness policy for the active worker's operator-command channel.
+//!
+//! Tokio mpsc receivers remain immediately ready after closure. A supervisor
+//! that keeps polling a closed receiver can hot-spin and starve worker joins,
+//! cancellation timers, and operator-visible lifecycle updates. This state
+//! object makes closure terminal and disables the receive branch thereafter.
+
+use tokio::sync::mpsc;
+
+#[derive(Debug, Default)]
+pub(crate) struct ActiveWorkerCommandChannel {
+    open: bool,
+}
+
+impl ActiveWorkerCommandChannel {
+    pub(crate) fn new() -> Self {
+        Self { open: true }
+    }
+
+    pub(crate) async fn recv<T>(&self, receiver: &mut mpsc::Receiver<T>) -> Option<T> {
+        if self.open {
+            receiver.recv().await
+        } else {
+            std::future::pending::<Option<T>>().await
+        }
+    }
+
+    /// Records the first observed closure. Returns false for duplicate calls,
+    /// which indicate a supervisor bug because a closed branch must be disabled.
+    pub(crate) fn observe_closed(&mut self) -> bool {
+        std::mem::replace(&mut self.open, false)
+    }
+
+    #[cfg(test)]
+    fn is_open(&self) -> bool {
+        self.open
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    #[tokio::test]
+    async fn open_channel_delivers_commands() {
+        let (tx, mut rx) = mpsc::channel(1);
+        tx.send("command").await.unwrap();
+        let state = ActiveWorkerCommandChannel::new();
+
+        assert_eq!(state.recv(&mut rx).await, Some("command"));
+        assert!(state.is_open());
+    }
+
+    #[tokio::test]
+    async fn first_closed_receive_is_observable_once() {
+        let (tx, mut rx) = mpsc::channel::<()>(1);
+        drop(tx);
+        let mut state = ActiveWorkerCommandChannel::new();
+
+        assert_eq!(state.recv(&mut rx).await, None);
+        assert!(state.observe_closed());
+        assert!(!state.observe_closed());
+        assert!(!state.is_open());
+    }
+
+    #[tokio::test]
+    async fn disabled_channel_branch_is_not_permanently_ready() {
+        let (tx, mut rx) = mpsc::channel::<()>(1);
+        drop(tx);
+        let mut state = ActiveWorkerCommandChannel::new();
+        assert_eq!(state.recv(&mut rx).await, None);
+        assert!(state.observe_closed());
+
+        assert!(
+            tokio::time::timeout(Duration::from_millis(25), state.recv(&mut rx))
+                .await
+                .is_err(),
+            "closed branch must become pending instead of hot-spinning"
+        );
+    }
+
+    #[tokio::test]
+    async fn disabled_channel_cannot_starve_ready_worker_completion() {
+        let (tx, mut rx) = mpsc::channel::<()>(1);
+        drop(tx);
+        let mut state = ActiveWorkerCommandChannel::new();
+        assert_eq!(state.recv(&mut rx).await, None);
+        assert!(state.observe_closed());
+        let worker = async { "worker-returned" };
+
+        let result = tokio::select! {
+            biased;
+            command = state.recv(&mut rx) => panic!("disabled branch returned: {command:?}"),
+            result = worker => result,
+        };
+
+        assert_eq!(result, "worker-returned");
+    }
+
+    #[tokio::test]
+    async fn disabled_channel_cannot_starve_cancellation_deadline() {
+        let (tx, mut rx) = mpsc::channel::<()>(1);
+        drop(tx);
+        let mut state = ActiveWorkerCommandChannel::new();
+        assert_eq!(state.recv(&mut rx).await, None);
+        assert!(state.observe_closed());
+
+        let fired = tokio::select! {
+            biased;
+            command = state.recv(&mut rx) => panic!("disabled branch returned: {command:?}"),
+            _ = tokio::time::sleep(Duration::from_millis(10)) => true,
+        };
+
+        assert!(fired);
+    }
+}

--- a/core/crates/omegon/src/main.rs
+++ b/core/crates/omegon/src/main.rs
@@ -98,6 +98,7 @@ mod usage;
 mod value_context;
 mod workspace;
 
+mod active_worker_channel;
 mod agent_manifest;
 mod armory;
 mod bundle_verify;
@@ -6081,6 +6082,7 @@ fn build_tui_secret_readiness_snapshot(
                     let mut slow_turn_notifications: u32 = 0;
                     let mut notified_blocked_prompt_queue = false;
                     let mut cancellation_deadline: Option<std::pin::Pin<Box<tokio::time::Sleep>>> = None;
+                    let mut active_command_channel = active_worker_channel::ActiveWorkerCommandChannel::new();
 
                     loop {
                         tokio::select! {
@@ -6146,13 +6148,14 @@ fn build_tui_secret_readiness_snapshot(
                                 }
                                 slow_turn_probe.as_mut().reset(tokio::time::Instant::now() + std::time::Duration::from_secs(10));
                             }
-                            maybe_cmd = command_rx.recv() => {
+                            maybe_cmd = active_command_channel.recv(&mut command_rx) => {
                                 let Some(cmd) = maybe_cmd else {
+                                    let first_close = active_command_channel.observe_closed();
+                                    debug_assert!(first_close, "disabled command branch returned closure twice");
                                     quit_after_turn = true;
-                                    if let Ok(guard) = shared_cancel.lock()
-                                        && let Some(ref cancel) = *guard
-                                    {
-                                        cancel.cancel();
+                                    turn_cancel.cancel();
+                                    if cancellation_deadline.is_none() {
+                                        cancellation_deadline = Some(Box::pin(tokio::time::sleep(std::time::Duration::from_secs(2))));
                                     }
                                     continue;
                                 };


### PR DESCRIPTION
## Summary
- disable the active-turn command receive branch after channel closure
- cancel the active turn and arm bounded abort without hot-spinning
- add a compiled liveness bastion covering worker completion and cancellation deadlines

## Scope
This PR contains only the runtime starvation fix. Existing unrelated nightly/site working-tree changes are not committed.

## Validation
- `cargo test -p omegon --locked active_worker_channel::tests:: -- --test-threads=16`
- `cargo check -p omegon --message-format=short`
- `just clippy-changed`
- `git diff --check`