### PR TITLE
fix(tools): bind stored secrets into child environments

### DIFF
--- a/core/crates/omegon/src/setup.rs
+++ b/core/crates/omegon/src/setup.rs
@@ -1055,6 +1055,7 @@ impl AgentSetup {
         } else {
             core_tools
         };
+        let core_tools = core_tools.with_secrets(secrets.clone());
         bus.register(Box::new(features::adapter::ToolAdapter::new(
             "core-tools",
             Box::new(core_tools),

--- a/core/crates/omegon/src/tools/bash.rs
+++ b/core/crates/omegon/src/tools/bash.rs
@@ -115,13 +115,25 @@ pub async fn execute_with_boundary(
     cancel: CancellationToken,
     boundary: Option<super::WorkspaceBoundary>,
 ) -> Result<ToolResult> {
-    execute_streaming(
+    execute_with_boundary_and_env(command, cwd, timeout_secs, cancel, boundary, &[]).await
+}
+
+pub async fn execute_with_boundary_and_env(
+    command: &str,
+    cwd: &Path,
+    timeout_secs: Option<u64>,
+    cancel: CancellationToken,
+    boundary: Option<super::WorkspaceBoundary>,
+    env: &[(String, String)],
+) -> Result<ToolResult> {
+    execute_streaming_with_env(
         command,
         cwd,
         timeout_secs,
         cancel,
         ToolProgressSink::noop(),
         boundary,
+        env,
     )
     .await
 }
@@ -143,6 +155,18 @@ pub async fn execute_streaming(
     cancel: CancellationToken,
     sink: ToolProgressSink,
     boundary: Option<super::WorkspaceBoundary>,
+) -> Result<ToolResult> {
+    execute_streaming_with_env(command, cwd, timeout_secs, cancel, sink, boundary, &[]).await
+}
+
+pub async fn execute_streaming_with_env(
+    command: &str,
+    cwd: &Path,
+    timeout_secs: Option<u64>,
+    cancel: CancellationToken,
+    sink: ToolProgressSink,
+    boundary: Option<super::WorkspaceBoundary>,
+    env: &[(String, String)],
 ) -> Result<ToolResult> {
     let start = Instant::now();
 
@@ -218,6 +242,7 @@ pub async fn execute_streaming(
     cmd.args(["-c", command])
         .current_dir(cwd)
         .envs(git_discovery_env(cwd))
+        .envs(env.iter().map(|(name, value)| (name, value)))
         .stdin(std::process::Stdio::null()) // /dev/null — commands needing input fail fast
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped())

--- a/core/crates/omegon/src/tools/mod.rs
+++ b/core/crates/omegon/src/tools/mod.rs
@@ -26,6 +26,7 @@ pub mod web_search;
 pub mod whoami;
 pub mod write;
 
+pub(crate) mod secret_env;
 pub mod secret_tools;
 
 // Phase 0+ stubs:
@@ -631,6 +632,7 @@ pub struct CoreTools {
     /// Workspace boundary enforcer — shared with other tool providers.
     boundary: WorkspaceBoundary,
     terminal_tool_enabled: bool,
+    secrets: Option<std::sync::Arc<omegon_secrets::SecretsManager>>,
 }
 
 impl CoreTools {
@@ -641,6 +643,7 @@ impl CoreTools {
             repo_model: None,
             boundary,
             terminal_tool_enabled: true,
+            secrets: None,
         }
     }
 
@@ -655,6 +658,7 @@ impl CoreTools {
             repo_model: Some(repo_model),
             boundary,
             terminal_tool_enabled: true,
+            secrets: None,
         }
     }
 
@@ -662,6 +666,11 @@ impl CoreTools {
     pub fn with_settings(mut self, settings: crate::settings::SharedSettings) -> Self {
         self.terminal_tool_enabled = settings.lock().map(|s| s.terminal_tool).unwrap_or(true);
         self.boundary = self.boundary.with_settings(settings);
+        self
+    }
+
+    pub fn with_secrets(mut self, secrets: std::sync::Arc<omegon_secrets::SecretsManager>) -> Self {
+        self.secrets = Some(secrets);
         self
     }
 

--- a/core/crates/omegon/src/tools/secret_env.rs
+++ b/core/crates/omegon/src/tools/secret_env.rs
@@ -1,0 +1,119 @@
+use std::collections::BTreeMap;
+
+use anyhow::{Context, anyhow, bail};
+use serde_json::Value;
+
+/// Process-local environment variables resolved from named Omegon secrets.
+///
+/// The names are safe to retain in diagnostics; values must only be passed to
+/// a child process and through the session redactor.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct SecretEnvBindings {
+    values: Vec<(String, String)>,
+}
+
+impl SecretEnvBindings {
+    pub(crate) fn resolve(
+        args: &Value,
+        secrets: Option<&omegon_secrets::SecretsManager>,
+    ) -> anyhow::Result<Self> {
+        let Some(requested) = args.get("secret_env") else {
+            return Ok(Self::default());
+        };
+        let requested = requested.as_object().ok_or_else(|| {
+            anyhow!("'secret_env' must be an object mapping environment names to secret names")
+        })?;
+        if requested.is_empty() {
+            return Ok(Self::default());
+        }
+        let secrets = secrets.ok_or_else(|| {
+            anyhow!("secret environment bindings are unavailable in this runtime")
+        })?;
+
+        // Validate the full contract before resolving any recipe. This prevents
+        // malformed requests from causing partial keychain/Vault side effects.
+        let mut names = BTreeMap::new();
+        for (env_name, secret_name) in requested {
+            validate_env_name(env_name)?;
+            let secret_name = secret_name
+                .as_str()
+                .ok_or_else(|| anyhow!("secret_env binding for '{env_name}' must name a secret"))?;
+            validate_secret_name(secret_name)
+                .with_context(|| format!("invalid secret_env binding for '{env_name}'"))?;
+            names.insert(env_name.clone(), secret_name.to_string());
+        }
+
+        // Resolve all values before returning anything spawnable. `resolve`
+        // registers successful values with the manager's redactor.
+        let mut values = Vec::with_capacity(names.len());
+        for (env_name, secret_name) in names {
+            let value = secrets.resolve(&secret_name).ok_or_else(|| {
+                anyhow!("secret_env could not resolve secret '{secret_name}' for '{env_name}'")
+            })?;
+            values.push((env_name, value));
+        }
+        Ok(Self { values })
+    }
+
+    pub(crate) fn iter(&self) -> impl Iterator<Item = (&str, &str)> {
+        self.values
+            .iter()
+            .map(|(name, value)| (name.as_str(), value.as_str()))
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.values.is_empty()
+    }
+}
+
+fn validate_env_name(name: &str) -> anyhow::Result<()> {
+    let mut chars = name.chars();
+    let Some(first) = chars.next() else {
+        bail!("secret_env environment name cannot be empty");
+    };
+    if !(first == '_' || first.is_ascii_alphabetic())
+        || !chars.all(|ch| ch == '_' || ch.is_ascii_alphanumeric())
+    {
+        bail!("invalid secret_env environment name '{name}'");
+    }
+    Ok(())
+}
+
+fn validate_secret_name(name: &str) -> anyhow::Result<()> {
+    if name.trim().is_empty() || name.contains('\0') {
+        bail!("secret name cannot be empty or contain NUL");
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejects_invalid_environment_names() {
+        for name in ["", "9TOKEN", "A=B", "BAD-NAME", "A\0B"] {
+            assert!(validate_env_name(name).is_err(), "accepted {name:?}");
+        }
+        for name in ["TOKEN", "_TOKEN", "GITHUB_TOKEN_2"] {
+            assert!(validate_env_name(name).is_ok(), "rejected {name:?}");
+        }
+    }
+
+    #[test]
+    fn absent_binding_requires_no_secret_manager() {
+        let bindings = SecretEnvBindings::resolve(&serde_json::json!({}), None).unwrap();
+        assert!(bindings.is_empty());
+    }
+
+    #[test]
+    fn binding_without_secret_manager_fails_before_spawn() {
+        let error = SecretEnvBindings::resolve(
+            &serde_json::json!({"secret_env": {"GH_TOKEN": "GITHUB_TOKEN"}}),
+            None,
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("unavailable"));
+        assert!(!error.to_string().contains("secret-value"));
+    }
+}


### PR DESCRIPTION
## Summary
- add explicit `secret_env` bindings for foreground bash and managed terminal starts
- resolve values through the authoritative Omegon secrets manager without shell interpolation
- redact streaming output, final results, terminal reads, completion tails, and transcripts
- reject host-terminal launches when secret bindings are requested

## Validation
- `just test-crate omegon` — 4261 passed, 0 failed, 2 ignored; integration suites passed
- `just clippy-changed`
- `git diff --check`

## Security
Bindings are explicit and process-local. Secret names and values are not persisted in terminal metadata or command text.