### PR TITLE
fix(release): dispatch nightlies at immutable cutoff

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  actions: write
 
 env:
   CARGO_TERM_COLOR: always
@@ -74,3 +75,29 @@ jobs:
           git commit -m "chore(release): ${VERSION}"
           git tag "$TAG"
           git push origin "refs/tags/${TAG}"
+
+      - name: Dispatch standard release workflow
+        if: steps.exists.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          TAG='${{ steps.nightly.outputs.tag }}'
+          gh workflow run release.yml --ref main -f tag_name="$TAG"
+
+      - name: Summarize nightly cutoff
+        if: always()
+        run: |
+          {
+            echo "## Nightly cutoff"
+            echo ""
+            echo "- Scheduled cutoff: 07:17 UTC"
+            echo "- Main cutoff commit: \`${GITHUB_SHA}\`"
+            echo "- Candidate tag: \`${{ steps.nightly.outputs.tag }}\`"
+            if [ '${{ steps.exists.outputs.exists }}' = 'true' ]; then
+              echo "- Result: immutable tag already exists; no replacement candidate was created"
+            else
+              echo "- Result: immutable tag pushed and standard release workflow dispatched"
+            fi
+            echo "- Quality gate: normal required PR checks and reviews; no nightly-specific hold"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -207,6 +207,16 @@ Ordinary dependency changes may update dependency entries in `Cargo.toml` and `C
 
 Stable releases are cut from `release/X.Y` branches. Release branches own stable tags for that line; trunk owns normal development and nightly/dev builds.
 
+### Nightly cutoff and merge policy
+
+Omegon automatically cuts one nightly from `main` every day at **07:17 UTC**. The immutable cutoff is the `main` commit checked out when the scheduled workflow starts. A pull request is included when its merge commit is reachable from that checkout; a pull request merged after the cutoff enters the following nightly.
+
+Required branch-protection checks and reviews are the complete pre-cut quality gate. There is no nightly-specific merge freeze, hold label, observation window, or manual release approval. Do not rush or bypass a required PR gate to catch a nightly cutoff, and do not move an existing nightly tag to include a late merge.
+
+Nightlies are integration builds and may contain functional bugs. A nightly is considered mechanically broken only when the standard release pipeline cannot build, sign, notarize, package, describe, publish, install, or launch its artifacts. Failed candidates are fixed forward on `main`; they are not reconstructed by mutating an immutable tag. Stable releases add deliberate release judgment and stronger validation beyond the nightly contract.
+
+The scheduled workflow generates release metadata in a detached release commit derived from the cutoff commit, pushes an immutable nightly tag, and explicitly dispatches the standard release workflow. It does not commit generated version state back to `main`.
+
 Use the existing release helpers rather than hand-rolling branch/version mechanics:
 
 ```bash
@@ -418,7 +428,7 @@ Omegon uses a **release candidate** flow. All releases go through RC builds befo
 |---|---|---|---|
 | **Stable** | When ready | `X.Y.Z` | `0.19.5` |
 | **RC** | Per-feature batch | `X.Y.Z-rc.N` | `0.19.6-rc.2` |
-| **Nightly** | Daily (planned) | `X.Y.Z-nightly.YYYYMMDD` | `0.19.6-nightly.20260510` |
+| **Nightly** | Daily at 07:17 UTC | `X.Y.Z-nightly.YYYYMMDD` | `0.19.6-nightly.20260510` |
 
 ### Commands
 

--- a/tests/test_nightly_cutoff_workflow.py
+++ b/tests/test_nightly_cutoff_workflow.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""Regression checks for the nightly cutoff and standard-release dispatch."""
+
+from pathlib import Path
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = (ROOT / ".github" / "workflows" / "nightly.yml").read_text()
+CONTRIBUTING = (ROOT / "CONTRIBUTING.md").read_text()
+
+
+class NightlyCutoffWorkflowTests(unittest.TestCase):
+    def test_schedule_uses_immutable_0717_utc_cutoff(self) -> None:
+        self.assertIn("cron: '17 7 * * *'", WORKFLOW)
+        self.assertIn("fetch-depth: 0", WORKFLOW)
+        self.assertNotIn("git push origin main", WORKFLOW)
+
+    def test_new_tag_explicitly_dispatches_standard_release(self) -> None:
+        self.assertIn("actions: write", WORKFLOW)
+        self.assertIn("gh workflow run release.yml --ref main -f tag_name=\"$TAG\"", WORKFLOW)
+        self.assertIn("if: steps.exists.outputs.exists == 'false'", WORKFLOW)
+
+    def test_existing_tag_is_never_replaced(self) -> None:
+        self.assertIn("git ls-remote --tags origin", WORKFLOW)
+        self.assertNotIn("git tag -f", WORKFLOW)
+        self.assertNotIn("git push --force", WORKFLOW)
+
+    def test_governance_documents_pr_gate_only_cutoff(self) -> None:
+        self.assertIn("every day at **07:17 UTC**", CONTRIBUTING)
+        self.assertIn("Required branch-protection checks and reviews are the complete pre-cut quality gate", CONTRIBUTING)
+        self.assertIn("explicitly dispatches the standard release workflow", CONTRIBUTING)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- define the daily nightly cutoff as 07:17 UTC with normal required PR checks as the complete gate
- preserve detached-checkout stamping and immutable nightly tags
- explicitly dispatch the standard release workflow after pushing a new nightly tag
- summarize cutoff provenance and add regression coverage

## Validation
- `python3 tests/test_nightly_cutoff_workflow.py`
- `python3 tests/test_nightly_standard_release.py`
- `git diff --check`