### PR TITLE
fix(runtime): harden terminal-loss teardown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [Semantic V
 
 ### Fixed
 
+- Hardened interactive terminal-loss teardown so loss of the controlling TTY authoritatively cancels active work and IPC ingress, restores terminal modes, persists sessions even when another task retains shared state, and still reaches bridge and extension shutdown. Extension startup and shutdown now reap failed children and terminate dedicated process groups, while TUI system notifications have per-card and aggregate retention bounds to prevent runaway memory growth.
+
 - Added `OLLAMA_API_KEY` to the first-party `/secrets` inventory and ensured logical Ollama Cloud routes participate in discovery refresh even without a conventional registry endpoint record. Retired `qwen3-coder:480b-cloud` catalog data was replaced with the verified `qwen3.5:397b` route.
 
 - Fixed the native TUI remaining locally active after a completed first turn when `AgentEnd` was delayed or lost, which rendered the answer but blocked the operator from submitting a second turn. Authoritative `supervisor_completed` lifecycle events and idle runtime-queue snapshots now bypass presentation buffering and idempotently reconcile streaming, busy, interrupt, spinner, and tool state. Parallel terminal-completion coverage was also isolated from the process-global registry and broadcast channel. The repaired release binary at `537dee1` passed the full Omegon suite (4,220 passed, 0 failed, 2 ignored), and an operator subsequently verified the original scribe-session reproduction by completing consecutive turns without the lockup.

--- a/core/crates/omegon/src/extensions/mod.rs
+++ b/core/crates/omegon/src/extensions/mod.rs
@@ -1408,14 +1408,30 @@ async fn spawn_native(
         (None, None)
     };
 
-    let handshake = handshake(
+    let handshake = match handshake(
         &mut handles,
         manifest,
         ext_dir,
         resolved_secrets,
         notification_pair.0.as_ref(),
     )
-    .await?;
+    .await
+    {
+        Ok(handshake) => handshake,
+        Err(error) => {
+            // Every successfully spawned child has an immediate reaping
+            // obligation, including failed startup negotiation. `Drop` can
+            // request a kill but cannot synchronously wait for Tokio children.
+            if let Err(cleanup_error) = handles.shutdown(std::time::Duration::ZERO).await {
+                tracing::warn!(
+                    extension = %manifest.extension.name,
+                    %cleanup_error,
+                    "failed to reap extension after handshake failure"
+                );
+            }
+            return Err(error);
+        }
+    };
 
     tracing::info!(
         name = %manifest.extension.name,
@@ -1515,14 +1531,30 @@ async fn spawn_container(
         (None, None)
     };
 
-    let handshake = handshake(
+    let handshake = match handshake(
         &mut handles,
         manifest,
         ext_dir,
         resolved_secrets,
         notification_pair.0.as_ref(),
     )
-    .await?;
+    .await
+    {
+        Ok(handshake) => handshake,
+        Err(error) => {
+            // Every successfully spawned child has an immediate reaping
+            // obligation, including failed startup negotiation. `Drop` can
+            // request a kill but cannot synchronously wait for Tokio children.
+            if let Err(cleanup_error) = handles.shutdown(std::time::Duration::ZERO).await {
+                tracing::warn!(
+                    extension = %manifest.extension.name,
+                    %cleanup_error,
+                    "failed to reap extension after handshake failure"
+                );
+            }
+            return Err(error);
+        }
+    };
 
     tracing::info!(
         name = %manifest.extension.name,

--- a/core/crates/omegon/src/extensions/mod.rs
+++ b/core/crates/omegon/src/extensions/mod.rs
@@ -107,6 +107,27 @@ impl ExtensionNotificationSink {
     }
 }
 
+fn configure_extension_process(command: &mut tokio::process::Command) {
+    command.kill_on_drop(true);
+    #[cfg(unix)]
+    command.process_group(0);
+}
+
+#[cfg(unix)]
+fn kill_extension_process_group(pid: Option<u32>) {
+    let Some(pid) = pid.and_then(|pid| i32::try_from(pid).ok()) else {
+        return;
+    };
+    // SAFETY: extension commands are spawned as leaders of dedicated process
+    // groups, so a negative PID cannot target the Omegon host process.
+    unsafe {
+        libc::kill(-pid, libc::SIGKILL);
+    }
+}
+
+#[cfg(not(unix))]
+fn kill_extension_process_group(_pid: Option<u32>) {}
+
 /// Handles for communicating with an extension process.
 pub struct ProcessHandles {
     child: tokio::process::Child,
@@ -195,6 +216,7 @@ impl ProcessHandles {
     async fn shutdown(&mut self, grace: std::time::Duration) -> Result<()> {
         use tokio::io::AsyncWriteExt as _;
 
+        let pid = self.child.id();
         let _ = self.stdin.shutdown().await;
         let deadline = tokio::time::Instant::now() + grace;
         loop {
@@ -207,6 +229,7 @@ impl ProcessHandles {
             tokio::time::sleep(std::time::Duration::from_millis(25)).await;
         }
 
+        kill_extension_process_group(pid);
         self.child.kill().await?;
         let _ = self.child.wait().await?;
         Ok(())
@@ -221,6 +244,7 @@ impl Drop for ProcessHandles {
         // `cargo test` can hang after assertions complete. Respawn paths still
         // perform explicit async kill/wait; this synchronous drop path is the
         // deterministic backstop for tests and normal shutdown.
+        kill_extension_process_group(self.child.id());
         let _ = self.child.start_kill();
     }
 }
@@ -1067,6 +1091,7 @@ async fn spawn_process_handles(
         RuntimeConfig::Native { .. } => {
             let binary = manifest.native_binary_path(ext_dir)?;
             let mut cmd = clean_command(&binary, manifest)?;
+            configure_extension_process(&mut cmd);
             cmd.arg("--rpc")
                 .stdin(std::process::Stdio::piped())
                 .stdout(std::process::Stdio::piped())
@@ -1076,6 +1101,7 @@ async fn spawn_process_handles(
         RuntimeConfig::Oci { .. } => {
             let image = manifest.oci_image()?;
             let mut cmd = clean_command("podman", manifest)?;
+            configure_extension_process(&mut cmd);
             cmd.args(["run", "--rm", "-i"]);
             for (name, value) in resolved_runtime_env(manifest)? {
                 cmd.args(["--env", &format!("{name}={value}")]);

--- a/core/crates/omegon/src/extensions/mod.rs
+++ b/core/crates/omegon/src/extensions/mod.rs
@@ -553,7 +553,7 @@ impl ExtensionFeature {
                     self.runtime.name
                 )
             })?;
-        let handshake = handshake(
+        let handshake = match handshake(
             &mut handles,
             &self.runtime.manifest,
             &self.runtime.ext_dir,
@@ -561,12 +561,22 @@ impl ExtensionFeature {
             self.runtime.notification_sink.as_ref(),
         )
         .await
-        .map_err(|err| {
-            anyhow!(
-                "extension '{}' transport failed ({cause}); respawn handshake failed: {err}",
-                self.runtime.name
-            )
-        })?;
+        {
+            Ok(handshake) => handshake,
+            Err(err) => {
+                if let Err(cleanup_error) = handles.shutdown(std::time::Duration::ZERO).await {
+                    tracing::warn!(
+                        extension = %self.runtime.name,
+                        %cleanup_error,
+                        "failed to reap extension after respawn handshake failure"
+                    );
+                }
+                return Err(anyhow!(
+                    "extension '{}' transport failed ({cause}); respawn handshake failed: {err}",
+                    self.runtime.name
+                ));
+            }
+        };
         self.request_id.store(handles.next_id, Ordering::SeqCst);
         *guard = Some(handles);
         tracing::warn!(
@@ -1082,8 +1092,23 @@ async fn spawn_process_handles(
         spawn_extension_stderr_drain(extension_name, stderr);
     }
 
-    let stdin = child.stdin.take().ok_or_else(|| anyhow!("no stdin"))?;
-    let stdout = child.stdout.take().ok_or_else(|| anyhow!("no stdout"))?;
+    let stdin = match child.stdin.take() {
+        Some(stdin) => stdin,
+        None => {
+            let _ = child.kill().await;
+            let _ = child.wait().await;
+            return Err(anyhow!("no stdin"));
+        }
+    };
+    let stdout = match child.stdout.take() {
+        Some(stdout) => stdout,
+        None => {
+            drop(stdin);
+            let _ = child.kill().await;
+            let _ = child.wait().await;
+            return Err(anyhow!("no stdout"));
+        }
+    };
     Ok(ProcessHandles::new(child, stdin, stdout))
 }
 
@@ -2343,6 +2368,65 @@ binary = "sdk-extension.sh"
         )
         .unwrap();
         script
+    }
+
+    fn write_failing_extension(dir: &Path) -> PathBuf {
+        let script = dir.join("failing-extension.sh");
+        std::fs::write(
+            &script,
+            r#"#!/bin/sh
+printf '%s\n' $$ > "$1"
+while IFS= read -r line; do
+  printf '%s\n' '{"jsonrpc":"2.0","id":1,"error":{"code":-32603,"message":"forced handshake failure"}}'
+done
+"#,
+        )
+        .unwrap();
+        let mut perms = std::fs::metadata(&script).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&script, perms).unwrap();
+        script
+    }
+
+    async fn assert_pid_reaped(pid: u32) {
+        for _ in 0..20 {
+            let status = std::process::Command::new("kill")
+                .args(["-0", &pid.to_string()])
+                .status()
+                .unwrap();
+            if !status.success() {
+                return;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+        panic!("extension child {pid} still exists after failed handshake");
+    }
+
+    #[tokio::test]
+    async fn failed_native_handshake_kills_and_reaps_child() {
+        let _guard = SDK_COMPAT_SPAWN_TEST_LOCK.lock().await;
+        let temp = tempfile::tempdir().unwrap();
+        let script = write_failing_extension(temp.path());
+        let pid_file = temp.path().join("pid");
+        let mut command = tokio::process::Command::new(&script);
+        command
+            .arg(&pid_file)
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::null());
+        let mut child = command.spawn().unwrap();
+        let stdin = child.stdin.take().unwrap();
+        let stdout = child.stdout.take().unwrap();
+        let mut handles = ProcessHandles::new(child, stdin, stdout);
+        handles.rpc_call("initialize", json!({})).await.unwrap_err();
+        handles.shutdown(std::time::Duration::ZERO).await.unwrap();
+
+        let pid: u32 = std::fs::read_to_string(pid_file)
+            .unwrap()
+            .trim()
+            .parse()
+            .unwrap();
+        assert_pid_reaped(pid).await;
     }
 
     #[tokio::test]

--- a/core/crates/omegon/src/main.rs
+++ b/core/crates/omegon/src/main.rs
@@ -4021,6 +4021,15 @@ fn background_completion_prompt(
     )
 }
 
+async fn save_shared_interactive_session(
+    state: &Arc<tokio::sync::Mutex<InteractiveAgentState>>,
+    cwd: &Path,
+    session_id: &str,
+) -> anyhow::Result<PathBuf> {
+    let state = state.lock().await;
+    session::save_session(&state.conversation, cwd, Some(session_id))
+}
+
 fn signal_tui_boundary_exit(exit: &CancellationToken) {
     exit.cancel();
 }
@@ -6128,9 +6137,32 @@ fn build_tui_secret_readiness_snapshot(
                                 lifecycle.transition("worker_revoked_by_terminal_loss", runtime.queue_depth(), &events_tx);
                                 mark_interactive_session_busy(&agent.dashboard_handles, false);
                                 let _ = events_tx.send(AgentEvent::AgentEnd);
-                                runtime_state = Arc::try_unwrap(state_for_turn)
-                                    .map_err(|_| anyhow::anyhow!("terminal-revoked worker retained durable state after IPC cancellation"))?
-                                    .into_inner();
+                                runtime_state = match Arc::try_unwrap(state_for_turn) {
+                                    Ok(state) => state.into_inner(),
+                                    Err(shared_state) => {
+                                        if !cli.no_session {
+                                            match save_shared_interactive_session(
+                                                &shared_state,
+                                                &agent.cwd,
+                                                &agent.session_id,
+                                            )
+                                            .await
+                                            {
+                                                Ok(path) => tracing::debug!(
+                                                    path = %path.display(),
+                                                    session_id = %agent.session_id,
+                                                    "saved retained interactive state after terminal loss"
+                                                ),
+                                                Err(error) => tracing::error!(
+                                                    %error,
+                                                    session_id = %agent.session_id,
+                                                    "failed to save retained interactive state after terminal loss"
+                                                ),
+                                            }
+                                        }
+                                        return Ok(());
+                                    }
+                                };
                                 break;
                             }
                             turn_result = &mut turn_task => {
@@ -9139,6 +9171,28 @@ mod tests {
             voice_notification_receivers: vec![],
             voice_polling_handles: vec![],
         }
+    }
+
+    #[tokio::test]
+    async fn retained_terminal_state_can_be_saved_without_unique_arc_ownership() {
+        let setup = test_agent_setup();
+        let cwd = setup.cwd.clone();
+        let session_id = "2026-08-12T12-00-00_deadbeef".to_string();
+        let state = std::sync::Arc::new(tokio::sync::Mutex::new(InteractiveAgentState {
+            bus: setup.bus,
+            context_manager: setup.context_manager,
+            conversation: setup.conversation,
+            inference_runtime: setup.inference_runtime,
+        }));
+        let retained = state.clone();
+
+        let path = super::save_shared_interactive_session(&state, &cwd, &session_id)
+            .await
+            .expect("retained state remains persistable");
+
+        assert!(path.exists());
+        drop(retained);
+        let _ = std::fs::remove_file(path);
     }
 
     #[test]

--- a/core/crates/omegon/src/main.rs
+++ b/core/crates/omegon/src/main.rs
@@ -6120,6 +6120,7 @@ fn build_tui_secret_readiness_snapshot(
                         tokio::select! {
                             _ = tui_exit.cancelled() => {
                                 quit_after_turn = true;
+                                ipc_cancel.cancel();
                                 turn_cancel.cancel();
                                 turn_task.abort();
                                 let _ = (&mut turn_task).await;
@@ -6128,7 +6129,7 @@ fn build_tui_secret_readiness_snapshot(
                                 mark_interactive_session_busy(&agent.dashboard_handles, false);
                                 let _ = events_tx.send(AgentEvent::AgentEnd);
                                 runtime_state = Arc::try_unwrap(state_for_turn)
-                                    .map_err(|_| anyhow::anyhow!("terminal-revoked worker retained durable state"))?
+                                    .map_err(|_| anyhow::anyhow!("terminal-revoked worker retained durable state after IPC cancellation"))?
                                     .into_inner();
                                 break;
                             }
@@ -6354,6 +6355,9 @@ fn build_tui_secret_readiness_snapshot(
     // owns terminal modes. Stop it and restore those modes before printing
     // session diagnostics or exec-restarting; otherwise those writes land in
     // the still-active alternate screen and corrupt the next TUI frame.
+    // Revoke IPC/background ingress before waiting on any presentation task.
+    // Terminal loss must not leave sender clones able to prolong teardown.
+    ipc_cancel.cancel();
     tui_handle.abort();
     let _ = tui_handle.await;
     let _ = io::stdout().execute(crossterm::event::DisableBracketedPaste);

--- a/core/crates/omegon/src/main.rs
+++ b/core/crates/omegon/src/main.rs
@@ -4021,13 +4021,32 @@ fn background_completion_prompt(
     )
 }
 
+const RETAINED_STATE_SAVE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
+
+async fn save_shared_interactive_session_with_timeout(
+    state: &Arc<tokio::sync::Mutex<InteractiveAgentState>>,
+    cwd: &Path,
+    session_id: &str,
+    timeout: std::time::Duration,
+) -> anyhow::Result<PathBuf> {
+    let state = tokio::time::timeout(timeout, state.lock())
+        .await
+        .map_err(|_| anyhow::anyhow!("timed out waiting for retained interactive state"))?;
+    session::save_session(&state.conversation, cwd, Some(session_id))
+}
+
 async fn save_shared_interactive_session(
     state: &Arc<tokio::sync::Mutex<InteractiveAgentState>>,
     cwd: &Path,
     session_id: &str,
 ) -> anyhow::Result<PathBuf> {
-    let state = state.lock().await;
-    session::save_session(&state.conversation, cwd, Some(session_id))
+    save_shared_interactive_session_with_timeout(
+        state,
+        cwd,
+        session_id,
+        RETAINED_STATE_SAVE_TIMEOUT,
+    )
+    .await
 }
 
 fn signal_tui_boundary_exit(exit: &CancellationToken) {
@@ -6148,11 +6167,13 @@ fn build_tui_secret_readiness_snapshot(
                                             )
                                             .await
                                             {
-                                                Ok(path) => tracing::debug!(
-                                                    path = %path.display(),
-                                                    session_id = %agent.session_id,
-                                                    "saved retained interactive state after terminal loss"
-                                                ),
+                                                Ok(path) => {
+                                                    tracing::debug!(
+                                                        path = %path.display(),
+                                                        session_id = %agent.session_id,
+                                                        "saved retained interactive state after terminal loss"
+                                                    );
+                                                }
                                                 Err(error) => tracing::error!(
                                                     %error,
                                                     session_id = %agent.session_id,
@@ -6160,6 +6181,8 @@ fn build_tui_secret_readiness_snapshot(
                                                 ),
                                             }
                                         }
+                                        extension_supervisors.shutdown().await;
+                                        bridge.read().await.shutdown().await;
                                         return Ok(());
                                     }
                                 };
@@ -9193,6 +9216,52 @@ mod tests {
         assert!(path.exists());
         drop(retained);
         let _ = std::fs::remove_file(path);
+    }
+
+    #[tokio::test]
+    async fn retained_terminal_state_save_times_out_when_lock_is_still_held() {
+        let setup = test_agent_setup();
+        let cwd = setup.cwd.clone();
+        let session_id = "2026-08-12T12-00-01_deadbeef";
+        let state = std::sync::Arc::new(tokio::sync::Mutex::new(InteractiveAgentState {
+            bus: setup.bus,
+            context_manager: setup.context_manager,
+            conversation: setup.conversation,
+            inference_runtime: setup.inference_runtime,
+        }));
+        let _guard = state.lock().await;
+
+        let error = super::save_shared_interactive_session_with_timeout(
+            &state,
+            &cwd,
+            session_id,
+            std::time::Duration::from_millis(1),
+        )
+        .await
+        .expect_err("held state lock must not hang terminal teardown");
+
+        assert!(error.to_string().contains("timed out"));
+    }
+
+    #[test]
+    fn retained_state_fallback_performs_resource_shutdown_before_return() {
+        let source = include_str!("main.rs");
+        let fallback = source
+            .split("Err(shared_state) =>")
+            .nth(1)
+            .and_then(|tail| tail.split("turn_result = &mut turn_task").next())
+            .expect("terminal-loss fallback source");
+        let extension_shutdown = fallback
+            .find("extension_supervisors.shutdown().await")
+            .expect("extension shutdown remains reachable");
+        let bridge_shutdown = fallback
+            .find("bridge.read().await.shutdown().await")
+            .expect("bridge shutdown remains reachable");
+        let return_position = fallback
+            .find("return Ok(())")
+            .expect("bounded fallback return");
+        assert!(extension_shutdown < return_position);
+        assert!(bridge_shutdown < return_position);
     }
 
     #[test]

--- a/core/crates/omegon/src/main.rs
+++ b/core/crates/omegon/src/main.rs
@@ -4021,13 +4021,8 @@ fn background_completion_prompt(
     )
 }
 
-async fn request_exit_after_tui_boundary(
-    command_tx: &operator_commands::OperatorCommandTx,
-) -> bool {
-    command_tx
-        .send(operator_commands::OperatorCommand::Quit { confirmed: true })
-        .await
-        .is_ok()
+fn signal_tui_boundary_exit(exit: &CancellationToken) {
+    exit.cancel();
 }
 
 async fn run_interactive_command(cli: &Cli) -> anyhow::Result<()> {
@@ -4534,15 +4529,14 @@ fn build_tui_secret_readiness_snapshot(
     // failure — must therefore revoke the coordinator instead of leaving it
     // running headless with IPC/background sender clones keeping its command
     // channel open.
-    let tui_lifecycle_tx = command_tx.clone();
+    let tui_exit = CancellationToken::new();
+    let tui_exit_signal = tui_exit.clone();
     let tui_handle = tokio::spawn(async move {
         let result = tui::run_tui(events_rx, command_tx, tui_config, tui_cancel, tui_settings).await;
         if let Err(error) = &result {
             tracing::error!(%error, "TUI terminated at the terminal boundary");
         }
-        if !request_exit_after_tui_boundary(&tui_lifecycle_tx).await {
-            tracing::debug!("interactive coordinator already stopped after TUI termination");
-        }
+        signal_tui_boundary_exit(&tui_exit_signal);
     });
 
     let ipc_cancel = tokio_util::sync::CancellationToken::new();
@@ -4606,9 +4600,13 @@ fn build_tui_secret_readiness_snapshot(
         let cmd = if let Some(cmd) = deferred_commands.pop_front() {
             cmd
         } else {
-            match command_rx.recv().await {
-                Some(cmd) => cmd,
-                None => break,
+            tokio::select! {
+                biased;
+                _ = tui_exit.cancelled() => break,
+                cmd = command_rx.recv() => match cmd {
+                    Some(cmd) => cmd,
+                    None => break,
+                },
             }
         };
 
@@ -6120,6 +6118,20 @@ fn build_tui_secret_readiness_snapshot(
 
                     loop {
                         tokio::select! {
+                            _ = tui_exit.cancelled() => {
+                                quit_after_turn = true;
+                                turn_cancel.cancel();
+                                turn_task.abort();
+                                let _ = (&mut turn_task).await;
+                                if let Ok(mut guard) = shared_cancel.lock() { guard.take(); }
+                                lifecycle.transition("worker_revoked_by_terminal_loss", runtime.queue_depth(), &events_tx);
+                                mark_interactive_session_busy(&agent.dashboard_handles, false);
+                                let _ = events_tx.send(AgentEvent::AgentEnd);
+                                runtime_state = Arc::try_unwrap(state_for_turn)
+                                    .map_err(|_| anyhow::anyhow!("terminal-revoked worker retained durable state"))?
+                                    .into_inner();
+                                break;
+                            }
                             turn_result = &mut turn_task => {
                                 if let Err(join_err) = turn_result {
                                     let message = format_interactive_turn_task_failure(&join_err);
@@ -9125,15 +9137,11 @@ mod tests {
         }
     }
 
-    #[tokio::test]
-    async fn tui_terminal_boundary_requests_authoritative_coordinator_exit() {
-        let (command_tx, mut command_rx) = tokio::sync::mpsc::channel(1);
-
-        assert!(super::request_exit_after_tui_boundary(&command_tx).await);
-        assert!(matches!(
-            command_rx.recv().await,
-            Some(operator_commands::OperatorCommand::Quit { confirmed: true })
-        ));
+    #[test]
+    fn tui_terminal_boundary_signal_is_authoritative_without_channel_capacity() {
+        let exit = CancellationToken::new();
+        super::signal_tui_boundary_exit(&exit);
+        assert!(exit.is_cancelled());
     }
 
     #[test]

--- a/core/crates/omegon/src/main.rs
+++ b/core/crates/omegon/src/main.rs
@@ -4021,6 +4021,15 @@ fn background_completion_prompt(
     )
 }
 
+async fn request_exit_after_tui_boundary(
+    command_tx: &operator_commands::OperatorCommandTx,
+) -> bool {
+    command_tx
+        .send(operator_commands::OperatorCommand::Quit { confirmed: true })
+        .await
+        .is_ok()
+}
+
 async fn run_interactive_command(cli: &Cli) -> anyhow::Result<()> {
     let local = tokio::task::LocalSet::new();
     local
@@ -4519,11 +4528,20 @@ fn build_tui_secret_readiness_snapshot(
     };
     let tui_cancel = shared_cancel.clone();
     let tui_settings = shared_settings.clone();
+    // The coordinator owns the process lifetime, while the TUI owns the
+    // interactive terminal. Any TUI terminal boundary — orderly return,
+    // terminal EOF/HUP surfaced as an I/O error, or partial initialization
+    // failure — must therefore revoke the coordinator instead of leaving it
+    // running headless with IPC/background sender clones keeping its command
+    // channel open.
+    let tui_lifecycle_tx = command_tx.clone();
     let tui_handle = tokio::spawn(async move {
-        if let Err(e) =
-            tui::run_tui(events_rx, command_tx, tui_config, tui_cancel, tui_settings).await
-        {
-            tracing::error!("TUI error: {e}");
+        let result = tui::run_tui(events_rx, command_tx, tui_config, tui_cancel, tui_settings).await;
+        if let Err(error) = &result {
+            tracing::error!(%error, "TUI terminated at the terminal boundary");
+        }
+        if !request_exit_after_tui_boundary(&tui_lifecycle_tx).await {
+            tracing::debug!("interactive coordinator already stopped after TUI termination");
         }
     });
 
@@ -9105,6 +9123,17 @@ mod tests {
             voice_notification_receivers: vec![],
             voice_polling_handles: vec![],
         }
+    }
+
+    #[tokio::test]
+    async fn tui_terminal_boundary_requests_authoritative_coordinator_exit() {
+        let (command_tx, mut command_rx) = tokio::sync::mpsc::channel(1);
+
+        assert!(super::request_exit_after_tui_boundary(&command_tx).await);
+        assert!(matches!(
+            command_rx.recv().await,
+            Some(operator_commands::OperatorCommand::Quit { confirmed: true })
+        ));
     }
 
     #[test]

--- a/core/crates/omegon/src/tui/conversation.rs
+++ b/core/crates/omegon/src/tui/conversation.rs
@@ -80,7 +80,24 @@ impl Default for TabState {
     }
 }
 
-const MAX_MERGED_SYSTEM_NOTIFICATION_BYTES: usize = 64 * 1024;
+const MAX_SYSTEM_NOTIFICATION_BYTES: usize = 64 * 1024;
+
+fn bounded_system_notification(text: &str) -> String {
+    if text.len() <= MAX_SYSTEM_NOTIFICATION_BYTES {
+        return text.to_string();
+    }
+
+    const ELLIPSIS: &str = "…";
+    let max_prefix_bytes = MAX_SYSTEM_NOTIFICATION_BYTES.saturating_sub(ELLIPSIS.len());
+    let mut boundary = max_prefix_bytes.min(text.len());
+    while boundary > 0 && !text.is_char_boundary(boundary) {
+        boundary -= 1;
+    }
+    let mut bounded = String::with_capacity(boundary + ELLIPSIS.len());
+    bounded.push_str(&text[..boundary]);
+    bounded.push_str(ELLIPSIS);
+    bounded
+}
 
 /// Conversation view state — segment list + scroll.
 pub struct ConversationView {
@@ -413,7 +430,7 @@ impl ConversationView {
                 })
                 .find(|existing| is_plan_progress_text(existing))
         {
-            *existing = text.to_string();
+            *existing = bounded_system_notification(text);
             self.conv_state.invalidate();
             self.conv_state.auto_scroll_to_bottom();
             return;
@@ -428,7 +445,7 @@ impl ConversationView {
                 text: ref mut existing,
             } = last.content
             && existing.len().saturating_add(text.len()).saturating_add(1)
-                <= MAX_MERGED_SYSTEM_NOTIFICATION_BYTES
+                <= MAX_SYSTEM_NOTIFICATION_BYTES
         {
             existing.push('\n');
             existing.push_str(text);
@@ -436,7 +453,8 @@ impl ConversationView {
             self.conv_state.auto_scroll_to_bottom();
             return;
         }
-        self.segments.push(Segment::system(text));
+        self.segments
+            .push(Segment::system(bounded_system_notification(text)));
         self.conv_state.invalidate();
         self.conv_state.auto_scroll_to_bottom();
     }
@@ -1870,6 +1888,18 @@ mod tests {
     }
 
     #[test]
+    fn one_oversized_system_notification_is_truncated_at_ingress() {
+        let mut cv = ConversationView::new();
+        cv.push_system(&"é".repeat(MAX_SYSTEM_NOTIFICATION_BYTES));
+
+        let SegmentContent::SystemNotification { text } = &cv.segments[0].content else {
+            panic!("expected system notification");
+        };
+        assert!(text.len() <= MAX_SYSTEM_NOTIFICATION_BYTES);
+        assert!(text.ends_with('…'));
+    }
+
+    #[test]
     fn repeated_system_notifications_roll_over_before_unbounded_growth() {
         let mut cv = ConversationView::new();
         let chunk = "x".repeat(16 * 1024);
@@ -1890,7 +1920,7 @@ mod tests {
         assert!(
             system_cards
                 .iter()
-                .all(|text| text.len() <= MAX_MERGED_SYSTEM_NOTIFICATION_BYTES + chunk.len())
+                .all(|text| text.len() <= MAX_SYSTEM_NOTIFICATION_BYTES)
         );
     }
 

--- a/core/crates/omegon/src/tui/conversation.rs
+++ b/core/crates/omegon/src/tui/conversation.rs
@@ -80,6 +80,8 @@ impl Default for TabState {
     }
 }
 
+const MAX_MERGED_SYSTEM_NOTIFICATION_BYTES: usize = 64 * 1024;
+
 /// Conversation view state — segment list + scroll.
 pub struct ConversationView {
     segments: Vec<Segment>,
@@ -418,11 +420,15 @@ impl ConversationView {
         }
 
         // Merge consecutive system notifications into a single card to avoid
-        // excessive vertical padding (each card has border overhead).
+        // excessive vertical padding (each card has border overhead). Bound
+        // the card: a repeated lifecycle/error producer must not turn this
+        // convenience merge into an unbounded String allocation storm.
         if let Some(last) = self.segments.last_mut()
             && let SegmentContent::SystemNotification {
                 text: ref mut existing,
             } = last.content
+            && existing.len().saturating_add(text.len()).saturating_add(1)
+                <= MAX_MERGED_SYSTEM_NOTIFICATION_BYTES
         {
             existing.push('\n');
             existing.push_str(text);
@@ -1861,6 +1867,31 @@ mod tests {
         assert!(cv.segments.iter().any(
             |segment| matches!(&segment.content, SegmentContent::ToolCard { name, complete: true, .. } if name == "read")
         ));
+    }
+
+    #[test]
+    fn repeated_system_notifications_roll_over_before_unbounded_growth() {
+        let mut cv = ConversationView::new();
+        let chunk = "x".repeat(16 * 1024);
+
+        for _ in 0..10 {
+            cv.push_system(&chunk);
+        }
+
+        let system_cards: Vec<_> = cv
+            .segments
+            .iter()
+            .filter_map(|segment| match &segment.content {
+                SegmentContent::SystemNotification { text } => Some(text),
+                _ => None,
+            })
+            .collect();
+        assert!(system_cards.len() > 1);
+        assert!(
+            system_cards
+                .iter()
+                .all(|text| text.len() <= MAX_MERGED_SYSTEM_NOTIFICATION_BYTES + chunk.len())
+        );
     }
 
     #[test]

--- a/core/crates/omegon/src/tui/conversation.rs
+++ b/core/crates/omegon/src/tui/conversation.rs
@@ -81,6 +81,7 @@ impl Default for TabState {
 }
 
 const MAX_SYSTEM_NOTIFICATION_BYTES: usize = 64 * 1024;
+const MAX_SYSTEM_NOTIFICATION_SEGMENTS: usize = 64;
 
 fn bounded_system_notification(text: &str) -> String {
     if text.len() <= MAX_SYSTEM_NOTIFICATION_BYTES {
@@ -418,6 +419,28 @@ impl ConversationView {
         self.conv_state.auto_scroll_to_bottom();
     }
 
+    fn enforce_system_notification_limit(&mut self) {
+        let mut excess = self
+            .segments
+            .iter()
+            .filter(|segment| matches!(segment.content, SegmentContent::SystemNotification { .. }))
+            .count()
+            .saturating_sub(MAX_SYSTEM_NOTIFICATION_SEGMENTS);
+        if excess == 0 {
+            return;
+        }
+        self.segments.retain(|segment| {
+            if excess > 0 && matches!(segment.content, SegmentContent::SystemNotification { .. }) {
+                excess -= 1;
+                false
+            } else {
+                true
+            }
+        });
+        self.selected_segment = None;
+        self.pinned_segment = None;
+    }
+
     pub fn push_system(&mut self, text: &str) {
         if is_plan_progress_text(text)
             && let Some(existing) = self
@@ -455,6 +478,7 @@ impl ConversationView {
         }
         self.segments
             .push(Segment::system(bounded_system_notification(text)));
+        self.enforce_system_notification_limit();
         self.conv_state.invalidate();
         self.conv_state.auto_scroll_to_bottom();
     }
@@ -1897,6 +1921,24 @@ mod tests {
         };
         assert!(text.len() <= MAX_SYSTEM_NOTIFICATION_BYTES);
         assert!(text.ends_with('…'));
+    }
+
+    #[test]
+    fn system_notification_history_has_an_aggregate_segment_cap() {
+        let mut cv = ConversationView::new();
+        for index in 0..(MAX_SYSTEM_NOTIFICATION_SEGMENTS + 10) {
+            cv.push_system(&format!(
+                "{}-{index}",
+                "x".repeat(MAX_SYSTEM_NOTIFICATION_BYTES)
+            ));
+        }
+
+        let system_count = cv
+            .segments
+            .iter()
+            .filter(|segment| matches!(segment.content, SegmentContent::SystemNotification { .. }))
+            .count();
+        assert_eq!(system_count, MAX_SYSTEM_NOTIFICATION_SEGMENTS);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- terminate interactive coordination when the controlling terminal disappears
- persist retained shared session state with a bounded lock wait
- cancel IPC ingress and shut down bridge/extension resources on fallback teardown
- reap failed extension children and terminate dedicated process groups
- bound per-card and aggregate TUI system-notification memory

## Validation

- `just test-commit` — 4,264 passed, 0 failed, 2 ignored; integration and black-box suites passed
- `just clippy-changed`
- `git diff --check`
