### PR TITLE
fix(runtime): harden stalled turn lifecycle

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ license = "BUSL-1.1"
 repository = "https://github.com/styrene-lab/omegon"
 
 [workspace.dependencies]
-tokio = { version = "1", features = ["full"] }
+tokio = { version = "1", features = ["full", "test-util"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 jsonc-parser = { version = "0.26", features = ["serde"] }

--- a/ai/lifecycle/state.json
+++ b/ai/lifecycle/state.json
@@ -1472,6 +1472,21 @@
       "bound_change": null,
       "created_at": "2026-08-02T23:45:24Z",
       "updated_at": "2026-08-02T23:45:24Z"
+    },
+    {
+      "id": "stream-idle-boundary-semantics",
+      "title": "Auditable stream idle and boundary semantics",
+      "state": "seed",
+      "parent": null,
+      "tags": [],
+      "priority": null,
+      "issue_type": null,
+      "open_questions": [],
+      "decisions": [],
+      "overview": "",
+      "bound_change": null,
+      "created_at": "2026-08-11T17:37:15Z",
+      "updated_at": "2026-08-11T17:37:15Z"
     }
   ],
   "changes": [
@@ -1694,7 +1709,7 @@
     {
       "name": "inference-discovery-producers",
       "title": "Discovery-layer producers and model catalog unification",
-      "state": "verifying",
+      "state": "archived",
       "bound_node": null,
       "specs": [
         "inference-discovery",
@@ -1708,7 +1723,7 @@
       "tasks_total": 21,
       "tasks_done": 21,
       "created_at": "2026-07-14T13:03:44Z",
-      "updated_at": "2026-07-14T16:16:57Z"
+      "updated_at": "2026-08-08T03:00:00Z"
     },
     {
       "name": "evidence-backed-model-admission",
@@ -4207,6 +4222,15 @@
       "timestamp": "2026-08-02T23:45:24Z",
       "entity_type": "node",
       "entity_id": "memory-minds-governance",
+      "from_state": "(new)",
+      "to_state": "seed",
+      "reason": null,
+      "forced": false
+    },
+    {
+      "timestamp": "2026-08-11T17:37:15Z",
+      "entity_type": "node",
+      "entity_id": "stream-idle-boundary-semantics",
       "from_state": "(new)",
       "to_state": "seed",
       "reason": null,

--- a/core/crates/omegon/src/active_worker_command.rs
+++ b/core/crates/omegon/src/active_worker_command.rs
@@ -220,7 +220,7 @@ mod tests {
         let mut runtime = InteractiveRuntimeSupervisor::default();
         let mut completion = PostWorkerCompletionPolicy::default();
         let effect = apply(
-            classify(tui::TuiCommand::Quit),
+            classify(tui::TuiCommand::Quit { confirmed: false }),
             &mut runtime,
             &mut completion,
         );
@@ -237,9 +237,9 @@ mod tests {
     #[test]
     fn active_worker_control_commands_have_typed_dispositions() {
         assert!(matches!(
-            classify(tui::TuiCommand::Quit),
+            classify(tui::TuiCommand::Quit { confirmed: false }),
             ActiveWorkerCommand::Lifecycle(
-                runtime_lifecycle_command::RuntimeLifecycleCommand::Quit
+                runtime_lifecycle_command::RuntimeLifecycleCommand::Quit { confirmed }
             )
         ));
         assert!(matches!(

--- a/core/crates/omegon/src/bridge.rs
+++ b/core/crates/omegon/src/bridge.rs
@@ -152,8 +152,18 @@ pub struct WireToolCall {
     pub arguments: Value,
 }
 
+/// Provider-neutral semantic expectation at a block boundary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BoundaryExpectation {
+    MoreReasoning,
+    MoreContent,
+    Terminal,
+    Unknown,
+}
+
 /// Events streamed from the bridge during an LLM call.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type")]
 #[allow(clippy::large_enum_variant)] // Done variant consumed immediately, never cloned
 pub enum LlmEvent {
@@ -178,6 +188,11 @@ pub enum LlmEvent {
     ToolCallDelta { delta: String },
     #[serde(rename = "toolcall_end")]
     ToolCallEnd { tool_call: WireToolCall },
+    /// Provider-normalized expectation after a semantic block boundary.
+    /// Adapters emit this only when the upstream protocol provides enough
+    /// evidence to distinguish reasoning, content, terminal, or unknown gaps.
+    #[serde(rename = "boundary")]
+    Boundary { expectation: BoundaryExpectation },
     #[serde(rename = "done")]
     Done {
         /// The complete assistant message in Omegon's format
@@ -316,6 +331,25 @@ impl LlmBridge for MockBridge {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn boundary_event_round_trips_without_render_payload() {
+        let event = LlmEvent::Boundary {
+            expectation: BoundaryExpectation::MoreReasoning,
+        };
+        let json = serde_json::to_string(&event).expect("serialize boundary");
+        assert_eq!(
+            json,
+            r#"{"type":"boundary","expectation":"more_reasoning"}"#
+        );
+        let parsed: LlmEvent = serde_json::from_str(&json).expect("deserialize boundary");
+        assert!(matches!(
+            parsed,
+            LlmEvent::Boundary {
+                expectation: BoundaryExpectation::MoreReasoning
+            }
+        ));
+    }
 
     #[test]
     fn llm_message_user_round_trip() {

--- a/core/crates/omegon/src/command_registry.rs
+++ b/core/crates/omegon/src/command_registry.rs
@@ -332,7 +332,7 @@ pub(crate) fn is_harness_owned_command(
             command_execution_owner(name) == CommandExecutionOwner::Harness
         }
         crate::operator_commands::OperatorCommand::CancelActiveTurn { .. }
-        | crate::operator_commands::OperatorCommand::Quit
+        | crate::operator_commands::OperatorCommand::Quit { confirmed: false }
         | crate::operator_commands::OperatorCommand::ModelView { .. }
         | crate::operator_commands::OperatorCommand::ModelList { .. }
         | crate::operator_commands::OperatorCommand::SetModel { .. }

--- a/core/crates/omegon/src/extensions/mod.rs
+++ b/core/crates/omegon/src/extensions/mod.rs
@@ -28,6 +28,8 @@ pub(crate) mod host_actions;
 pub mod manifest;
 pub mod mind;
 pub(crate) mod sdk_compat;
+mod supervisor_set;
+pub use supervisor_set::ExtensionSupervisorSet;
 pub mod state;
 mod tool_result;
 pub mod voice_bridge;
@@ -185,6 +187,30 @@ impl ProcessHandles {
             // Continue reading (may be out-of-order notifications or prior responses)
         }
     }
+    /// Deterministically stop and reap the canonical extension child.
+    ///
+    /// RPC/polling clones must not own process lifetime; the supervisor calls
+    /// this after disabling new calls and respawn. Closing stdin gives a
+    /// cooperative peer a bounded opportunity to exit before forced kill.
+    async fn shutdown(&mut self, grace: std::time::Duration) -> Result<()> {
+        use tokio::io::AsyncWriteExt as _;
+
+        let _ = self.stdin.shutdown().await;
+        let deadline = tokio::time::Instant::now() + grace;
+        loop {
+            if self.child.try_wait()?.is_some() {
+                return Ok(());
+            }
+            if tokio::time::Instant::now() >= deadline {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        }
+
+        self.child.kill().await?;
+        let _ = self.child.wait().await?;
+        Ok(())
+    }
 }
 
 impl Drop for ProcessHandles {
@@ -248,13 +274,76 @@ struct ExtensionRuntimeContext {
     notification_sink: Option<ExtensionNotificationSink>,
 }
 
+/// Canonical owner of an extension child process. Feature and polling handles
+/// borrow RPC access through this supervisor; they never own process lifetime.
+pub struct ExtensionSupervisor {
+    name: String,
+    handles: Mutex<Option<ProcessHandles>>,
+    accepting_calls: std::sync::atomic::AtomicBool,
+}
+
+impl ExtensionSupervisor {
+    fn new(name: String, handles: ProcessHandles) -> Self {
+        Self {
+            name,
+            handles: Mutex::new(Some(handles)),
+            accepting_calls: std::sync::atomic::AtomicBool::new(true),
+        }
+    }
+
+    fn ensure_accepting(&self) -> Result<()> {
+        if self.accepting_calls.load(Ordering::Acquire) {
+            Ok(())
+        } else {
+            Err(anyhow!("extension '{}' is shutting down", self.name))
+        }
+    }
+
+    /// Disable new RPC/respawn work, take the canonical child exactly once,
+    /// then close, terminate if needed, and reap it.
+    pub async fn shutdown(&self, grace: std::time::Duration) -> Result<()> {
+        self.accepting_calls.store(false, Ordering::Release);
+        let mut handles = self.handles.lock().await.take();
+        if let Some(handles) = handles.as_mut()
+            && let Err(error) = handles.shutdown(grace).await
+        {
+            // A failed graceful/forced shutdown must not drop the canonical
+            // child before one final kill attempt. `Drop` remains the
+            // synchronous backstop, while this error is preserved for audit.
+            let _ = handles.child.start_kill();
+            return Err(error);
+        }
+        Ok(())
+    }
+
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+}
+
+/// Shut down all canonical extension children. Every runtime surface uses this
+/// function so cleanup semantics cannot drift between TUI, daemon, ACP, tests,
+/// startup failures, and ordinary exits.
+pub async fn shutdown_supervisors(
+    supervisors: &[Arc<ExtensionSupervisor>],
+    grace: std::time::Duration,
+) -> Vec<String> {
+    let mut failures = Vec::new();
+    for supervisor in supervisors {
+        if let Err(error) = supervisor.shutdown(grace).await {
+            failures.push(format!("{}: {error}", supervisor.name()));
+        }
+    }
+    failures
+}
+
 /// Wrapper Feature for any extension (native or OCI).
 /// Manages RPC communication via stdin/stdout, agnostic to runtime type.
 #[derive(Clone)]
 pub struct ExtensionFeature {
     runtime: ExtensionRuntimeContext,
     tools: Vec<ToolDefinition>,
-    handles: Arc<Mutex<Option<ProcessHandles>>>,
+    supervisor: Arc<ExtensionSupervisor>,
     request_id: Arc<AtomicU64>,
     widgets: Vec<WidgetDeclaration>,
     widget_tx: broadcast::Sender<WidgetEvent>,
@@ -272,11 +361,12 @@ impl ExtensionFeature {
     ) -> (Self, broadcast::Receiver<WidgetEvent>) {
         let (widget_tx, widget_rx) = broadcast::channel::<WidgetEvent>(100);
         let next_id = handles.next_id;
+        let supervisor = Arc::new(ExtensionSupervisor::new(runtime.name.clone(), handles));
         (
             Self {
                 runtime,
                 tools,
-                handles: Arc::new(Mutex::new(Some(handles))),
+                supervisor,
                 request_id: Arc::new(AtomicU64::new(next_id)),
                 widgets,
                 widget_tx,
@@ -304,7 +394,8 @@ impl ExtensionFeature {
         cancel: CancellationToken,
         idle_timeout: Option<std::time::Duration>,
     ) -> Result<Value> {
-        let mut guard = self.handles.lock().await;
+        self.supervisor.ensure_accepting()?;
+        let mut guard = self.supervisor.handles.lock().await;
         let handles = guard
             .as_mut()
             .ok_or_else(|| anyhow!("extension process not running"))?;
@@ -447,7 +538,8 @@ impl ExtensionFeature {
     }
 
     async fn respawn_after_transport_error(&self, cause: &anyhow::Error) -> Result<()> {
-        let mut guard = self.handles.lock().await;
+        self.supervisor.ensure_accepting()?;
+        let mut guard = self.supervisor.handles.lock().await;
         if let Some(mut stale) = guard.take() {
             let _ = stale.child.kill().await;
             let _ = stale.child.wait().await;
@@ -520,7 +612,7 @@ impl ExtensionFeature {
     /// Used by the daemon's vox event bridge to poll for inbound messages.
     pub fn polling_handle(&self) -> ExtensionPollingHandle {
         ExtensionPollingHandle {
-            handles: self.handles.clone(),
+            supervisor: self.supervisor.clone(),
             request_id: self.request_id.clone(),
             name: self.runtime.name.clone(),
             notification_sink: self.runtime.notification_sink.clone(),
@@ -533,7 +625,7 @@ impl ExtensionFeature {
 /// can poll the extension without going through the EventBus/agent turn.
 #[derive(Clone)]
 pub struct ExtensionPollingHandle {
-    handles: Arc<Mutex<Option<ProcessHandles>>>,
+    supervisor: Arc<ExtensionSupervisor>,
     request_id: Arc<AtomicU64>,
     name: String,
     notification_sink: Option<ExtensionNotificationSink>,
@@ -549,7 +641,8 @@ impl std::fmt::Debug for ExtensionPollingHandle {
 
 impl ExtensionPollingHandle {
     pub async fn pump_notifications_for(&self, idle_timeout: std::time::Duration) -> Result<()> {
-        let mut guard = self.handles.lock().await;
+        self.supervisor.ensure_accepting()?;
+        let mut guard = self.supervisor.handles.lock().await;
         let handles = guard
             .as_mut()
             .ok_or_else(|| anyhow!("extension process not running"))?;
@@ -585,7 +678,8 @@ impl ExtensionPollingHandle {
 
     /// Send a JSON-RPC request and receive the response.
     pub async fn rpc_call(&self, method: &str, params: Value) -> Result<Value> {
-        let mut guard = self.handles.lock().await;
+        self.supervisor.ensure_accepting()?;
+        let mut guard = self.supervisor.handles.lock().await;
         let handles = guard
             .as_mut()
             .ok_or_else(|| anyhow!("extension process not running"))?;
@@ -807,6 +901,8 @@ impl Feature for ExtensionFeature {
 
 /// Result of spawning an extension: feature + widgets
 pub struct SpawnedExtension {
+    /// Canonical process owner used for deterministic host shutdown.
+    pub supervisor: Arc<ExtensionSupervisor>,
     pub feature: Box<dyn Feature>,
     pub widgets: Vec<ExtensionTabWidget>,
     pub widget_rx: broadcast::Receiver<WidgetEvent>,
@@ -1381,7 +1477,9 @@ async fn spawn_native(
     };
 
     let rpc_polling_handle = feature.polling_handle();
+    let supervisor = feature.supervisor.clone();
     Ok(SpawnedExtension {
+        supervisor,
         feature: Box::new(feature),
         widgets: tab_widgets,
         widget_rx,
@@ -1481,7 +1579,9 @@ async fn spawn_container(
     };
 
     let rpc_polling_handle = feature.polling_handle();
+    let supervisor = feature.supervisor.clone();
     Ok(SpawnedExtension {
+        supervisor,
         feature: Box::new(feature),
         widgets: tab_widgets,
         widget_rx,

--- a/core/crates/omegon/src/extensions/supervisor_set.rs
+++ b/core/crates/omegon/src/extensions/supervisor_set.rs
@@ -1,0 +1,28 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use super::ExtensionSupervisor;
+
+/// Runtime-owned collection that converges every host surface on one
+/// deterministic extension shutdown path.
+pub struct ExtensionSupervisorSet {
+    supervisors: Vec<Arc<ExtensionSupervisor>>,
+    grace: Duration,
+}
+
+impl ExtensionSupervisorSet {
+    pub fn new(supervisors: Vec<Arc<ExtensionSupervisor>>) -> Self {
+        Self {
+            supervisors,
+            grace: Duration::from_millis(500),
+        }
+    }
+
+    pub async fn shutdown(&mut self) {
+        for supervisor in self.supervisors.drain(..) {
+            if let Err(error) = supervisor.shutdown(self.grace).await {
+                tracing::warn!(%error, "extension cleanup failed");
+            }
+        }
+    }
+}

--- a/core/crates/omegon/src/ipc/connection.rs
+++ b/core/crates/omegon/src/ipc/connection.rs
@@ -908,7 +908,10 @@ impl IpcConnection {
                         serde_json::to_value(AcceptedResponse { accepted: true })?,
                     )
                     .await;
-                    let _ = cfg.command_tx.send(TuiCommand::Quit).await;
+                    let _ = cfg
+                        .command_tx
+                        .send(TuiCommand::Quit { confirmed: false })
+                        .await;
                     shutdown_requested = true;
                     break;
                 }

--- a/core/crates/omegon/src/loop.rs
+++ b/core/crates/omegon/src/loop.rs
@@ -4,7 +4,7 @@
 //! Includes: turn limits, retry with backoff, stuck detection,
 //! context wiring, and parallel tool dispatch.
 
-use crate::bridge::{LlmBridge, LlmEvent, LlmMessage, StreamOptions};
+use crate::bridge::{BoundaryExpectation, LlmBridge, LlmEvent, LlmMessage, StreamOptions};
 
 use crate::context::ContextManager;
 use crate::conversation::{
@@ -2152,12 +2152,13 @@ async fn stream_with_retry(
         // of aborting immediately via `?`.
         let err = match bridge.stream(system_prompt, messages, tools, options).await {
             Ok(mut rx) => {
-                match consume_llm_stream(
+                match consume_llm_stream_with_policy(
                     &mut rx,
                     events,
                     &provider,
                     &model,
                     config.cancel_keeps_prompt.as_ref(),
+                    StreamIdlePolicy::from_env(),
                 )
                 .await
                 {
@@ -2508,41 +2509,67 @@ impl StreamIdleState {
     }
 }
 
-fn select_stream_idle_budget(
-    phase: StreamIdlePhase,
-    _initial: std::time::Duration,
+#[derive(Debug, Clone, Copy)]
+struct StreamIdlePolicy {
+    initial: std::time::Duration,
     active: std::time::Duration,
-    reasoning_budget: std::time::Duration,
-) -> std::time::Duration {
-    match phase {
-        StreamIdlePhase::OutputStreaming | StreamIdlePhase::ToolStreaming => active,
-        StreamIdlePhase::AwaitingFirstEvent
-        | StreamIdlePhase::ReasoningStreaming
-        | StreamIdlePhase::AmbiguousSilent => reasoning_budget,
+    reasoning: std::time::Duration,
+}
+
+impl StreamIdlePolicy {
+    fn from_env() -> Self {
+        let initial = std::env::var("OMEGON_LLM_INITIAL_IDLE_TIMEOUT_SECS")
+            .ok()
+            .and_then(|value| value.parse::<u64>().ok())
+            .filter(|seconds| *seconds >= 30)
+            .map(std::time::Duration::from_secs)
+            .unwrap_or_else(|| std::time::Duration::from_secs(90));
+        let reasoning = std::env::var("OMEGON_LLM_REASONING_IDLE_TIMEOUT_SECS")
+            .ok()
+            .and_then(|value| value.parse::<u64>().ok())
+            .filter(|seconds| *seconds >= 60)
+            .map(std::time::Duration::from_secs)
+            .unwrap_or_else(|| std::time::Duration::from_secs(600));
+        Self {
+            initial,
+            active: std::time::Duration::from_secs(90),
+            reasoning,
+        }
+    }
+
+    fn budget(self, phase: StreamIdlePhase, visible_output_seen: bool) -> std::time::Duration {
+        if visible_output_seen {
+            // Once the operator has observed output or a tool effect, silence
+            // is a stalled active turn regardless of the adapter's last phase.
+            // A provider cannot silently promote a visible turn back onto the
+            // long pre-output reasoning leash.
+            return self.active;
+        }
+        match phase {
+            // A provider must emit an explicit reasoning/inter-item boundary to
+            // receive the long leash. Visible text does not permanently ban
+            // reasoning, but an adapter that leaves the stream in an active
+            // output/tool phase cannot silently promote itself to 600 seconds.
+            StreamIdlePhase::AwaitingFirstEvent
+            | StreamIdlePhase::ReasoningStreaming
+            | StreamIdlePhase::AmbiguousSilent => self.reasoning,
+            StreamIdlePhase::OutputStreaming | StreamIdlePhase::ToolStreaming => self.active,
+        }
     }
 }
 
-/// Decide whether a stream that idled out under the tight *active* budget
-/// should be re-armed with the generous reasoning budget instead of being
-/// treated as a stall.
-///
-/// Reasoning-capable providers (notably the OpenAI Responses API behind
-/// `openai-codex`) can stream output deltas for one item, then pause for
-/// minutes while deciding the next item — *without* first emitting a
-/// `TextEnd`/`ToolCallEnd` that would move the phase out of the active band.
-/// The first such silence should not abort the turn; it should fall through to
-/// the ambiguous-silent phase and get the reasoning leash. A second silence
-/// (now evaluated in `AmbiguousSilent`) is a genuine stall and is *not*
-/// re-armed, so a dead stream still dies inside the retry budget.
-fn rearm_idle_phase(phase: StreamIdlePhase) -> Option<StreamIdlePhase> {
-    match phase {
-        StreamIdlePhase::OutputStreaming | StreamIdlePhase::ToolStreaming => {
-            Some(StreamIdlePhase::AmbiguousSilent)
-        }
-        StreamIdlePhase::AwaitingFirstEvent
-        | StreamIdlePhase::ReasoningStreaming
-        | StreamIdlePhase::AmbiguousSilent => None,
+fn select_stream_idle_budget(
+    phase: StreamIdlePhase,
+    initial: std::time::Duration,
+    active: std::time::Duration,
+    reasoning_budget: std::time::Duration,
+) -> std::time::Duration {
+    StreamIdlePolicy {
+        initial,
+        active,
+        reasoning: reasoning_budget,
     }
+    .budget(phase, false)
 }
 
 fn stream_idle_phase_after_event(current: StreamIdlePhase, event: &LlmEvent) -> StreamIdlePhase {
@@ -2556,6 +2583,12 @@ fn stream_idle_phase_after_event(current: StreamIdlePhase, event: &LlmEvent) -> 
         LlmEvent::ThinkingEnd => StreamIdlePhase::AmbiguousSilent,
         LlmEvent::ToolCallStart | LlmEvent::ToolCallDelta { .. } => StreamIdlePhase::ToolStreaming,
         LlmEvent::ToolCallEnd { .. } => StreamIdlePhase::AmbiguousSilent,
+        LlmEvent::Boundary { expectation } => match expectation {
+            BoundaryExpectation::MoreReasoning => StreamIdlePhase::ReasoningStreaming,
+            BoundaryExpectation::MoreContent => StreamIdlePhase::OutputStreaming,
+            BoundaryExpectation::Unknown => StreamIdlePhase::AmbiguousSilent,
+            BoundaryExpectation::Terminal => current,
+        },
         LlmEvent::Done { .. } | LlmEvent::Error { .. } => current,
     }
 }
@@ -2567,12 +2600,33 @@ async fn consume_llm_stream(
     model: &str,
     cancel_keeps_prompt: Option<&std::sync::Arc<std::sync::atomic::AtomicBool>>,
 ) -> anyhow::Result<AssistantMessage> {
+    consume_llm_stream_with_policy(
+        rx,
+        events,
+        provider,
+        model,
+        cancel_keeps_prompt,
+        StreamIdlePolicy::from_env(),
+    )
+    .await
+}
+
+async fn consume_llm_stream_with_policy(
+    rx: &mut tokio::sync::mpsc::Receiver<LlmEvent>,
+    events: &broadcast::Sender<AgentEvent>,
+    provider: &str,
+    model: &str,
+    cancel_keeps_prompt: Option<&std::sync::Arc<std::sync::atomic::AtomicBool>>,
+    idle_policy: StreamIdlePolicy,
+) -> anyhow::Result<AssistantMessage> {
     let mut text_parts: Vec<String> = Vec::new();
     let mut thinking_parts: Vec<String> = Vec::new();
     let mut tool_calls: Vec<ToolCall> = Vec::new();
     let mut final_raw: Value = Value::Null;
     let mut provider_tokens: (u64, u64, u64, u64) = (0, 0, 0, 0); // (input, output, cache_read, cache_write)
     let mut provider_telemetry = None;
+    let mut completed = false;
+    let mut visible_output_seen = false;
 
     let _ = events.send(AgentEvent::MessageStart {
         role: "assistant".into(),
@@ -2597,105 +2651,47 @@ async fn consume_llm_stream(
     //   text/thinking/tool-call blocks while deciding the next item.
     // The legacy initial budget is retained as an input for compatibility, but
     // AwaitingFirstEvent intentionally selects the reasoning budget below.
-    let initial_idle_timeout = std::env::var("OMEGON_LLM_INITIAL_IDLE_TIMEOUT_SECS")
-        .ok()
-        .and_then(|value| value.parse::<u64>().ok())
-        .filter(|seconds| *seconds >= 30)
-        .map(std::time::Duration::from_secs)
-        .unwrap_or_else(|| std::time::Duration::from_secs(90));
-    let content_idle_timeout = std::time::Duration::from_secs(90);
-    // Reasoning phase: the model has begun thinking but emitted no content or
-    // tool call yet. Reasoning models (OpenAI gpt-5.x/o-series, Anthropic
-    // interleaved thinking) can stream nothing — not even reasoning-summary
-    // deltas — for minutes. Give this phase a strictly longer leash than the
-    // active-content phase, mirroring the provider-side SSE watchdog.
-    let reasoning_idle_timeout = std::env::var("OMEGON_LLM_REASONING_IDLE_TIMEOUT_SECS")
-        .ok()
-        .and_then(|value| value.parse::<u64>().ok())
-        .filter(|seconds| *seconds >= 60)
-        .map(std::time::Duration::from_secs)
-        .unwrap_or_else(|| std::time::Duration::from_secs(600));
-    // Active output phases use a tight watchdog; explicit thinking and
-    // provider decision gaps between output items use the generous reasoning
-    // budget. This mirrors provider-side SSE gates for Anthropic/Codex and
-    // local thinking-capable providers such as Ollama.
     let stream_idle_phase =
         std::sync::atomic::AtomicU8::new(StreamIdlePhase::AwaitingFirstEvent as u8);
-    let idle_timeout = || {
-        select_stream_idle_budget(
+    let idle_timeout = |visible_output_seen: bool| {
+        idle_policy.budget(
             StreamIdlePhase::from_u8(stream_idle_phase.load(std::sync::atomic::Ordering::Relaxed)),
-            initial_idle_timeout,
-            content_idle_timeout,
-            reasoning_idle_timeout,
+            visible_output_seen,
         )
     };
-    while let Some(event) = 'recv: loop {
-        match tokio::time::timeout(idle_timeout(), rx.recv()).await {
-            Ok(event) => break 'recv event,
-            Err(_) => {
-                let phase = StreamIdlePhase::from_u8(
-                    stream_idle_phase.load(std::sync::atomic::Ordering::Relaxed),
-                );
-                // A silent gap *after* active output/tool streaming is most
-                // often a reasoning-capable provider (notably the OpenAI
-                // Responses API used by openai-codex) pausing between output
-                // items without first emitting a TextEnd/ToolCallEnd. The phase
-                // is still OutputStreaming/ToolStreaming, so the tight active
-                // budget would abort a live reasoning gap and surface as a
-                // spurious "stalled stream — retrying". Downgrade once to the
-                // ambiguous-silent phase and re-arm with the generous reasoning
-                // budget instead of aborting. A genuinely dead stream still
-                // dies on the next timeout (now evaluated in the ambiguous
-                // phase), and any resumed delta flips the phase back to active.
-                if let Some(rearmed) = rearm_idle_phase(phase) {
-                    stream_idle_phase.store(rearmed as u8, std::sync::atomic::Ordering::Relaxed);
-                    let idle_secs = idle_timeout().as_secs();
-                    tracing::debug!(
-                        provider,
-                        model,
-                        from_phase = phase.label(),
-                        idle_secs,
-                        "stream idle after active output — re-arming with reasoning budget before treating as a stall"
-                    );
-                    let _ = events.send(AgentEvent::StreamIdle {
-                        provider: provider.to_string(),
-                        model: model.to_string(),
-                        phase: phase.label().to_string(),
-                        idle_secs,
-                        ambiguous: true,
-                        message: format!(
-                            "LLM stream idle for {idle_secs}s after {} — re-arming with reasoning budget before treating as a stall",
-                            phase.label()
-                        ),
-                    });
-                    continue 'recv;
-                }
-                let reason = if phase.is_ambiguous_reasoning() {
-                    format!(
-                        "LLM stream had no observable activity for {}s during {} — this may be a long-running reasoning window or a stalled stream",
-                        idle_timeout().as_secs(),
-                        phase.label()
-                    )
-                } else {
-                    format!(
-                        "LLM stream idle for {}s during {} — connection may be stalled",
-                        idle_timeout().as_secs(),
-                        phase.label()
-                    )
-                };
-                let _ = events.send(AgentEvent::StreamIdle {
-                    provider: provider.to_string(),
-                    model: model.to_string(),
-                    phase: phase.label().to_string(),
-                    idle_secs: idle_timeout().as_secs(),
-                    ambiguous: phase.is_ambiguous_reasoning(),
-                    message: reason.clone(),
-                });
-                let _ = events.send(AgentEvent::MessageAbort {
-                    reason: Some(reason.clone()),
-                });
-                anyhow::bail!("{reason}");
-            }
+    while let Some(event) = match tokio::time::timeout(idle_timeout(visible_output_seen), rx.recv())
+        .await
+    {
+        Ok(event) => event,
+        Err(_) => {
+            let phase = StreamIdlePhase::from_u8(
+                stream_idle_phase.load(std::sync::atomic::Ordering::Relaxed),
+            );
+            let reason = if phase.is_ambiguous_reasoning() && !visible_output_seen {
+                format!(
+                    "LLM stream had no observable activity for {}s during {} — this may be a long-running reasoning window or a stalled stream",
+                    idle_timeout(visible_output_seen).as_secs(),
+                    phase.label()
+                )
+            } else {
+                format!(
+                    "LLM stream idle for {}s during {} — connection may be stalled",
+                    idle_timeout(visible_output_seen).as_secs(),
+                    phase.label()
+                )
+            };
+            let _ = events.send(AgentEvent::StreamIdle {
+                provider: provider.to_string(),
+                model: model.to_string(),
+                phase: phase.label().to_string(),
+                idle_secs: idle_timeout(visible_output_seen).as_secs(),
+                ambiguous: phase.is_ambiguous_reasoning() && !visible_output_seen,
+                message: reason.clone(),
+            });
+            let _ = events.send(AgentEvent::MessageAbort {
+                reason: Some(reason.clone()),
+            });
+            anyhow::bail!("{reason}");
         }
     } {
         let next_phase = stream_idle_phase_after_event(
@@ -2711,6 +2707,7 @@ async fn consume_llm_stream(
             LlmEvent::TextStart => {}
             LlmEvent::TextDelta { delta } => {
                 if !delta.is_empty() {
+                    visible_output_seen = true;
                     // Partial assistant output is visible to the operator. If
                     // they interrupt now, keep the prompt in canonical replay.
                     // This makes Escape useful for cutting off rambling output
@@ -2795,11 +2792,18 @@ async fn consume_llm_stream(
                 // Deltas accumulated by the bridge — complete tool call in ToolCallEnd
             }
             LlmEvent::ToolCallEnd { tool_call } => {
+                visible_output_seen = true;
+                if let Some(cancel_keeps_prompt) = cancel_keeps_prompt {
+                    cancel_keeps_prompt.store(true, std::sync::atomic::Ordering::Relaxed);
+                }
                 tool_calls.push(ToolCall {
                     id: tool_call.id,
                     name: tool_call.name,
                     arguments: tool_call.arguments,
                 });
+            }
+            LlmEvent::Boundary { .. } => {
+                // Semantic-only boundary consumed by the watchdog state machine.
             }
             LlmEvent::Done {
                 message,
@@ -2818,6 +2822,7 @@ async fn consume_llm_stream(
                     cache_creation_tokens,
                 );
                 provider_telemetry = done_provider_telemetry;
+                completed = true;
                 break;
             }
             LlmEvent::Error { message } => {
@@ -2831,10 +2836,10 @@ async fn consume_llm_stream(
 
     let _ = events.send(AgentEvent::MessageEnd);
 
-    // Detect incomplete streams — if we never got a Done event, the bridge
-    // probably died. An empty message with no text and no tool calls is
-    // almost certainly a dropped connection, not a valid LLM response.
-    if final_raw == Value::Null && text_parts.is_empty() && tool_calls.is_empty() {
+    // A stream is complete only after the provider's explicit terminal event.
+    // EOF after partial text/tool output is still an abnormal protocol close;
+    // accepting it would leave the outer loop reasoning from a truncated turn.
+    if !completed {
         anyhow::bail!("LLM stream ended without a completion event — the bridge may have crashed");
     }
 
@@ -5027,39 +5032,104 @@ mod tests {
     }
 
     #[test]
-    fn active_output_silence_rearms_to_reasoning_budget() {
+    fn visible_output_forces_active_budget_for_every_phase() {
         use std::time::Duration;
-        let initial = Duration::from_secs(90);
-        let content = Duration::from_secs(90);
-        let reasoning = Duration::from_secs(600);
 
-        // Regression: openai-codex (OpenAI Responses API) streams text deltas
-        // for one item, then pauses for minutes deciding the next item without
-        // first emitting TextEnd. The phase is still OutputStreaming, so the
-        // *first* silence must re-arm to the ambiguous-silent phase and pick up
-        // the generous reasoning leash instead of aborting at the tight budget.
-        for active_phase in [
+        let policy = StreamIdlePolicy {
+            initial: Duration::from_secs(30),
+            active: Duration::from_secs(2),
+            reasoning: Duration::from_secs(60),
+        };
+        for phase in [
+            StreamIdlePhase::AwaitingFirstEvent,
             StreamIdlePhase::OutputStreaming,
             StreamIdlePhase::ToolStreaming,
+            StreamIdlePhase::ReasoningStreaming,
+            StreamIdlePhase::AmbiguousSilent,
         ] {
-            let rearmed =
-                rearm_idle_phase(active_phase).expect("active output silence must re-arm once");
-            assert_eq!(rearmed, StreamIdlePhase::AmbiguousSilent);
             assert_eq!(
-                select_stream_idle_budget(rearmed, initial, content, reasoning),
-                reasoning,
-                "re-armed phase must use the generous reasoning budget"
+                policy.budget(phase, true),
+                policy.active,
+                "visible output in {} must retain the active-turn deadline",
+                phase.label()
             );
         }
+    }
 
-        // A *second* silence is now evaluated in the ambiguous phase: it must
-        // NOT re-arm, so a genuinely dead stream still dies inside the retry
-        // budget rather than looping forever.
-        assert_eq!(rearm_idle_phase(StreamIdlePhase::AmbiguousSilent), None);
-        assert_eq!(rearm_idle_phase(StreamIdlePhase::ReasoningStreaming), None);
-        // Awaiting-first-event silence is a connection problem, not a reasoning
-        // gap; it must surface as a stall, not re-arm.
-        assert_eq!(rearm_idle_phase(StreamIdlePhase::AwaitingFirstEvent), None);
+    #[tokio::test(start_paused = true)]
+    async fn visible_output_then_silence_terminalizes_with_abort() {
+        use std::time::Duration;
+
+        let (stream_tx, mut stream_rx) = tokio::sync::mpsc::channel(4);
+        let (events_tx, mut events_rx) = broadcast::channel(16);
+        stream_tx.send(LlmEvent::TextStart).await.unwrap();
+        stream_tx
+            .send(LlmEvent::TextDelta {
+                delta: "visible".into(),
+            })
+            .await
+            .unwrap();
+
+        let result = consume_llm_stream_with_policy(
+            &mut stream_rx,
+            &events_tx,
+            "test-provider",
+            "test-model",
+            None,
+            StreamIdlePolicy {
+                initial: Duration::from_secs(30),
+                active: Duration::from_secs(2),
+                reasoning: Duration::from_secs(60),
+            },
+        );
+        tokio::pin!(result);
+        tokio::time::advance(Duration::from_secs(3)).await;
+        let error = result.await.expect_err("silent partial stream must fail");
+        assert!(error.to_string().contains("idle for 2s"));
+
+        let mut saw_visible = false;
+        let mut abort_reason = None;
+        while let Ok(event) = events_rx.try_recv() {
+            match event {
+                AgentEvent::MessageChunk { text } if text == "visible" => saw_visible = true,
+                AgentEvent::MessageAbort { reason } => abort_reason = reason,
+                _ => {}
+            }
+        }
+        assert!(saw_visible, "partial output must remain observable");
+        assert!(
+            abort_reason.is_some_and(|reason| reason.contains("idle for 2s")),
+            "stall must emit an explicit terminal abort"
+        );
+    }
+
+    #[tokio::test]
+    async fn partial_output_then_stream_close_is_an_abnormal_terminal_error() {
+        let (stream_tx, mut stream_rx) = tokio::sync::mpsc::channel(4);
+        let (events_tx, _) = broadcast::channel(16);
+        stream_tx
+            .send(LlmEvent::TextDelta {
+                delta: "truncated".into(),
+            })
+            .await
+            .unwrap();
+        drop(stream_tx);
+
+        let error = consume_llm_stream_with_policy(
+            &mut stream_rx,
+            &events_tx,
+            "test-provider",
+            "test-model",
+            None,
+            StreamIdlePolicy {
+                initial: std::time::Duration::from_secs(30),
+                active: std::time::Duration::from_secs(2),
+                reasoning: std::time::Duration::from_secs(60),
+            },
+        )
+        .await
+        .expect_err("EOF without Done must fail");
+        assert!(error.to_string().contains("without a completion event"));
     }
 
     #[test]

--- a/core/crates/omegon/src/main.rs
+++ b/core/crates/omegon/src/main.rs
@@ -2604,6 +2604,8 @@ async fn run_embedded_command(
     }
 
     let router = Arc::new(session_router::SessionRouter::new());
+    let mut extension_supervisors =
+        extensions::ExtensionSupervisorSet::new(std::mem::take(&mut agent.extension_supervisors));
     let agent_cwd = agent.cwd.clone();
     let agent_session_id = agent.session_id.clone();
     let agent_secrets = agent.secrets.clone();
@@ -3022,9 +3024,12 @@ async fn run_embedded_command(
                             },
                         );
                     }
-                    Some(operator_commands::OperatorCommand::Quit) => {
-                        tracing::info!("daemon: IPC shutdown requested");
+                    Some(operator_commands::OperatorCommand::Quit { confirmed: true }) => {
+                        tracing::info!("daemon: confirmed IPC shutdown requested");
                         break;
+                    }
+                    Some(operator_commands::OperatorCommand::Quit { confirmed: false }) => {
+                        tracing::warn!("daemon: rejected unconfirmed IPC shutdown request");
                     }
                     Some(_) => {
                         tracing::debug!("daemon: unhandled IPC command variant");
@@ -3209,6 +3214,7 @@ async fn run_embedded_command(
             );
         }
     }
+    extension_supervisors.shutdown().await;
     Ok(())
 }
 
@@ -4254,6 +4260,9 @@ async fn run_interactive_command(cli: &Cli) -> anyhow::Result<()> {
         s.provider_connected = startup_decision.provider_connected;
     }
     let (events_tx, events_rx) = bootstrap::wire_event_channel(&agent, 256);
+    let mut extension_supervisors = extensions::ExtensionSupervisorSet::new(
+        std::mem::take(&mut agent.extension_supervisors),
+    );
     let startup_model_intent = settings::Profile::load(&agent.cwd)
         .model_intent
         .and_then(|intent| intent.to_route_intent())
@@ -4598,7 +4607,13 @@ fn build_tui_secret_readiness_snapshot(
         };
 
         match cmd {
-            operator_commands::OperatorCommand::Quit => break,
+            operator_commands::OperatorCommand::Quit { confirmed: true } => break,
+            operator_commands::OperatorCommand::Quit { confirmed: false } => {
+                let _ = events_tx.send(AgentEvent::SystemNotification {
+                    message: "Shutdown rejected: destructive exit was not confirmed by an interactive surface.".to_string(),
+                });
+                continue;
+            }
             operator_commands::OperatorCommand::InstallUpdate { info, args } => {
                 let latest = info.latest.clone();
                 let operation_id = uuid::Uuid::new_v4().to_string();
@@ -5525,7 +5540,7 @@ fn build_tui_secret_readiness_snapshot(
                                         continue;
                                     }
                                     web::WebCommand::Shutdown => {
-                                        if cmd_tx_clone.send(operator_commands::OperatorCommand::Quit).await.is_err() {
+                                        if cmd_tx_clone.send(operator_commands::OperatorCommand::Quit { confirmed: false }).await.is_err() {
                                             break;
                                         }
                                         continue;
@@ -6202,17 +6217,38 @@ fn build_tui_secret_readiness_snapshot(
                                             submitted_by,
                                             via,
                                         );
-                                        if cancellation_deadline.is_none() {
-                                            cancellation_deadline = Some(Box::pin(tokio::time::sleep(std::time::Duration::from_secs(2))));
-                                        }
+                                        // Revocation is authoritative: abort the worker now rather
+                                        // than treating cancellation as a request that may be ignored.
+                                        // Durable state is supervisor-owned behind `state_for_turn`.
+                                        turn_task.abort();
+                                        let _ = (&mut turn_task).await;
+                                        if let Ok(mut guard) = shared_cancel.lock() { guard.take(); }
+                                        lifecycle.transition("worker_revoked", runtime.queue_depth(), &events_tx);
+                                        mark_interactive_session_busy(&agent.dashboard_handles, false);
+                                        let _ = events_tx.send(AgentEvent::AgentEnd);
+                                        runtime_state = Arc::try_unwrap(state_for_turn)
+                                            .map_err(|_| anyhow::anyhow!("revoked worker retained durable state"))?
+                                            .into_inner();
+                                        break;
                                     }
-                                    operator_commands::OperatorCommand::Quit => {
+                                    operator_commands::OperatorCommand::Quit { confirmed: false } => {
+                                        let _ = events_tx.send(AgentEvent::SystemNotification {
+                                            message: "Shutdown rejected: destructive exit was not confirmed by an interactive surface.".to_string(),
+                                        });
+                                    }
+                                    operator_commands::OperatorCommand::Quit { confirmed: true } => {
                                         quit_after_turn = true;
-                                        if let Ok(guard) = shared_cancel.lock()
-                                            && let Some(ref cancel) = *guard
-                                        {
-                                            cancel.cancel();
-                                        }
+                                        turn_cancel.cancel();
+                                        turn_task.abort();
+                                        let _ = (&mut turn_task).await;
+                                        if let Ok(mut guard) = shared_cancel.lock() { guard.take(); }
+                                        lifecycle.transition("worker_revoked_for_exit", runtime.queue_depth(), &events_tx);
+                                        mark_interactive_session_busy(&agent.dashboard_handles, false);
+                                        let _ = events_tx.send(AgentEvent::AgentEnd);
+                                        runtime_state = Arc::try_unwrap(state_for_turn)
+                                            .map_err(|_| anyhow::anyhow!("exit-revoked worker retained durable state"))?
+                                            .into_inner();
+                                        break;
                                     }
                                     operator_commands::OperatorCommand::InstallUpdate { info, args } => {
                                         deferred_commands.push_back(
@@ -6355,6 +6391,8 @@ fn build_tui_secret_readiness_snapshot(
     }
 
     bridge.read().await.shutdown().await;
+    extension_supervisors.shutdown().await;
+
     if let Some((binary, args)) = restart_request {
         let args = restart_args_for_session(args, &agent.session_id);
         crate::update::exec_restart(&binary, &args)?;
@@ -9056,6 +9094,7 @@ mod tests {
                 lease: workspace_lease,
                 admission: crate::workspace::types::AdmissionOutcome::GrantedMutable,
             },
+            extension_supervisors: vec![],
             extension_widgets: vec![],
             extension_metadata: Default::default(),
             extension_rpc_handles: Default::default(),

--- a/core/crates/omegon/src/model_commands.rs
+++ b/core/crates/omegon/src/model_commands.rs
@@ -235,6 +235,6 @@ mod tests {
             respond_to: None,
         }));
         assert!(!is_model_command(&tui::TuiCommand::Compact));
-        assert!(!is_model_command(&tui::TuiCommand::Quit));
+        assert!(!is_model_command(&tui::TuiCommand::Quit { confirmed: false }));
     }
 }

--- a/core/crates/omegon/src/operator_commands.rs
+++ b/core/crates/omegon/src/operator_commands.rs
@@ -320,8 +320,9 @@ pub enum OperatorCommand {
     /// the Kitty protocol around the subprocess without querying the
     /// terminal again (which can fail if stdin is redirected).
     ShellHandoff { keyboard_enhancement: bool },
-    /// User wants to quit (double Ctrl+C, or /exit).
-    Quit,
+    /// Destructive process exit. The coordinator rejects this unless the
+    /// submitting surface records that operator confirmation has completed.
+    Quit { confirmed: bool },
     /// Download and verify an update, then enter the graceful restart lifecycle.
     InstallUpdate {
         info: crate::update::UpdateInfo,

--- a/core/crates/omegon/src/providers.rs
+++ b/core/crates/omegon/src/providers.rs
@@ -13,7 +13,7 @@ use serde_json::{Value, json};
 use tokio::sync::mpsc;
 use tokio_stream::StreamExt;
 
-use crate::bridge::{LlmBridge, LlmEvent, LlmMessage, StreamOptions};
+use crate::bridge::{BoundaryExpectation, LlmBridge, LlmEvent, LlmMessage, StreamOptions};
 
 /// Claude Code CLI version for OAuth user-agent header.
 /// Must match what Anthropic expects for subscription recognition.
@@ -1645,6 +1645,9 @@ async fn parse_anthropic_stream(
                     Some("text") => {
                         content_blocks.push(json!({"type": "text", "text": current_block_text.clone()}));
                         let _ = tx.try_send(LlmEvent::TextEnd);
+                        let _ = tx.try_send(LlmEvent::Boundary {
+                            expectation: BoundaryExpectation::MoreReasoning,
+                        });
                     }
                     Some("thinking") => {
                         let mut block = json!({

--- a/core/crates/omegon/src/runtime_lifecycle_command.rs
+++ b/core/crates/omegon/src/runtime_lifecycle_command.rs
@@ -4,7 +4,7 @@ use crate::tui;
 
 #[derive(Debug)]
 pub(crate) enum RuntimeLifecycleCommand {
-    Quit,
+    Quit { confirmed: bool },
     InstallUpdate {
         info: crate::update::UpdateInfo,
         args: Vec<String>,
@@ -35,7 +35,9 @@ pub(crate) enum LifecycleClassification {
 
 pub(crate) fn classify(command: tui::TuiCommand) -> LifecycleClassification {
     match command {
-        tui::TuiCommand::Quit => LifecycleClassification::Lifecycle(RuntimeLifecycleCommand::Quit),
+        tui::TuiCommand::Quit { confirmed } => LifecycleClassification::Lifecycle(
+            RuntimeLifecycleCommand::Quit { confirmed },
+        ),
         tui::TuiCommand::InstallUpdate { info, args } => {
             LifecycleClassification::Lifecycle(RuntimeLifecycleCommand::InstallUpdate {
                 info,
@@ -55,7 +57,7 @@ pub(crate) fn classify(command: tui::TuiCommand) -> LifecycleClassification {
 impl RuntimeLifecycleCommand {
     pub(crate) fn for_active_worker(self) -> ActiveWorkerLifecycleDisposition {
         match self {
-            Self::Quit => ActiveWorkerLifecycleDisposition::QuitAfterTurn,
+            Self::Quit { confirmed: _ } => ActiveWorkerLifecycleDisposition::QuitAfterTurn,
             Self::InstallUpdate { info, args } => {
                 ActiveWorkerLifecycleDisposition::DeferInstallUpdate { info, args }
             }
@@ -151,7 +153,7 @@ mod tests {
 
     #[test]
     fn active_worker_lifecycle_commands_have_typed_dispositions() {
-        let disposition = RuntimeLifecycleCommand::Quit.for_active_worker();
+        let disposition = RuntimeLifecycleCommand::Quit { confirmed: false }.for_active_worker();
         assert!(matches!(
             disposition,
             ActiveWorkerLifecycleDisposition::QuitAfterTurn

--- a/core/crates/omegon/src/setup.rs
+++ b/core/crates/omegon/src/setup.rs
@@ -87,6 +87,8 @@ pub struct AgentSetup {
     pub resume_info: Option<ResumeInfo>,
     /// Startup-local workspace ownership metadata.
     pub workspace_state: WorkspaceStartupState,
+    /// Canonical owners for deterministic extension process shutdown.
+    pub extension_supervisors: Vec<std::sync::Arc<crate::extensions::ExtensionSupervisor>>,
     /// Extension widgets discovered during setup — passed to TUI for rendering.
     pub extension_widgets: Vec<crate::extensions::ExtensionTabWidget>,
     /// Extension deployment metadata discovered during startup.
@@ -997,6 +999,7 @@ impl AgentSetup {
         // ─── Operator-installed extensions (RPC + OCI) ────────────────
         // All extensions, including bundled ones (scribe-rpc), are discovered here
         let (
+            extension_supervisors,
             extension_widgets,
             widget_receivers,
             vox_polling_handles,
@@ -1008,6 +1011,7 @@ impl AgentSetup {
             .await
         {
             Ok((
+                supervisors,
                 widgets,
                 receivers,
                 handles,
@@ -1016,6 +1020,7 @@ impl AgentSetup {
                 metadata,
                 rpc_handles,
             )) => (
+                supervisors,
                 widgets,
                 receivers,
                 handles,
@@ -1027,6 +1032,7 @@ impl AgentSetup {
             Err(e) => {
                 tracing::warn!("extension discovery failed: {}", e);
                 (
+                    vec![],
                     vec![],
                     vec![],
                     vec![],
@@ -1512,6 +1518,7 @@ impl AgentSetup {
             workspace_state,
             startup_snapshot,
             initial_harness_status: initial_harness_status.clone(),
+            extension_supervisors,
             extension_widgets,
             extension_metadata,
             extension_rpc_handles,
@@ -1878,6 +1885,7 @@ async fn discover_and_register_extensions(
     bus: &mut crate::bus::EventBus,
     secrets: std::sync::Arc<omegon_secrets::SecretsManager>,
 ) -> anyhow::Result<(
+    Vec<std::sync::Arc<crate::extensions::ExtensionSupervisor>>,
     Vec<crate::extensions::ExtensionTabWidget>,
     Vec<tokio::sync::broadcast::Receiver<crate::extensions::WidgetEvent>>,
     Vec<crate::extensions::ExtensionPollingHandle>,
@@ -1896,6 +1904,7 @@ async fn discover_and_register_extensions(
             vec![],
             vec![],
             vec![],
+            vec![],
             Default::default(),
             Default::default(),
         ));
@@ -1905,6 +1914,7 @@ async fn discover_and_register_extensions(
     let env_enabled = crate::parse_csv_env("OMEGON_CHILD_ENABLED_EXTENSIONS");
     let env_disabled = crate::parse_csv_env("OMEGON_CHILD_DISABLED_EXTENSIONS");
     let mut count = 0;
+    let mut extension_supervisors = Vec::new();
     let mut extension_widgets = vec![];
     let mut widget_receivers = vec![];
     let mut vox_polling_handles = vec![];
@@ -1964,6 +1974,7 @@ async fn discover_and_register_extensions(
                     widgets = widget_count,
                     "discovered and spawned extension"
                 );
+                extension_supervisors.push(spawned.supervisor.clone());
                 // Collect vox polling handle if present
                 if let Some(handle) = spawned.vox_polling_handle {
                     vox_polling_handles.push(handle);
@@ -2008,6 +2019,7 @@ async fn discover_and_register_extensions(
     }
 
     Ok((
+        extension_supervisors,
         extension_widgets,
         widget_receivers,
         vox_polling_handles,

--- a/core/crates/omegon/src/tui/input.rs
+++ b/core/crates/omegon/src/tui/input.rs
@@ -624,7 +624,7 @@ impl App {
                                     SlashResult::Quit
                                 )
                             {
-                                let _ = command_tx.send(TuiCommand::Quit).await;
+                                let _ = command_tx.send(TuiCommand::Quit { confirmed: true }).await;
                             }
                         }
                         KeyCode::Enter => {
@@ -637,7 +637,7 @@ impl App {
                                     SlashResult::Quit
                                 )
                             {
-                                let _ = command_tx.send(TuiCommand::Quit).await;
+                                let _ = command_tx.send(TuiCommand::Quit { confirmed: true }).await;
                             }
                         }
                         KeyCode::Esc => {
@@ -1101,7 +1101,8 @@ impl App {
                             if let Some(last) = self.last_ctrl_c {
                                 if now.duration_since(last).as_millis() < 1000 {
                                     self.should_quit = true;
-                                    let _ = command_tx.send(TuiCommand::Quit).await;
+                                    let _ =
+                                        command_tx.send(TuiCommand::Quit { confirmed: true }).await;
                                 } else {
                                     self.last_ctrl_c = Some(now);
                                     self.show_command_toast(CommandToast::new(

--- a/core/crates/omegon/src/tui/mod.rs
+++ b/core/crates/omegon/src/tui/mod.rs
@@ -7733,7 +7733,7 @@ pub async fn run_tui(
                 // Terminal restoration alone must not leave the coordinator
                 // running headless while IPC/other sender clones keep the
                 // command channel open.
-                let _ = command_tx.send(TuiCommand::Quit).await;
+                let _ = command_tx.send(TuiCommand::Quit { confirmed: true }).await;
                 break;
             }
             event = events_rx.recv() => {
@@ -8859,7 +8859,8 @@ mod slash_command_parsing_tests {
         let settings = crate::settings::shared("anthropic:claude-sonnet-4-5");
         let mut app = App::new(settings);
         let (tx, _rx) = mpsc::channel(1);
-        tx.try_send(TuiCommand::Quit).expect("seed full channel");
+        tx.try_send(TuiCommand::Quit { confirmed: false })
+            .expect("seed full channel");
 
         let result = app.handle_slash_command("/skills create", &tx);
         match result {

--- a/core/crates/omegon/src/tui/ui_actions.rs
+++ b/core/crates/omegon/src/tui/ui_actions.rs
@@ -63,7 +63,7 @@ impl App {
                         self.history.push(action.raw);
                         self.exit_history_recall();
                         self.should_quit = true;
-                        let _ = command_tx.send(TuiCommand::Quit).await;
+                        let _ = command_tx.send(TuiCommand::Quit { confirmed: true }).await;
                         UiActionOutcome::accepted_message("quit requested")
                     }
                     SlashResult::NotACommand => UiActionOutcome::rejected("not a slash command"),

--- a/docs/stream-idle-boundary-semantics.md
+++ b/docs/stream-idle-boundary-semantics.md
@@ -1,0 +1,110 @@
+---
+id: stream-idle-boundary-semantics
+title: "Auditable stream idle and boundary semantics"
+status: seed
+tags: [runtime, providers, streaming, audit, operator-agency]
+open_questions:
+  - "[assumption] Every provider adapter can classify a post-block boundary as terminal, more-content/reasoning expected, or unknown without provider-name checks in the shared loop."
+  - "[assumption] Existing AgentEvent projections and audit sinks can carry structured watchdog transitions without leaking chain-of-thought or sensitive provider payloads."
+  - "[assumption] A default 90s active threshold plus 90s ambiguity grace is tolerable across supported cloud and local providers; provider/profile overrides remain bounded."
+  - "What assumptions is this design making that haven't been stated? In particular, do transport heartbeats, usage events, and repeated boundary markers count as semantic progress for any supported provider?"
+  - "[assumption] Provider adapters can reliably classify explicit boundaries as MoreReasoning, MoreContent, Terminal, or Unknown without inspecting hidden reasoning content."
+  - "[assumption] A 180-second default cap for unknown post-block silence is long enough for current providers while materially improving recovery UX."
+  - "[assumption] Existing AgentEvent/audit sinks can persist structured watchdog decisions without exposing raw chain-of-thought or requiring a new telemetry backend."
+  - "[assumption] A 250ms cooperative teardown grace is sufficient before forced abort while still feeling immediate to operators; validate with local, cloud, tool-child, and extension-child cancellation tests."
+  - "What `/exit` confirmation policy should apply across TUI, CLI, web, ACP, and IPC, and which explicit force-exit form bypasses confirmation?"
+dependencies: []
+related: []
+---
+
+# Auditable stream idle and boundary semantics
+
+## Overview
+
+Replace implicit post-block timeout promotion with provider-normalized boundary expectations, dual transport/semantic-progress clocks, bounded ambiguity escalation, and auditable operator extensions. This prevents unexplained silence from inheriting the full reasoning budget while preserving providers that interleave reasoning and visible replies.
+
+## Research
+
+### Current implementation evidence
+
+`core/crates/omegon/src/loop.rs` currently maps TextEnd/ThinkingEnd/ToolCallEnd to one AmbiguousSilent phase, losing why the boundary occurred. StreamIdlePolicy then grants that phase the reasoning budget. `core/crates/omegon/src/providers.rs` already has adapter-local phase knowledge (for example Anthropic content_block_start/stop and SsePhaseGate), but provider and consumer watchdogs can disagree. The design must establish one normalized semantic source and prevent independent blind promotion.
+
+### Agency gap in current cancellation path
+
+The current `CancelActiveTurn` path is cooperative: TUI input routes Esc/Ctrl+C to a runtime command and `loop.rs` selects the token during LLM streaming, but this alone does not prove descendants terminate, prevent late event publication, or make readiness independent of worker return. The required semantic is supervisor-enforced revocation with generation-scoped publication/mutation authority and owned child handles.
+
+## Decisions
+
+### Normalize provider boundaries before the shared loop
+
+**Status:** accepted
+
+**Rationale:** The adapter owns protocol semantics. The shared loop consumes BoundaryExpectation::{MoreReasoning, MoreContent, Terminal, Unknown} and never branches on provider names.
+
+### Track transport activity and semantic progress separately
+
+**Status:** accepted
+
+**Rationale:** Bytes, pings, empty deltas, and repeated phase markers prove connection liveness but cannot extend a turn indefinitely. Only content/tool/reasoning progress or a meaningful authoritative transition resets semantic deadlines.
+
+### Make every watchdog transition auditable
+
+**Status:** accepted
+
+**Rationale:** Emit structured events for phase changes, threshold selection, ambiguity warnings, operator extensions, timeout/EOF terminalization, and retry disposition. Include turn/provider/model IDs, prior/new phase, boundary expectation, elapsed durations, configured budgets, evidence counters, and provenance; exclude raw reasoning and secrets.
+
+### Bound ambiguity and operator extensions
+
+**Status:** accepted
+
+**Rationale:** Unknown post-block silence warns at 90s and terminalizes at 180s by default. Operator keep-waiting grants a bounded interval, records actor/surface/time/reason, and cannot disable the absolute turn ceiling.
+
+### Operator interrupt is enforced teardown, not advisory cancellation
+
+**Status:** accepted
+
+**Rationale:** Esc/Ctrl+C transfers authority to the supervisor immediately. The supervisor closes admission for the active turn, revokes its capability to publish events or mutate session state, cancels provider/tool/extension children, and force-aborts non-cooperative tasks after a short bounded grace. Provider acknowledgement is not required for the TUI to become ready.
+
+### Separate turn interruption from destructive process exit
+
+**Status:** accepted
+
+**Rationale:** Esc/Ctrl+C terminalizes only the active turn and preserves queued/draft work. `/exit` during an active turn is a destructive session/process operation: require confirmation by default, then revoke the turn, terminate descendants, flush bounded durable state, restore terminal modes, and exit without waiting indefinitely for upstream cooperation.
+
+### Extension process lifetime has explicit supervisor ownership
+
+**Status:** accepted
+
+**Rationale:** Fold the extension hang breakfix into authoritative terminalization. Cloned RPC/polling handles may observe services but must not own child lifetime. Full session shutdown closes admission and respawn, cancels polling, gracefully closes then kills and reaps canonical extension children; turn interruption only revokes turn-owned extension calls.
+
+## Open Questions
+
+- [assumption] Every provider adapter can classify a post-block boundary as terminal, more-content/reasoning expected, or unknown without provider-name checks in the shared loop.
+- [assumption] Existing AgentEvent projections and audit sinks can carry structured watchdog transitions without leaking chain-of-thought or sensitive provider payloads.
+- [assumption] A default 90s active threshold plus 90s ambiguity grace is tolerable across supported cloud and local providers; provider/profile overrides remain bounded.
+- What assumptions is this design making that haven't been stated? In particular, do transport heartbeats, usage events, and repeated boundary markers count as semantic progress for any supported provider?
+- [assumption] Provider adapters can reliably classify explicit boundaries as MoreReasoning, MoreContent, Terminal, or Unknown without inspecting hidden reasoning content.
+- [assumption] A 180-second default cap for unknown post-block silence is long enough for current providers while materially improving recovery UX.
+- [assumption] Existing AgentEvent/audit sinks can persist structured watchdog decisions without exposing raw chain-of-thought or requiring a new telemetry backend.
+- [assumption] A 250ms cooperative teardown grace is sufficient before forced abort while still feeling immediate to operators; validate with local, cloud, tool-child, and extension-child cancellation tests.
+- What `/exit` confirmation policy should apply across TUI, CLI, web, ACP, and IPC, and which explicit force-exit form bypasses confirmation?
+
+## Implementation Notes
+
+### Constraints
+
+- No provider-name branching in the shared loop
+- No raw reasoning text, credentials, or full tool arguments in watchdog audit records
+- Heartbeats and empty deltas never reset semantic progress deadlines
+- Operator extension remains bounded by an absolute turn ceiling
+- Stream EOF without an authoritative terminal event remains abnormal
+- Esc/Ctrl+C revokes the active turn immediately; readiness never depends on provider acknowledgement
+- Revoked turn IDs cannot publish message/tool/terminal events or mutate conversation/session state
+- Supervisor owns durable state and all spawned child handles for provider, tool, terminal, delegate, extension, MCP, and subprocess work
+- Cooperative cancellation grace is short and bounded; remaining child tasks/process groups are force-aborted/killed afterward
+- TUI emits authoritative cancelled TurnEnd/AgentEnd and becomes input-ready before background cleanup finishes
+- Late events from revoked generations are dropped and audited
+- Queued prompts and editor drafts survive turn interruption
+- `/exit` during an active turn requires confirmation by default and performs destructive session/process teardown
+- Confirmed exit uses bounded state flush and terminal restoration; it does not wait indefinitely for upstream cleanup
+- A force-exit command or repeated explicit confirmation may bypass the prompt only when provenance is operator-authenticated


### PR DESCRIPTION
## Summary
- add provider-normalized, phase-aware stream-idle watchdog semantics
- make active-turn cancellation authoritative and require confirmed destructive quit
- give extension supervisors explicit ownership and bounded shutdown across runtime surfaces
- document stream-idle boundary semantics and add deterministic regression coverage

## Validation
- `just test-crate omegon` — 4251 passed, 0 failed, 2 ignored; integration suites passed
- `just clippy-changed`
- `cargo check -p omegon --tests`
- `git diff --check`