### PR TITLE
fix(runtime): consolidate turn liveness fixes for 0.29 nightly

### DIFF
--- a/core/crates/omegon/src/active_worker_channel.rs
+++ b/core/crates/omegon/src/active_worker_channel.rs
@@ -1,0 +1,117 @@
+//! Liveness policy for the active worker's operator-command channel.
+//!
+//! Tokio mpsc receivers remain immediately ready after closure. A supervisor
+//! that keeps polling a closed receiver can hot-spin and starve worker joins,
+//! cancellation timers, and operator-visible lifecycle updates. This state
+//! object makes closure terminal and disables the receive branch thereafter.
+
+use tokio::sync::mpsc;
+
+#[derive(Debug, Default)]
+pub(crate) struct ActiveWorkerCommandChannel {
+    open: bool,
+}
+
+impl ActiveWorkerCommandChannel {
+    pub(crate) fn new() -> Self {
+        Self { open: true }
+    }
+
+    pub(crate) async fn recv<T>(&self, receiver: &mut mpsc::Receiver<T>) -> Option<T> {
+        if self.open {
+            receiver.recv().await
+        } else {
+            std::future::pending::<Option<T>>().await
+        }
+    }
+
+    /// Records the first observed closure. Returns false for duplicate calls,
+    /// which indicate a supervisor bug because a closed branch must be disabled.
+    pub(crate) fn observe_closed(&mut self) -> bool {
+        std::mem::replace(&mut self.open, false)
+    }
+
+    #[cfg(test)]
+    fn is_open(&self) -> bool {
+        self.open
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    #[tokio::test]
+    async fn open_channel_delivers_commands() {
+        let (tx, mut rx) = mpsc::channel(1);
+        tx.send("command").await.unwrap();
+        let state = ActiveWorkerCommandChannel::new();
+
+        assert_eq!(state.recv(&mut rx).await, Some("command"));
+        assert!(state.is_open());
+    }
+
+    #[tokio::test]
+    async fn first_closed_receive_is_observable_once() {
+        let (tx, mut rx) = mpsc::channel::<()>(1);
+        drop(tx);
+        let mut state = ActiveWorkerCommandChannel::new();
+
+        assert_eq!(state.recv(&mut rx).await, None);
+        assert!(state.observe_closed());
+        assert!(!state.observe_closed());
+        assert!(!state.is_open());
+    }
+
+    #[tokio::test]
+    async fn disabled_channel_branch_is_not_permanently_ready() {
+        let (tx, mut rx) = mpsc::channel::<()>(1);
+        drop(tx);
+        let mut state = ActiveWorkerCommandChannel::new();
+        assert_eq!(state.recv(&mut rx).await, None);
+        assert!(state.observe_closed());
+
+        assert!(
+            tokio::time::timeout(Duration::from_millis(25), state.recv(&mut rx))
+                .await
+                .is_err(),
+            "closed branch must become pending instead of hot-spinning"
+        );
+    }
+
+    #[tokio::test]
+    async fn disabled_channel_cannot_starve_ready_worker_completion() {
+        let (tx, mut rx) = mpsc::channel::<()>(1);
+        drop(tx);
+        let mut state = ActiveWorkerCommandChannel::new();
+        assert_eq!(state.recv(&mut rx).await, None);
+        assert!(state.observe_closed());
+        let worker = async { "worker-returned" };
+
+        let result = tokio::select! {
+            biased;
+            command = state.recv(&mut rx) => panic!("disabled branch returned: {command:?}"),
+            result = worker => result,
+        };
+
+        assert_eq!(result, "worker-returned");
+    }
+
+    #[tokio::test]
+    async fn disabled_channel_cannot_starve_cancellation_deadline() {
+        let (tx, mut rx) = mpsc::channel::<()>(1);
+        drop(tx);
+        let mut state = ActiveWorkerCommandChannel::new();
+        assert_eq!(state.recv(&mut rx).await, None);
+        assert!(state.observe_closed());
+
+        let fired = tokio::select! {
+            biased;
+            command = state.recv(&mut rx) => panic!("disabled branch returned: {command:?}"),
+            _ = tokio::time::sleep(Duration::from_millis(10)) => true,
+        };
+
+        assert!(fired);
+    }
+}

--- a/core/crates/omegon/src/loop.rs
+++ b/core/crates/omegon/src/loop.rs
@@ -4151,7 +4151,14 @@ fn should_continue_text_only_turn(
     }
     let assistant = assistant_text.trim();
     if assistant.is_empty() {
-        return false;
+        // An empty provider message is not an operator-facing completion. This
+        // commonly occurs after tool results on OpenAI-compatible routes; if we
+        // accept it as complete the TUI returns to idle with no answer and an
+        // unfinished task. Re-enter the bounded dead-mouse recovery path when
+        // work has already started or the operator explicitly requested action.
+        return prior_tool_activity
+            || user_prompt_is_continue_or_proceed(user_prompt)
+            || user_prompt_expects_concrete_action(user_prompt);
     }
     if looks_like_blocked_response(assistant) || looks_like_completion(assistant) {
         return false;
@@ -7179,6 +7186,34 @@ This is the right first slice."#;
             crate::settings::AutomationLevel::Flow,
             "fix the release flow",
             "All done. The release flow has been updated and tested.",
+            true
+        ));
+    }
+
+    #[test]
+    fn empty_post_tool_message_reenters_bounded_recovery() {
+        assert!(should_continue_text_only_turn(
+            crate::settings::AutomationLevel::Flow,
+            "What model are you?",
+            "   ",
+            true
+        ));
+        assert!(should_continue_text_only_turn(
+            crate::settings::AutomationLevel::Guarded,
+            "fix the release flow",
+            "",
+            false
+        ));
+        assert!(!should_continue_text_only_turn(
+            crate::settings::AutomationLevel::Flow,
+            "hello",
+            "",
+            false
+        ));
+        assert!(!should_continue_text_only_turn(
+            crate::settings::AutomationLevel::Ask,
+            "fix the release flow",
+            "",
             true
         ));
     }

--- a/core/crates/omegon/src/loop.rs
+++ b/core/crates/omegon/src/loop.rs
@@ -3183,6 +3183,32 @@ fn enrich_plan_list_tool_results(
     }
 }
 
+fn normalize_tool_result_content(
+    tool_name: &str,
+    result: &mut omegon_traits::ToolResult,
+    is_error: bool,
+) {
+    let has_substantive_content = result.content.iter().any(|block| match block {
+        ContentBlock::Text { text } => !text.trim().is_empty(),
+        ContentBlock::Image { .. } => true,
+    });
+    if has_substantive_content {
+        return;
+    }
+
+    let details_are_empty = result.details.is_null()
+        || matches!(&result.details, Value::Object(map) if map.is_empty())
+        || matches!(&result.details, Value::Array(items) if items.is_empty());
+    let text = if !details_are_empty {
+        serde_json::to_string_pretty(&result.details).unwrap_or_else(|_| result.details.to_string())
+    } else if is_error {
+        format!("Tool `{tool_name}` failed without returning diagnostic content.")
+    } else {
+        format!("Tool `{tool_name}` completed successfully with no output.")
+    };
+    result.content = vec![ContentBlock::Text { text }];
+}
+
 #[allow(clippy::too_many_arguments)]
 async fn dispatch_single_tool(
     bus: &crate::bus::EventBus,
@@ -3195,7 +3221,7 @@ async fn dispatch_single_tool(
     permission_policy: Option<&crate::permissions::LayeredPermissionPolicy>,
     permission_role: Option<styrene_rbac::Role>,
 ) -> ToolResultEntry {
-    let (result, is_error) = execute_tool_invocation(
+    let (mut result, is_error) = execute_tool_invocation(
         bus,
         &call.id,
         &call.name,
@@ -3213,6 +3239,7 @@ async fn dispatch_single_tool(
     )
     .await;
 
+    normalize_tool_result_content(&call.name, &mut result, is_error);
     ToolResultEntry {
         call_id: call.id.clone(),
         tool_name: call.name.clone(),
@@ -7216,6 +7243,47 @@ This is the right first slice."#;
             "",
             true
         ));
+    }
+
+    #[test]
+    fn empty_tool_results_are_normalized_at_dispatch_boundary() {
+        let mut empty = omegon_traits::ToolResult {
+            content: Vec::new(),
+            details: Value::Null,
+        };
+        normalize_tool_result_content("whoami", &mut empty, false);
+        assert_eq!(
+            empty.content[0].as_text(),
+            Some("Tool `whoami` completed successfully with no output.")
+        );
+
+        let mut whitespace = omegon_traits::ToolResult {
+            content: vec![ContentBlock::Text {
+                text: "  \n".into(),
+            }],
+            details: serde_json::json!({"status": "ok"}),
+        };
+        normalize_tool_result_content("status", &mut whitespace, false);
+        assert!(whitespace.content[0].as_text().unwrap().contains("status"));
+
+        let mut failed = omegon_traits::ToolResult {
+            content: Vec::new(),
+            details: Value::Null,
+        };
+        normalize_tool_result_content("broken", &mut failed, true);
+        assert!(failed.content[0].as_text().unwrap().contains("failed"));
+    }
+
+    #[test]
+    fn substantive_tool_results_are_preserved() {
+        let mut result = omegon_traits::ToolResult {
+            content: vec![ContentBlock::Text {
+                text: "identity".into(),
+            }],
+            details: Value::Null,
+        };
+        normalize_tool_result_content("whoami", &mut result, false);
+        assert_eq!(result.content[0].as_text(), Some("identity"));
     }
 
     #[test]

--- a/core/crates/omegon/src/main.rs
+++ b/core/crates/omegon/src/main.rs
@@ -98,6 +98,7 @@ mod usage;
 mod value_context;
 mod workspace;
 
+mod active_worker_channel;
 mod agent_manifest;
 mod armory;
 mod bundle_verify;
@@ -6081,6 +6082,7 @@ fn build_tui_secret_readiness_snapshot(
                     let mut slow_turn_notifications: u32 = 0;
                     let mut notified_blocked_prompt_queue = false;
                     let mut cancellation_deadline: Option<std::pin::Pin<Box<tokio::time::Sleep>>> = None;
+                    let mut active_command_channel = active_worker_channel::ActiveWorkerCommandChannel::new();
 
                     loop {
                         tokio::select! {
@@ -6146,13 +6148,14 @@ fn build_tui_secret_readiness_snapshot(
                                 }
                                 slow_turn_probe.as_mut().reset(tokio::time::Instant::now() + std::time::Duration::from_secs(10));
                             }
-                            maybe_cmd = command_rx.recv() => {
+                            maybe_cmd = active_command_channel.recv(&mut command_rx) => {
                                 let Some(cmd) = maybe_cmd else {
+                                    let first_close = active_command_channel.observe_closed();
+                                    debug_assert!(first_close, "disabled command branch returned closure twice");
                                     quit_after_turn = true;
-                                    if let Ok(guard) = shared_cancel.lock()
-                                        && let Some(ref cancel) = *guard
-                                    {
-                                        cancel.cancel();
+                                    turn_cancel.cancel();
+                                    if cancellation_deadline.is_none() {
+                                        cancellation_deadline = Some(Box::pin(tokio::time::sleep(std::time::Duration::from_secs(2))));
                                     }
                                     continue;
                                 };


### PR DESCRIPTION
## Summary
- prevent a closed active-worker command channel from starving worker completion and cancellation
- recover from empty post-tool assistant replies with bounded retries
- normalize empty successful and failed tool results into explicit provider evidence

## Release intent
Consolidate the validated runtime liveness fixes into `main` for the 0.29.0 nightly line. Stable publication remains a later, separate decision.

## Validation
- `just test-crate omegon` — 4236 passed, 0 failed, 2 ignored; integration suites passed
- focused active-worker starvation regressions — 5 passed
- focused empty-result/post-tool recovery regressions — passed
- installed starvation-fixed runtime smoke: `omegon 0.29.0-dev (008016ca 2026-08-10)`