### PR TITLE
feat(web): route runtime inventory controls

### DIFF
--- a/core/crates/omegon/src/web/mod.rs
+++ b/core/crates/omegon/src/web/mod.rs
@@ -1384,6 +1384,48 @@ pub(crate) async fn process_next_daemon_event(state: &WebState) -> anyhow::Resul
             request: crate::operator_commands::InterfaceControlRequest::ModelList,
             respond_to: None,
         }),
+        "runtime-inventory-status" => Some(WebCommand::ExecuteControl {
+            request: crate::operator_commands::InterfaceControlRequest::RuntimeInventoryStatus,
+            respond_to: None,
+        }),
+        "profile-view" => Some(WebCommand::ExecuteControl {
+            request: crate::operator_commands::InterfaceControlRequest::ProfileView,
+            respond_to: None,
+        }),
+        "workspace-status-view" => Some(WebCommand::ExecuteControl {
+            request: crate::operator_commands::InterfaceControlRequest::WorkspaceStatusView,
+            respond_to: None,
+        }),
+        "workspace-list-view" => Some(WebCommand::ExecuteControl {
+            request: crate::operator_commands::InterfaceControlRequest::WorkspaceListView,
+            respond_to: None,
+        }),
+        "skills-view" => Some(WebCommand::ExecuteControl {
+            request: crate::operator_commands::InterfaceControlRequest::SkillsView,
+            respond_to: None,
+        }),
+        "extension-view" => Some(WebCommand::ExecuteControl {
+            request: crate::operator_commands::InterfaceControlRequest::ExtensionView,
+            respond_to: None,
+        }),
+        "armory-browse" => Some(WebCommand::ExecuteControl {
+            request: crate::operator_commands::InterfaceControlRequest::ArmoryBrowse {
+                query: None,
+            },
+            respond_to: None,
+        }),
+        "catalog-view" => Some(WebCommand::ExecuteControl {
+            request: crate::operator_commands::InterfaceControlRequest::CatalogView,
+            respond_to: None,
+        }),
+        "plugin-view" => Some(WebCommand::ExecuteControl {
+            request: crate::operator_commands::InterfaceControlRequest::PluginView,
+            respond_to: None,
+        }),
+        "permissions-view" => Some(WebCommand::ExecuteControl {
+            request: crate::operator_commands::InterfaceControlRequest::PermissionsView,
+            respond_to: None,
+        }),
         "set-model" => event
             .payload
             .get("model")

--- a/core/crates/omegon/src/web/ws.rs
+++ b/core/crates/omegon/src/web/ws.rs
@@ -206,6 +206,68 @@ async fn handle_client_command(
             };
             let _ = snapshot_tx.send(reply).await;
         }
+        "runtime-inventory-status"
+        | "profile-view"
+        | "workspace-status-view"
+        | "workspace-list-view"
+        | "skills-view"
+        | "extension-view"
+        | "armory-browse"
+        | "catalog-view"
+        | "plugin-view"
+        | "permissions-view" => {
+            let request = match cmd_type {
+                "runtime-inventory-status" => {
+                    crate::operator_commands::InterfaceControlRequest::RuntimeInventoryStatus
+                }
+                "profile-view" => crate::operator_commands::InterfaceControlRequest::ProfileView,
+                "workspace-status-view" => {
+                    crate::operator_commands::InterfaceControlRequest::WorkspaceStatusView
+                }
+                "workspace-list-view" => {
+                    crate::operator_commands::InterfaceControlRequest::WorkspaceListView
+                }
+                "skills-view" => crate::operator_commands::InterfaceControlRequest::SkillsView,
+                "extension-view" => {
+                    crate::operator_commands::InterfaceControlRequest::ExtensionView
+                }
+                "armory-browse" => {
+                    crate::operator_commands::InterfaceControlRequest::ArmoryBrowse { query: None }
+                }
+                "catalog-view" => crate::operator_commands::InterfaceControlRequest::CatalogView,
+                "plugin-view" => crate::operator_commands::InterfaceControlRequest::PluginView,
+                "permissions-view" => {
+                    crate::operator_commands::InterfaceControlRequest::PermissionsView
+                }
+                _ => unreachable!(),
+            };
+            let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
+            let accepted = command_tx
+                .send(WebCommand::ExecuteControl {
+                    request,
+                    respond_to: Some(reply_tx),
+                })
+                .await
+                .is_ok();
+            let response = if accepted {
+                reply_rx
+                    .await
+                    .unwrap_or_else(|_| omegon_traits::ControlOutputResponse {
+                        accepted: false,
+                        output: Some(format!(
+                            "{cmd_type} executor dropped response before completion"
+                        )),
+                    })
+            } else {
+                omegon_traits::ControlOutputResponse {
+                    accepted: false,
+                    output: Some(format!("failed to enqueue {cmd_type}")),
+                }
+            };
+            let _ = snapshot_tx
+                .send(control_result_message(cmd_type, response))
+                .await;
+        }
         "user_prompt" => {
             let classified = crate::control_actions::classify_web_method("user_prompt");
             if !crate::control_actions::is_role_sufficient(caller_role, classified.role) {


### PR DESCRIPTION
## Summary

Complete the Web transport wiring for the read-only runtime inventory requests introduced by #182.

- map daemon-event method slugs to canonical `InterfaceControlRequest` variants
- execute direct WebSocket inventory commands through `WebCommand::ExecuteControl`
- return standard `control_result` envelopes
- report enqueue and dropped-runtime failures explicitly

Methods covered:

- `runtime-inventory-status`
- `profile-view`
- `workspace-status-view`
- `workspace-list-view`
- `skills-view`
- `extension-view`
- `armory-browse`
- `catalog-view`
- `plugin-view`
- `permissions-view`

## Release targeting

This branch is rebased directly onto the current `release/0.29` head. The diff contains only the two transport commits needed to make the #182 inventory contract executable over the Web control plane used by Auspex.

## Validation

- `cargo test -p omegon web::tests` — 22 passed
- `cargo test -p omegon web::ws::tests` — 25 passed
- `cargo clippy -p omegon --bins -- -D warnings` — passed
- `git diff --check origin/release/0.29...HEAD` — passed

## Headless build note

`cargo check -p omegon --no-default-features` currently fails on the existing `release/0.29` head in unrelated interactive/TUI cfg boundaries (`run_interactive_command`, `crossterm`, and related symbols). This PR does not touch those boundaries; its default-feature build and focused tests are clean.