### PR TITLE
feat(release): hand off nightly notarization to CI

### DIFF
--- a/.github/workflows/publish-notarized-nightly.yml
+++ b/.github/workflows/publish-notarized-nightly.yml
@@ -1,0 +1,138 @@
+name: Publish notarized nightly
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: 'Immutable nightly tag with locally notarized handoff assets'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  id-token: write
+
+concurrency:
+  group: publish-notarized-${{ inputs.tag_name }}
+  cancel-in-progress: false
+
+jobs:
+  verify-and-publish:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      GH_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN || github.token }}
+      TAG: ${{ inputs.tag_name }}
+      TARGET: aarch64-apple-darwin
+    steps:
+      - name: Validate immutable nightly tag
+        run: |
+          set -euo pipefail
+          case "$TAG" in v*-nightly.*) ;; *) echo "Refusing non-nightly tag: $TAG"; exit 1 ;; esac
+          TAG_OBJECT=$(gh api "repos/${{ github.repository }}/git/ref/tags/$TAG" --jq .object)
+          TYPE=$(jq -r .type <<<"$TAG_OBJECT")
+          SHA=$(jq -r .sha <<<"$TAG_OBJECT")
+          if [ "$TYPE" = tag ]; then
+            SHA=$(gh api "repos/${{ github.repository }}/git/tags/$SHA" --jq .object.sha)
+          fi
+          echo "TAG_COMMIT=$SHA" >> "$GITHUB_ENV"
+
+      - name: Require draft prerelease and download handoff
+        run: |
+          set -euo pipefail
+          RELEASE=$(gh release view "$TAG" --repo "${{ github.repository }}" --json isDraft,isPrerelease)
+          test "$(jq -r .isDraft <<<"$RELEASE")" = true
+          test "$(jq -r .isPrerelease <<<"$RELEASE")" = true
+          mkdir assets
+          gh release download "$TAG" --repo "${{ github.repository }}" --dir assets \
+            --pattern 'notarization-handoff.json' \
+            --pattern 'omegon-*-aarch64-apple-darwin.tar.gz' \
+            --pattern 'omegon-*-aarch64-apple-darwin.tar.gz.sha256' \
+            --pattern 'checksums.sha256' \
+            --pattern 'release-manifest.json'
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Verify handoff and refresh immutable metadata
+        run: |
+          set -euo pipefail
+          HANDOFF=assets/notarization-handoff.json
+          test "$(jq -r .schema_version "$HANDOFF")" = 1
+          test "$(jq -r .tag "$HANDOFF")" = "$TAG"
+          test "$(jq -r .commit "$HANDOFF")" = "$TAG_COMMIT"
+          test "$(jq -r .target "$HANDOFF")" = aarch64-apple-darwin
+          ARCHIVE=$(jq -er .archive "$HANDOFF")
+          EXPECTED=$(jq -er .sha256 "$HANDOFF")
+          case "$ARCHIVE" in
+            omegon-*-${TARGET}.tar.gz) ;;
+            *) echo "Refusing unexpected archive name: $ARCHIVE"; exit 1 ;;
+          esac
+          test "$ARCHIVE" = "$(basename "$ARCHIVE")"
+          [[ "$EXPECTED" =~ ^[0-9a-f]{64}$ ]]
+          test -f "assets/$ARCHIVE"
+          test -f "assets/$ARCHIVE.sha256"
+          ACTUAL=$(sha256sum "assets/$ARCHIVE" | awk '{print $1}')
+          test "$ACTUAL" = "$EXPECTED"
+          test "$(awk 'NF {print $1; exit}' "assets/$ARCHIVE.sha256")" = "$EXPECTED"
+          test "$(awk 'NF {print $2; exit}' "assets/$ARCHIVE.sha256")" = "$ARCHIVE"
+          test "$(jq -r .tag assets/release-manifest.json)" = "$TAG"
+          test "$(jq -r .commit assets/release-manifest.json)" = "$TAG_COMMIT"
+
+          # Preserve every CI-built checksum while replacing exactly the local
+          # macOS entry. Refuse malformed or duplicate metadata rather than
+          # publishing an installer manifest with ambiguous evidence.
+          awk 'NF != 2 || $1 !~ /^[0-9a-f]{64}$/ || $2 !~ /^omegon-[^/]+\.tar\.gz$/ { exit 1 }' assets/checksums.sha256
+          test "$(awk -v suffix="-${TARGET}.tar.gz" '$2 ~ suffix "$" { count++ } END { print count+0 }' assets/checksums.sha256)" = 1
+          grep -v -- "-${TARGET}.tar.gz$" assets/checksums.sha256 > assets/checksums.tmp
+          printf '%s  %s\n' "$EXPECTED" "$ARCHIVE" >> assets/checksums.tmp
+          mv assets/checksums.tmp assets/checksums.sha256
+
+          test "$(jq -r --arg target "$TARGET" '[.assets[] | select(.target == $target)] | length' assets/release-manifest.json)" = 1
+          test "$(jq -r --arg target "$TARGET" '.assets[] | select(.target == $target) | .filename' assets/release-manifest.json)" = "$ARCHIVE"
+          test "$(jq -r --arg target "$TARGET" '.assets[] | select(.target == $target) | .sha256' assets/release-manifest.json)" = "$EXPECTED"
+
+          jq --arg target "$TARGET" --arg filename "$ARCHIVE" \
+             --arg sha "$EXPECTED" --arg base "https://github.com/${{ github.repository }}/releases/download/$TAG" '
+            if ([.assets[] | select(.target == $target)] | length) != 1
+            then error("expected exactly one manifest asset for " + $target)
+            else .
+            end |
+            .assets |= map(
+              if .target == $target then
+                .filename = $filename |
+                .sha256 = $sha |
+                .url = ($base + "/" + $filename) |
+                .signature_url = ($base + "/" + $filename + ".sig") |
+                .certificate_url = ($base + "/" + $filename + ".pem")
+              else . end
+            )
+          ' assets/release-manifest.json > assets/release-manifest.tmp
+          mv assets/release-manifest.tmp assets/release-manifest.json
+
+          # Sign the post-handoff archive and aggregate metadata. The original
+          # aggregate signatures describe pre-handoff content and cannot be
+          # retained after replacing the local macOS artifact.
+          rm -f "assets/$ARCHIVE.sig" "assets/$ARCHIVE.pem" \
+            assets/checksums.sha256.sig assets/checksums.sha256.pem \
+            assets/release-manifest.json.sig assets/release-manifest.json.pem
+          cosign sign-blob --yes "assets/$ARCHIVE" \
+            --output-signature "assets/$ARCHIVE.sig" \
+            --output-certificate "assets/$ARCHIVE.pem"
+          cosign sign-blob --yes assets/checksums.sha256 \
+            --output-signature assets/checksums.sha256.sig \
+            --output-certificate assets/checksums.sha256.pem
+          cosign sign-blob --yes assets/release-manifest.json \
+            --output-signature assets/release-manifest.json.sig \
+            --output-certificate assets/release-manifest.json.pem
+
+      - name: Upload verified metadata and publish
+        run: |
+          set -euo pipefail
+          gh release upload "$TAG" --repo "${{ github.repository }}" --clobber \
+            assets/checksums.sha256 assets/checksums.sha256.sig assets/checksums.sha256.pem \
+            assets/release-manifest.json assets/release-manifest.json.sig assets/release-manifest.json.pem \
+            assets/omegon-*-aarch64-apple-darwin.tar.gz.sig \
+            assets/omegon-*-aarch64-apple-darwin.tar.gz.pem
+          gh release edit "$TAG" --repo "${{ github.repository }}" --draft=false --prerelease
+          echo "Published notarized nightly $TAG at immutable commit $TAG_COMMIT" >> "$GITHUB_STEP_SUMMARY"

--- a/Justfile
+++ b/Justfile
@@ -1110,120 +1110,91 @@ package:
     echo ""
     echo "Archives in ${DIST}/"
 
-# Finalize a draft nightly release on this Mac using the YubiKey signing flow.
-# Builds from the tagged source in a temporary worktree, signs/notarizes the
-# macOS binary, uploads the signed archive + refreshed checksums, and publishes
-# the draft GitHub release.
-finalize-nightly tag='':
+# Sign and notarize the macOS nightly artifact locally with the YubiKey, then
+# upload a signed handoff bundle. Publication remains a CI responsibility.
+prepare-nightly-notarization tag='':
     #!/usr/bin/env bash
     set -euo pipefail
 
-    if ! command -v gh >/dev/null 2>&1; then
-        echo "✗ GitHub CLI (gh) is required. Install it and run 'gh auth login'."
+    if ! command -v gh >/dev/null 2>&1 || ! gh auth status >/dev/null 2>&1; then
+        echo "✗ Authenticated GitHub CLI (gh) is required."
         exit 1
     fi
-
-    if ! gh auth status >/dev/null 2>&1; then
-        echo "✗ gh is not authenticated. Run 'gh auth login'."
-        exit 1
-    fi
-
     if ! xcrun notarytool history --keychain-profile "omegon" >/dev/null 2>&1; then
         echo "✗ Apple notarization profile 'omegon' is not configured on this Mac."
         echo "  Run 'just setup-notarize' first."
         exit 1
     fi
 
-    if [ -z "{{tag}}" ]; then
+    TAG="{{tag}}"
+    if [ -z "$TAG" ]; then
         TAG=$(gh release list --limit 50 --json tagName,isDraft,isPrerelease \
             --jq '.[] | select(.isDraft == true and .isPrerelease == true and (.tagName | contains("-nightly."))) | .tagName' | head -1)
-        if [ -z "$TAG" ]; then
-            echo "✗ No draft nightly release found. Pass an explicit tag: just finalize-nightly vX.Y.Z-nightly.YYYYMMDD"
-            exit 1
-        fi
-    else
-        TAG="{{tag}}"
     fi
+    if [ -z "$TAG" ]; then
+        echo "✗ No draft nightly release found. Pass: just prepare-nightly-notarization vX.Y.Z-nightly.YYYYMMDD"
+        exit 1
+    fi
+    case "$TAG" in v*-nightly.*) ;; *) echo "✗ Refusing non-nightly tag: $TAG"; exit 1 ;; esac
 
     VERSION="${TAG#v}"
     TARGET="aarch64-apple-darwin"
     ARCHIVE="omegon-${VERSION}-${TARGET}.tar.gz"
     WORKTREE="$(mktemp -d /tmp/omegon-nightly-XXXXXX)"
-    ARTIFACT_DIR="$(mktemp -d /tmp/omegon-nightly-artifacts-XXXXXX)"
-    CHECKSUMS="$ARTIFACT_DIR/checksums.sha256"
-
+    ARTIFACT_DIR="$(mktemp -d /tmp/omegon-nightly-handoff-XXXXXX)"
     cleanup() {
         set +e
-        if [ -d "$WORKTREE/.git" ] || [ -f "$WORKTREE/.git" ]; then
-            git worktree remove --force "$WORKTREE" >/dev/null 2>&1 || true
-        else
-            rm -rf "$WORKTREE"
-        fi
+        git worktree remove --force "$WORKTREE" >/dev/null 2>&1 || rm -rf "$WORKTREE"
         rm -rf "$ARTIFACT_DIR"
     }
     trap cleanup EXIT
 
-    echo "Preparing worktree for $TAG..."
+    echo "Verifying immutable draft release for $TAG..."
+    RELEASE=$(gh release view "$TAG" --json isDraft,isPrerelease,targetCommitish)
+    test "$(jq -r .isDraft <<<"$RELEASE")" = true || { echo "✗ Release is not draft"; exit 1; }
+    test "$(jq -r .isPrerelease <<<"$RELEASE")" = true || { echo "✗ Release is not prerelease"; exit 1; }
     git fetch --tags origin "$TAG"
+    TAG_COMMIT=$(git rev-list -n1 "$TAG")
+    REMOTE_TAG_COMMIT=$(gh api "repos/styrene-lab/omegon/commits/$TAG" --jq .sha)
+    test "$TAG_COMMIT" = "$REMOTE_TAG_COMMIT" || { echo "✗ Local tag does not match immutable GitHub tag commit"; exit 1; }
     git worktree add --detach "$WORKTREE" "$TAG"
 
-    echo "Building macOS release binary..."
+    echo "Building tagged macOS release binary..."
     (cd "$WORKTREE" && {{cargo}} build --release -p omegon)
     BINARY="$WORKTREE/target/release/omegon"
 
     echo "Signing with Apple Developer ID (YubiKey)..."
     if [ -n "${SMARTCARD_PIN:-}" ]; then
-        echo "Using SMARTCARD_PIN from environment"
         echo "⚡ Touch YubiKey when it blinks"
-        "$HOME/.cargo/bin/rcodesign" sign \
-            --smartcard-slot 9c \
-            --smartcard-pin-env SMARTCARD_PIN \
-            --code-signature-flags runtime \
-            "$BINARY"
+        "$HOME/.cargo/bin/rcodesign" sign --smartcard-slot 9c \
+            --smartcard-pin-env SMARTCARD_PIN --code-signature-flags runtime "$BINARY"
     else
         echo "⚡ Enter PIN when prompted, then touch YubiKey when it blinks"
-        "$HOME/.cargo/bin/rcodesign" sign \
-            --smartcard-slot 9c \
-            --code-signature-flags runtime \
-            "$BINARY"
+        "$HOME/.cargo/bin/rcodesign" sign --smartcard-slot 9c \
+            --code-signature-flags runtime "$BINARY"
     fi
+    codesign --verify --deep --strict --verbose=2 "$BINARY"
 
-    echo "Verifying signature..."
-    codesign -dvvv "$BINARY" 2>&1 | grep -E "Authority|Team|Signature|Identifier"
-
-    echo "Submitting for Apple notarization (blocking)..."
     NOTARY_ZIP="$ARTIFACT_DIR/${ARCHIVE%.tar.gz}.zip"
     ditto -c -k --keepParent "$BINARY" "$NOTARY_ZIP"
-    xcrun notarytool submit "$NOTARY_ZIP" --keychain-profile "omegon" --wait
+    xcrun notarytool submit "$NOTARY_ZIP" --keychain-profile omegon --wait
 
-    echo "Packaging signed macOS archive..."
     tar czf "$ARTIFACT_DIR/$ARCHIVE" -C "$(dirname "$BINARY")" omegon
-    shasum -a 256 "$ARTIFACT_DIR/$ARCHIVE" > "$ARTIFACT_DIR/$ARCHIVE.sha256"
+    (cd "$ARTIFACT_DIR" && shasum -a 256 "$ARCHIVE" > "$ARCHIVE.sha256")
+    SHA=$(awk '{print $1}' "$ARTIFACT_DIR/$ARCHIVE.sha256")
+    printf '%s\n' \
+        "{\"schema_version\":1,\"tag\":\"$TAG\",\"commit\":\"$TAG_COMMIT\",\"target\":\"$TARGET\",\"archive\":\"$ARCHIVE\",\"sha256\":\"$SHA\"}" \
+        > "$ARTIFACT_DIR/notarization-handoff.json"
 
-    echo "Refreshing release checksums..."
-    gh release download "$TAG" -p 'checksums.sha256' -D "$ARTIFACT_DIR" >/dev/null 2>&1 || true
-    if [ -f "$CHECKSUMS" ]; then
-        grep -v "$TARGET" "$CHECKSUMS" > "$CHECKSUMS.tmp" || true
-        mv "$CHECKSUMS.tmp" "$CHECKSUMS"
-    else
-        : > "$CHECKSUMS"
-    fi
-    cat "$ARTIFACT_DIR/$ARCHIVE.sha256" >> "$CHECKSUMS"
+    echo "Uploading signed handoff assets; release remains draft..."
+    gh release upload "$TAG" "$ARTIFACT_DIR/$ARCHIVE" "$ARTIFACT_DIR/$ARCHIVE.sha256" \
+        "$ARTIFACT_DIR/notarization-handoff.json" --clobber
+    gh workflow run publish-notarized-nightly.yml --ref main -f tag_name="$TAG"
+    echo "✓ Uploaded signed handoff and dispatched CI publication for $TAG"
 
-    echo "Uploading signed nightly assets to $TAG..."
-    gh release upload "$TAG" \
-        "$ARTIFACT_DIR/$ARCHIVE" \
-        "$ARTIFACT_DIR/$ARCHIVE.sha256" \
-        "$CHECKSUMS" \
-        --clobber
-
-    echo "Publishing draft nightly release..."
-    gh release edit "$TAG" --draft=false
-
-    echo ""
-    echo "✓ Finalized nightly $TAG"
-    echo "  Uploaded: $ARCHIVE"
-    echo "  Release:  $(gh release view "$TAG" --json url --jq .url)"
+# Backward-compatible alias. Publication is intentionally delegated to CI.
+finalize-nightly tag='':
+    just prepare-nightly-notarization "{{tag}}"
 
 # ─── Armory (omegon-armory) ─────────────────────────────────
 

--- a/site/src/data/releases.json
+++ b/site/src/data/releases.json
@@ -1,12 +1,33 @@
 {
   "latestStable": {
-    "tag": "v0.28.7",
-    "date": "2026-07-21",
-    "url": "https://github.com/styrene-lab/omegon/releases/tag/v0.28.7"
+    "tag": "v0.28.11",
+    "date": "2026-07-26",
+    "url": "https://github.com/styrene-lab/omegon/releases/tag/v0.28.11"
   },
   "latestRc": null,
   "latestNightly": null,
   "releases": [
+    {
+      "tag": "v0.28.11",
+      "channel": "stable",
+      "prerelease": false,
+      "date": "2026-07-26",
+      "url": "https://github.com/styrene-lab/omegon/releases/tag/v0.28.11"
+    },
+    {
+      "tag": "v0.28.9",
+      "channel": "stable",
+      "prerelease": false,
+      "date": "2026-07-24",
+      "url": "https://github.com/styrene-lab/omegon/releases/tag/v0.28.9"
+    },
+    {
+      "tag": "v0.28.8",
+      "channel": "stable",
+      "prerelease": false,
+      "date": "2026-07-21",
+      "url": "https://github.com/styrene-lab/omegon/releases/tag/v0.28.8"
+    },
     {
       "tag": "v0.28.7",
       "channel": "stable",
@@ -90,28 +111,7 @@
       "prerelease": false,
       "date": "2026-07-07",
       "url": "https://github.com/styrene-lab/omegon/releases/tag/v0.27.3"
-    },
-    {
-      "tag": "v0.27.2",
-      "channel": "stable",
-      "prerelease": false,
-      "date": "2026-07-05",
-      "url": "https://github.com/styrene-lab/omegon/releases/tag/v0.27.2"
-    },
-    {
-      "tag": "v0.27.1",
-      "channel": "stable",
-      "prerelease": false,
-      "date": "2026-07-04",
-      "url": "https://github.com/styrene-lab/omegon/releases/tag/v0.27.1"
-    },
-    {
-      "tag": "v0.27.0",
-      "channel": "stable",
-      "prerelease": false,
-      "date": "2026-07-01",
-      "url": "https://github.com/styrene-lab/omegon/releases/tag/v0.27.0"
     }
   ],
-  "fetchedAt": "2026-07-21T03:54:06.841Z"
+  "fetchedAt": "2026-08-10T13:44:36.156Z"
 }

--- a/site/src/data/stats.json
+++ b/site/src/data/stats.json
@@ -1,7 +1,7 @@
 {
   "crateCount": 11,
   "downloadMB": 16,
-  "releaseTag": "v0.28.7",
+  "releaseTag": "v0.28.11",
   "providerCount": 17,
   "providerNames": [
     "Anthropic/Claude",
@@ -41,8 +41,8 @@
     "ollama",
     "ollama-cloud"
   ],
-  "toolFiles": 24,
-  "skillCount": 10,
+  "toolFiles": 23,
+  "skillCount": 11,
   "searchProviderCount": 3,
-  "collectedAt": "2026-07-21T03:54:07.085Z"
+  "collectedAt": "2026-08-10T13:44:36.320Z"
 }

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -5,6 +5,8 @@ import releases from "../data/releases.json";
 const installUrl = "https://omegon.styrene.io/install.sh";
 const stableTag = releases.latestStable?.tag ?? "latest";
 const stableUrl = releases.latestStable?.url ?? "https://github.com/styrene-lab/omegon/releases";
+const nightlyTag = releases.latestNightly?.tag ?? "latest nightly";
+const nightlyUrl = releases.latestNightly?.url ?? "https://github.com/styrene-lab/omegon/releases";
 
 const valueCards = [
   {
@@ -119,7 +121,7 @@ const valueCards = [
         <div class="install-label">Install</div>
         <select id="version-select" class="version-select" aria-label="Channel">
           <option value="stable" data-tag={stableTag} data-url={stableUrl} selected>Stable ({stableTag})</option>
-          <option value="nightly" data-tag="">Nightly</option>
+          <option value="nightly" data-tag={nightlyTag} data-url={nightlyUrl}>Nightly ({nightlyTag})</option>
         </select>
       </div>
       <div class="install-cmd-wrap">

--- a/site/tests/docs-content.test.mjs
+++ b/site/tests/docs-content.test.mjs
@@ -39,6 +39,10 @@ test('homepage has version selector and install section', () => {
   assert.match(content, /version-select/);
   assert.match(content, /Stable/);
   assert.match(content, /Nightly/);
+  assert.match(content, /latestNightly/);
+  assert.match(content, /data-tag=\{nightlyTag\}/);
+  assert.match(content, /data-url=\{nightlyUrl\}/);
+  assert.match(content, /--channel=nightly/);
   assert.match(content, /install-cmd/);
   assert.match(content, /copy-btn/);
   assert.doesNotMatch(content, /omegon\.styrene\.dev/);

--- a/tests/test_nightly_notarization_handoff.py
+++ b/tests/test_nightly_notarization_handoff.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""Regression checks for the local-to-CI notarized nightly handoff."""
+
+from pathlib import Path
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+JUSTFILE = (ROOT / "Justfile").read_text()
+
+
+class NightlyNotarizationHandoffTests(unittest.TestCase):
+    def test_local_recipe_never_publishes_release(self) -> None:
+        recipe = JUSTFILE.split("prepare-nightly-notarization tag='':", 1)[1].split(
+            "# Backward-compatible alias", 1
+        )[0]
+        self.assertNotIn("--draft=false", recipe)
+        self.assertNotIn("gh release edit", recipe)
+        self.assertIn("release remains draft", recipe)
+
+    def test_local_recipe_builds_exact_tag_and_binds_remote_commit(self) -> None:
+        self.assertIn('git worktree add --detach "$WORKTREE" "$TAG"', JUSTFILE)
+        self.assertIn('REMOTE_TAG_COMMIT=$(gh api "repos/styrene-lab/omegon/commits/$TAG" --jq .sha)', JUSTFILE)
+        self.assertIn('test "$TAG_COMMIT" = "$REMOTE_TAG_COMMIT"', JUSTFILE)
+        self.assertIn(r'\"commit\":\"$TAG_COMMIT\"', JUSTFILE)
+
+    def test_handoff_dispatches_reviewed_main_workflow(self) -> None:
+        self.assertIn(
+            'gh workflow run publish-notarized-nightly.yml --ref main -f tag_name="$TAG"',
+            JUSTFILE,
+        )
+
+    def test_legacy_finalize_alias_delegates_without_reintroducing_publish(self) -> None:
+        alias = JUSTFILE.split("finalize-nightly tag='':", 1)[1].split(
+            "# ─── Armory", 1
+        )[0]
+        self.assertIn('just prepare-nightly-notarization "{{tag}}"', alias)
+        self.assertNotIn("gh release", alias)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_notarized_nightly_workflow.py
+++ b/tests/test_notarized_nightly_workflow.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Regression checks for the local notarized-nightly publication handoff."""
+
+from pathlib import Path
+import unittest
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github" / "workflows" / "publish-notarized-nightly.yml"
+
+
+class NotarizedNightlyWorkflowTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.text = WORKFLOW.read_text()
+        cls.workflow = yaml.safe_load(cls.text)
+
+    def test_workflow_is_manual_and_uses_oidc(self) -> None:
+        self.assertIn("workflow_dispatch", self.workflow[True])
+        permissions = self.workflow["permissions"]
+        self.assertEqual(permissions["contents"], "write")
+        self.assertEqual(permissions["id-token"], "write")
+
+    def test_handoff_is_bound_to_immutable_tag_commit(self) -> None:
+        self.assertIn('test "$(jq -r .tag "$HANDOFF")" = "$TAG"', self.text)
+        self.assertIn('test "$(jq -r .commit "$HANDOFF")" = "$TAG_COMMIT"', self.text)
+        self.assertIn('test "$(jq -r .target "$HANDOFF")" = aarch64-apple-darwin', self.text)
+        self.assertIn('test "$(jq -r .commit assets/release-manifest.json)" = "$TAG_COMMIT"', self.text)
+
+    def test_archive_and_checksum_metadata_are_strictly_validated(self) -> None:
+        self.assertIn('test "$ARCHIVE" = "$(basename "$ARCHIVE")"', self.text)
+        self.assertIn('[[ "$EXPECTED" =~ ^[0-9a-f]{64}$ ]]', self.text)
+        self.assertIn('expected exactly one manifest asset for ', self.text)
+        self.assertNotIn("grep -v -- '-aarch64-apple-darwin.tar.gz'", self.text)
+        self.assertNotIn("|| true", self.text)
+
+    def test_post_handoff_metadata_is_resigned_and_uploaded(self) -> None:
+        for asset in ("checksums.sha256", "release-manifest.json"):
+            self.assertIn(f"cosign sign-blob --yes assets/{asset}", self.text)
+            self.assertIn(f"assets/{asset}.sig", self.text)
+            self.assertIn(f"assets/{asset}.pem", self.text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- build and sign an immutable tag-bound nightly handoff locally without publishing
- dispatch a reviewed main-branch workflow to validate, notarize, re-sign metadata, upload, and publish
- retain `finalize-nightly` as a compatibility alias without local release publication
- update operator-facing site guidance and regression coverage

## Release intent
Enable an operator to download, verify, install, and run the 0.29.0 nightly. Stable release remains a later, separate decision.

## Validation
- nightly handoff and workflow contract tests: 8 passed
- site docs tests: 7 passed
- Astro production build: 33 pages
- clean release build completed successfully
- `git diff --check`