### PR TITLE
docs(site): advertise 0.29 nightly downloads

### DIFF
--- a/site/src/data/releases.json
+++ b/site/src/data/releases.json
@@ -5,8 +5,19 @@
     "url": "https://github.com/styrene-lab/omegon/releases/tag/v0.28.11"
   },
   "latestRc": null,
-  "latestNightly": null,
+  "latestNightly": {
+    "tag": "v0.29.0-nightly.20260811.2",
+    "date": "2026-08-11",
+    "url": "https://github.com/styrene-lab/omegon/releases/tag/v0.29.0-nightly.20260811.2"
+  },
   "releases": [
+    {
+      "tag": "v0.29.0-nightly.20260811.2",
+      "channel": "nightly",
+      "prerelease": true,
+      "date": "2026-08-11",
+      "url": "https://github.com/styrene-lab/omegon/releases/tag/v0.29.0-nightly.20260811.2"
+    },
     {
       "tag": "v0.28.11",
       "channel": "stable",
@@ -104,14 +115,7 @@
       "prerelease": false,
       "date": "2026-07-08",
       "url": "https://github.com/styrene-lab/omegon/releases/tag/v0.27.4"
-    },
-    {
-      "tag": "v0.27.3",
-      "channel": "stable",
-      "prerelease": false,
-      "date": "2026-07-07",
-      "url": "https://github.com/styrene-lab/omegon/releases/tag/v0.27.3"
     }
   ],
-  "fetchedAt": "2026-08-10T13:44:36.156Z"
+  "fetchedAt": "2026-08-11T01:35:47.352Z"
 }

--- a/site/src/pages/docs/install.astro
+++ b/site/src/pages/docs/install.astro
@@ -13,6 +13,22 @@ import { snippet } from "../../lib/snippets";
     verifies the SHA-256 checksum, and installs to <code>/usr/local/bin</code> by default.
   </p>
 
+  <h2>0.29 Nightly Preview</h2>
+  <p>
+    The current 0.29 preview is
+    <a href="https://github.com/styrene-lab/omegon/releases/tag/v0.29.0-nightly.20260811.2"><code>v0.29.0-nightly.20260811.2</code></a>.
+    It is a prerelease build from <code>main</code>; use stable 0.28 for production workflows that require a stable channel.
+  </p>
+  <pre><code># Install this exact assessed 0.29 nightly
+curl -fsSL https://omegon.styrene.io/install.sh | sh -s -- --version 0.29.0-nightly.20260811.2
+
+# Or track the newest published nightly
+{snippet("install.install_nightly")}</code></pre>
+  <p>
+    Direct archives are available on the release page for macOS arm64/x86_64 and Linux
+    x86_64/aarch64, with SHA-256 checksums and Sigstore signatures.
+  </p>
+
   <h3>Options</h3>
   <pre><code># Install to a custom directory
 {snippet("install.install_custom_dir")}

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -7,6 +7,7 @@ const stableTag = releases.latestStable?.tag ?? "latest";
 const stableUrl = releases.latestStable?.url ?? "https://github.com/styrene-lab/omegon/releases";
 const nightlyTag = releases.latestNightly?.tag ?? "latest nightly";
 const nightlyUrl = releases.latestNightly?.url ?? "https://github.com/styrene-lab/omegon/releases";
+const nightlyVersion = nightlyTag.startsWith("v") ? nightlyTag.slice(1) : nightlyTag;
 
 const valueCards = [
   {
@@ -141,6 +142,13 @@ const valueCards = [
         <span class="install-then">then run <code>om</code></span>
         <a href="/docs/install">all install options</a>
       </div>
+      {releases.latestNightly && (
+        <p class="nightly-available">
+          Want the 0.29 preview? Install <a href={nightlyUrl}>{nightlyTag}</a> with
+          <code>curl -fsSL {installUrl} | sh -s -- --version {nightlyVersion}</code>.
+          Nightlies are prerelease builds from <code>main</code>.
+        </p>
+      )}
     </section>
 
     <section class="cards">

--- a/site/tests/docs-content.test.mjs
+++ b/site/tests/docs-content.test.mjs
@@ -27,6 +27,10 @@ test('install docs use canonical snippets for all channels', () => {
   assert.match(content, /snippet\("install\.quick_install"\)/);
   assert.match(content, /snippet\("install\.install_nightly"\)/);
   assert.match(content, /snippet\("install\.install_version"\)/);
+  assert.match(content, /0\.29 Nightly Preview/);
+  assert.match(content, /v0\.29\.0-nightly\.20260811\.2/);
+  assert.match(content, /--version 0\.29\.0-nightly\.20260811\.2/);
+  assert.match(content, /releases\/tag\/v0\.29\.0-nightly\.20260811\.2/);
   assert.doesNotMatch(content, /omegon\.styrene\.dev/);
   // Auth commands use correct form
   assert.match(content, /snippet\("auth\.login_anthropic"\)/);
@@ -43,6 +47,8 @@ test('homepage has version selector and install section', () => {
   assert.match(content, /data-tag=\{nightlyTag\}/);
   assert.match(content, /data-url=\{nightlyUrl\}/);
   assert.match(content, /--channel=nightly/);
+  assert.match(content, /Want the 0\.29 preview/);
+  assert.match(content, /--version \{nightlyVersion\}/);
   assert.match(content, /install-cmd/);
   assert.match(content, /copy-btn/);
   assert.doesNotMatch(content, /omegon\.styrene\.dev/);


### PR DESCRIPTION
## Summary
- refresh checked-in release data with v0.29.0-nightly.20260811.2
- add an explicit 0.29 nightly install section and artifact matrix
- advertise the published 0.29 candidate from the homepage Nightly selector
- guard the nightly URL and prerelease warning in site content tests

## Validation
- cd site; node --test tests/docs-content.test.mjs
- cd site; npm run build
- git diff --check
