### PR TITLE
fix(stream): bound semantically stalled provider turns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [Semantic V
 
 ### Fixed
 
+- Distinguished provider transport heartbeats from semantic model progress so keepalives, unknown Codex Responses events, and repeated lifecycle markers cannot retain a stalled turn indefinitely. Streams now enforce phase-aware semantic-progress budgets plus a non-resettable absolute deadline, emit bounded stall diagnostics, and parse fragmented or CRLF SSE frames without repeatedly copying the unconsumed buffer.
+
 - Hardened interactive terminal-loss teardown so loss of the controlling TTY authoritatively cancels active work and IPC ingress, restores terminal modes, persists sessions even when another task retains shared state, and still reaches bridge and extension shutdown. Extension startup and shutdown now reap failed children and terminate dedicated process groups, while TUI system notifications have per-card and aggregate retention bounds to prevent runaway memory growth.
 
 - Added `OLLAMA_API_KEY` to the first-party `/secrets` inventory and ensured logical Ollama Cloud routes participate in discovery refresh even without a conventional registry endpoint record. Retired `qwen3-coder:480b-cloud` catalog data was replaced with the verified `qwen3.5:397b` route.

--- a/core/crates/omegon/src/bridge.rs
+++ b/core/crates/omegon/src/bridge.rs
@@ -170,6 +170,10 @@ pub enum LlmEvent {
     /// Initial event with partial message — we ignore the content but must accept the variant.
     #[serde(rename = "start")]
     Start,
+    /// Transport activity that carries no model-visible progress. This proves
+    /// the connection is alive but must not extend semantic-progress budgets.
+    #[serde(rename = "transport_heartbeat")]
+    TransportHeartbeat,
     #[serde(rename = "text_delta")]
     TextDelta { delta: String },
     #[serde(rename = "thinking_delta")]

--- a/core/crates/omegon/src/codex_events.rs
+++ b/core/crates/omegon/src/codex_events.rs
@@ -1,0 +1,76 @@
+use crate::bridge::LlmEvent;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum CodexEventClass {
+    SemanticStart,
+    TransportHeartbeat,
+    Other,
+}
+
+pub(super) fn classify_codex_event_type(event_type: &str) -> CodexEventClass {
+    match event_type {
+        "response.created" | "response.in_progress" => CodexEventClass::SemanticStart,
+        "response.content_part.added" | "response.reasoning_summary_part.added" => {
+            CodexEventClass::TransportHeartbeat
+        }
+        "response.output_text.delta"
+        | "response.reasoning_summary_text.delta"
+        | "response.output_item.added"
+        | "response.function_call_arguments.delta"
+        | "response.function_call_arguments.done"
+        | "response.output_item.done"
+        | "response.completed"
+        | "response.failed"
+        | "error" => CodexEventClass::Other,
+        _ => CodexEventClass::TransportHeartbeat,
+    }
+}
+
+pub(super) fn liveness_event_for_codex_type(event_type: &str) -> Option<LlmEvent> {
+    match classify_codex_event_type(event_type) {
+        CodexEventClass::SemanticStart => Some(LlmEvent::Start),
+        CodexEventClass::TransportHeartbeat => Some(LlmEvent::TransportHeartbeat),
+        CodexEventClass::Other => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lifecycle_events_are_semantic_start() {
+        for event_type in ["response.created", "response.in_progress"] {
+            assert!(matches!(
+                liveness_event_for_codex_type(event_type),
+                Some(LlmEvent::Start)
+            ));
+        }
+    }
+
+    #[test]
+    fn known_noops_and_unknown_events_are_transport_only() {
+        for event_type in [
+            "response.content_part.added",
+            "response.reasoning_summary_part.added",
+            "response.future_noop",
+        ] {
+            assert!(matches!(
+                liveness_event_for_codex_type(event_type),
+                Some(LlmEvent::TransportHeartbeat)
+            ));
+        }
+    }
+
+    #[test]
+    fn semantic_payload_events_remain_owned_by_full_parser() {
+        for event_type in [
+            "response.output_text.delta",
+            "response.output_item.added",
+            "response.completed",
+            "response.failed",
+        ] {
+            assert!(liveness_event_for_codex_type(event_type).is_none());
+        }
+    }
+}

--- a/core/crates/omegon/src/loop.rs
+++ b/core/crates/omegon/src/loop.rs
@@ -2548,6 +2548,7 @@ struct StreamIdlePolicy {
     initial: std::time::Duration,
     active: std::time::Duration,
     reasoning: std::time::Duration,
+    absolute: std::time::Duration,
 }
 
 impl StreamIdlePolicy {
@@ -2564,10 +2565,17 @@ impl StreamIdlePolicy {
             .filter(|seconds| *seconds >= 60)
             .map(std::time::Duration::from_secs)
             .unwrap_or_else(|| std::time::Duration::from_secs(600));
+        let absolute = std::env::var("OMEGON_LLM_ABSOLUTE_TIMEOUT_SECS")
+            .ok()
+            .and_then(|value| value.parse::<u64>().ok())
+            .filter(|seconds| *seconds >= 60)
+            .map(std::time::Duration::from_secs)
+            .unwrap_or_else(|| std::time::Duration::from_secs(1800));
         Self {
             initial,
             active: std::time::Duration::from_secs(90),
             reasoning,
+            absolute,
         }
     }
 
@@ -2602,13 +2610,14 @@ fn select_stream_idle_budget(
         initial,
         active,
         reasoning: reasoning_budget,
+        absolute: std::time::Duration::from_secs(1800),
     }
     .budget(phase, false)
 }
 
 fn stream_idle_phase_after_event(current: StreamIdlePhase, event: &LlmEvent) -> StreamIdlePhase {
     match event {
-        LlmEvent::Start => current,
+        LlmEvent::Start | LlmEvent::TransportHeartbeat => current,
         LlmEvent::TextStart | LlmEvent::TextDelta { .. } => StreamIdlePhase::OutputStreaming,
         LlmEvent::TextEnd => StreamIdlePhase::AmbiguousSilent,
         LlmEvent::ThinkingStart | LlmEvent::ThinkingDelta { .. } => {
@@ -2661,6 +2670,11 @@ async fn consume_llm_stream_with_policy(
     let mut provider_telemetry = None;
     let mut completed = false;
     let mut visible_output_seen = false;
+    let mut stream_started = false;
+    let stream_started_at = tokio::time::Instant::now();
+    let absolute_deadline = stream_started_at + idle_policy.absolute;
+    let mut last_semantic_progress = stream_started_at;
+    let mut transport_heartbeats: u64 = 0;
 
     let _ = events.send(AgentEvent::MessageStart {
         role: "assistant".into(),
@@ -2693,25 +2707,33 @@ async fn consume_llm_stream_with_policy(
             visible_output_seen,
         )
     };
-    while let Some(event) = match tokio::time::timeout(idle_timeout(visible_output_seen), rx.recv())
-        .await
+    while let Some(event) = match tokio::time::timeout(
+        idle_timeout(visible_output_seen)
+            .saturating_sub(last_semantic_progress.elapsed())
+            .min(absolute_deadline.saturating_duration_since(tokio::time::Instant::now())),
+        rx.recv(),
+    )
+    .await
     {
         Ok(event) => event,
         Err(_) => {
             let phase = StreamIdlePhase::from_u8(
                 stream_idle_phase.load(std::sync::atomic::Ordering::Relaxed),
             );
-            let reason = if phase.is_ambiguous_reasoning() && !visible_output_seen {
+            let absolute_expired = tokio::time::Instant::now() >= absolute_deadline;
+            let reason = if absolute_expired {
                 format!(
-                    "LLM stream had no observable activity for {}s during {} — this may be a long-running reasoning window or a stalled stream",
-                    idle_timeout(visible_output_seen).as_secs(),
-                    phase.label()
+                    "LLM stream exceeded the absolute {}s turn deadline during {} — transport received {} heartbeat event(s)",
+                    idle_policy.absolute.as_secs(),
+                    phase.label(),
+                    transport_heartbeats
                 )
             } else {
                 format!(
-                    "LLM stream idle for {}s during {} — connection may be stalled",
+                    "LLM stream made no semantic progress for {}s during {} — transport received {} heartbeat event(s)",
                     idle_timeout(visible_output_seen).as_secs(),
-                    phase.label()
+                    phase.label(),
+                    transport_heartbeats
                 )
             };
             let _ = events.send(AgentEvent::StreamIdle {
@@ -2735,12 +2757,22 @@ async fn consume_llm_stream_with_policy(
         stream_idle_phase.store(next_phase as u8, std::sync::atomic::Ordering::Relaxed);
         match event {
             LlmEvent::Start => {
-                // Heartbeat — any server activity proves connection is alive.
-                // Does NOT count as "content" for timeout phase transition.
+                // Stream start is semantic only once. Providers may repeat
+                // lifecycle markers; repeats must not re-arm the watchdog.
+                if !stream_started {
+                    stream_started = true;
+                    last_semantic_progress = tokio::time::Instant::now();
+                }
             }
-            LlmEvent::TextStart => {}
+            LlmEvent::TransportHeartbeat => {
+                transport_heartbeats = transport_heartbeats.saturating_add(1);
+            }
+            LlmEvent::TextStart => {
+                last_semantic_progress = tokio::time::Instant::now();
+            }
             LlmEvent::TextDelta { delta } => {
                 if !delta.is_empty() {
+                    last_semantic_progress = tokio::time::Instant::now();
                     visible_output_seen = true;
                     // Partial assistant output is visible to the operator. If
                     // they interrupt now, keep the prompt in canonical replay.
@@ -2800,10 +2832,14 @@ async fn consume_llm_stream_with_policy(
                 text_parts.push(String::new());
             }
             LlmEvent::ThinkingStart => {
+                last_semantic_progress = tokio::time::Instant::now();
                 // Active reasoning has begun. This is a liveness phase, not a
                 // promise that every provider exposes raw chain-of-thought.
             }
             LlmEvent::ThinkingDelta { delta } => {
+                if !delta.is_empty() {
+                    last_semantic_progress = tokio::time::Instant::now();
+                }
                 if !delta.is_empty()
                     && let Some(cancel_keeps_prompt) = cancel_keeps_prompt
                 {
@@ -2821,11 +2857,17 @@ async fn consume_llm_stream_with_policy(
             LlmEvent::ThinkingEnd => {
                 thinking_parts.push(String::new());
             }
-            LlmEvent::ToolCallStart => {}
-            LlmEvent::ToolCallDelta { .. } => {
+            LlmEvent::ToolCallStart => {
+                last_semantic_progress = tokio::time::Instant::now();
+            }
+            LlmEvent::ToolCallDelta { delta } => {
+                if !delta.is_empty() {
+                    last_semantic_progress = tokio::time::Instant::now();
+                }
                 // Deltas accumulated by the bridge — complete tool call in ToolCallEnd
             }
             LlmEvent::ToolCallEnd { tool_call } => {
+                last_semantic_progress = tokio::time::Instant::now();
                 visible_output_seen = true;
                 if let Some(cancel_keeps_prompt) = cancel_keeps_prompt {
                     cancel_keeps_prompt.store(true, std::sync::atomic::Ordering::Relaxed);
@@ -2836,8 +2878,12 @@ async fn consume_llm_stream_with_policy(
                     arguments: tool_call.arguments,
                 });
             }
-            LlmEvent::Boundary { .. } => {
-                // Semantic-only boundary consumed by the watchdog state machine.
+            LlmEvent::Boundary { expectation } => {
+                // A repeated unknown boundary carries no new semantic evidence.
+                // Explicit content/reasoning/terminal expectations do.
+                if !matches!(expectation, BoundaryExpectation::Unknown) {
+                    last_semantic_progress = tokio::time::Instant::now();
+                }
             }
             LlmEvent::Done {
                 message,
@@ -5065,6 +5111,77 @@ mod tests {
         assert!(reasoning > content);
     }
 
+    #[tokio::test(start_paused = true)]
+    async fn transport_heartbeat_flood_cannot_extend_semantic_deadline() {
+        use std::time::Duration;
+
+        let (stream_tx, mut stream_rx) = tokio::sync::mpsc::channel(64);
+        let (events_tx, _) = tokio::sync::broadcast::channel(16);
+        stream_tx.send(LlmEvent::Start).await.unwrap();
+        for _ in 0..32 {
+            stream_tx.send(LlmEvent::TransportHeartbeat).await.unwrap();
+        }
+
+        let result = consume_llm_stream_with_policy(
+            &mut stream_rx,
+            &events_tx,
+            "openai-codex",
+            "test-model",
+            None,
+            StreamIdlePolicy {
+                initial: Duration::from_secs(2),
+                active: Duration::from_secs(2),
+                reasoning: Duration::from_secs(2),
+                absolute: Duration::from_secs(120),
+            },
+        );
+        tokio::pin!(result);
+        tokio::time::advance(Duration::from_secs(3)).await;
+        let error = result
+            .await
+            .expect_err("heartbeat flood must not extend semantic deadline");
+        assert!(error.to_string().contains("32 heartbeat event(s)"));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn absolute_deadline_is_not_reset_by_semantic_progress() {
+        use std::time::Duration;
+
+        let (stream_tx, mut stream_rx) = tokio::sync::mpsc::channel(16);
+        let (events_tx, _) = tokio::sync::broadcast::channel(16);
+        stream_tx.send(LlmEvent::Start).await.unwrap();
+
+        let producer = tokio::spawn(async move {
+            for _ in 0..4 {
+                tokio::time::sleep(Duration::from_secs(1)).await;
+                stream_tx
+                    .send(LlmEvent::TextDelta { delta: "x".into() })
+                    .await
+                    .unwrap();
+            }
+        });
+        let result = consume_llm_stream_with_policy(
+            &mut stream_rx,
+            &events_tx,
+            "test-provider",
+            "test-model",
+            None,
+            StreamIdlePolicy {
+                initial: Duration::from_secs(30),
+                active: Duration::from_secs(30),
+                reasoning: Duration::from_secs(30),
+                absolute: Duration::from_secs(3),
+            },
+        );
+        tokio::pin!(result);
+        tokio::time::advance(Duration::from_secs(4)).await;
+        let error = result
+            .await
+            .expect_err("semantic progress must not reset absolute deadline");
+        assert!(error.to_string().contains("absolute 3s turn deadline"));
+        producer.abort();
+    }
+
     #[test]
     fn visible_output_forces_active_budget_for_every_phase() {
         use std::time::Duration;
@@ -5073,6 +5190,7 @@ mod tests {
             initial: Duration::from_secs(30),
             active: Duration::from_secs(2),
             reasoning: Duration::from_secs(60),
+            absolute: Duration::from_secs(120),
         };
         for phase in [
             StreamIdlePhase::AwaitingFirstEvent,
@@ -5114,12 +5232,13 @@ mod tests {
                 initial: Duration::from_secs(30),
                 active: Duration::from_secs(2),
                 reasoning: Duration::from_secs(60),
+                absolute: Duration::from_secs(120),
             },
         );
         tokio::pin!(result);
         tokio::time::advance(Duration::from_secs(3)).await;
         let error = result.await.expect_err("silent partial stream must fail");
-        assert!(error.to_string().contains("idle for 2s"));
+        assert!(error.to_string().contains("no semantic progress for 2s"));
 
         let mut saw_visible = false;
         let mut abort_reason = None;
@@ -5132,7 +5251,7 @@ mod tests {
         }
         assert!(saw_visible, "partial output must remain observable");
         assert!(
-            abort_reason.is_some_and(|reason| reason.contains("idle for 2s")),
+            abort_reason.is_some_and(|reason| reason.contains("no semantic progress for 2s")),
             "stall must emit an explicit terminal abort"
         );
     }
@@ -5159,6 +5278,7 @@ mod tests {
                 initial: std::time::Duration::from_secs(30),
                 active: std::time::Duration::from_secs(2),
                 reasoning: std::time::Duration::from_secs(60),
+                absolute: std::time::Duration::from_secs(120),
             },
         )
         .await

--- a/core/crates/omegon/src/main.rs
+++ b/core/crates/omegon/src/main.rs
@@ -53,6 +53,7 @@ pub mod code_act;
 pub mod code_act_proxy;
 pub mod code_act_sandbox;
 mod codex_config;
+mod codex_events;
 mod command_registry;
 mod container_runtime;
 mod context;

--- a/core/crates/omegon/src/providers.rs
+++ b/core/crates/omegon/src/providers.rs
@@ -1055,13 +1055,39 @@ fn sse_idle_budget() -> SseIdleBudget {
     }
 }
 
+fn drain_sse_lines<F>(buffer: &mut Vec<u8>, mut on_data: F) -> bool
+where
+    F: FnMut(&str) -> bool,
+{
+    let mut consumed = 0;
+    while let Some(relative_newline) = buffer[consumed..].iter().position(|byte| *byte == b'\n') {
+        let newline = consumed + relative_newline;
+        let mut end = newline;
+        if end > consumed && buffer[end - 1] == b'\r' {
+            end -= 1;
+        }
+        let line = String::from_utf8_lossy(&buffer[consumed..end]);
+        consumed = newline + 1;
+        if let Some(data) = line.strip_prefix("data: ")
+            && (data == "[DONE]" || !on_data(data))
+        {
+            buffer.drain(..consumed);
+            return false;
+        }
+    }
+    if consumed > 0 {
+        buffer.drain(..consumed);
+    }
+    true
+}
+
 async fn process_sse<F>(response: reqwest::Response, mut on_data: F) -> anyhow::Result<()>
 where
     F: FnMut(&str, &SsePhaseGate) -> bool, // returns false to stop
 {
     let budget = sse_idle_budget();
     let gate = SsePhaseGate::new();
-    let mut buffer = String::new();
+    let mut buffer = Vec::new();
     let mut stream = response.bytes_stream();
 
     loop {
@@ -1073,17 +1099,10 @@ where
         match tokio::time::timeout(idle_timeout, stream.next()).await {
             Ok(Some(chunk)) => {
                 let chunk = chunk?;
-                buffer.push_str(&String::from_utf8_lossy(&chunk));
+                buffer.extend_from_slice(&chunk);
 
-                while let Some(newline) = buffer.find('\n') {
-                    let line = buffer[..newline].trim_end_matches('\r').to_string();
-                    buffer = buffer[newline + 1..].to_string();
-
-                    if let Some(data) = line.strip_prefix("data: ")
-                        && (data == "[DONE]" || !on_data(data, &gate))
-                    {
-                        return Ok(());
-                    }
+                if !drain_sse_lines(&mut buffer, |data| on_data(data, &gate)) {
+                    return Ok(());
                 }
             }
             Ok(None) => break, // stream ended
@@ -3464,17 +3483,28 @@ async fn parse_codex_stream(
                 ));
                 return false;
             }
-            "response.content_part.added" | "response.reasoning_summary_part.added" => {}
+            "response.created" | "response.in_progress" => {
+                if let Some(event) = crate::codex_events::liveness_event_for_codex_type(etype) {
+                    let _ = tx.try_send(event);
+                }
+            }
+            "response.content_part.added" | "response.reasoning_summary_part.added" => {
+                if let Some(event) = crate::codex_events::liveness_event_for_codex_type(etype) {
+                    let _ = tx.try_send(event);
+                }
+            }
             _ => {
-                // Forward unhandled Codex events as a no-op heartbeat.
-                // The Responses API sends events like response.created,
-                // response.in_progress, and reasoning.delta during model
-                // thinking — these don't map to LlmEvents but MUST reset
-                // the 30s consumer idle timer in consume_llm_stream,
-                // otherwise the consumer assumes the stream is stalled
-                // while the model is still reasoning.  LlmEvent::Start is
-                // already handled as a no-op by the consumer.
-                let _ = tx.try_send(LlmEvent::Start);
+                // Unknown/no-op Responses events prove transport liveness only.
+                // They must never masquerade as a new stream start or reset the
+                // semantic-progress watchdog.
+                tracing::debug!(
+                    provider = "openai-codex",
+                    event_type = %crate::util::truncate(etype, 160),
+                    "unhandled Codex SSE event treated as transport heartbeat"
+                );
+                if let Some(event) = crate::codex_events::liveness_event_for_codex_type(etype) {
+                    let _ = tx.try_send(event);
+                }
             }
         }
         true
@@ -6673,6 +6703,40 @@ mod tests {
         .expect_err("malformed arguments should fail");
 
         assert!(error.to_string().contains("arguments are not valid JSON"));
+    }
+
+    #[test]
+    fn sse_framer_preserves_partial_chunks_crlf_and_multiple_events() {
+        let mut buffer = Vec::new();
+        let mut data = Vec::new();
+
+        buffer.extend_from_slice(b"data: fir");
+        assert!(drain_sse_lines(&mut buffer, |value| {
+            data.push(value.to_string());
+            true
+        }));
+        assert!(data.is_empty());
+        assert_eq!(&buffer[..], b"data: fir");
+
+        buffer.extend_from_slice(b"st\r\ndata: second\n");
+        assert!(drain_sse_lines(&mut buffer, |value| {
+            data.push(value.to_string());
+            true
+        }));
+        assert_eq!(data, ["first", "second"]);
+        assert!(buffer.is_empty());
+    }
+
+    #[test]
+    fn sse_framer_stops_at_done_without_consuming_following_partial_data() {
+        let mut buffer = Vec::from(&b"data: first\ndata: [DONE]\ndata: later"[..]);
+        let mut data = Vec::new();
+        assert!(!drain_sse_lines(&mut buffer, |value| {
+            data.push(value.to_string());
+            true
+        }));
+        assert_eq!(data, ["first"]);
+        assert_eq!(&buffer[..], b"data: later");
     }
 
     #[test]

--- a/docs/design/semantic-stream-watchdog.md
+++ b/docs/design/semantic-stream-watchdog.md
@@ -1,0 +1,85 @@
++++
+id = "semantic-stream-watchdog"
+status = "implemented"
+tags = ["providers", "streaming", "watchdog", "codex", "performance"]
+aliases = []
+imported_reference = false
+
+[publication]
+enabled = false
+visibility = "private"
++++
+
+# Semantic stream watchdog
+
+## Overview
+
+Prevent a transport-active but semantically stalled provider stream from retaining an unbounded turn lease. Transport liveness, semantic progress, and absolute turn duration are separate signals. A heartbeat can prove that a socket is alive; it cannot reset semantic-progress time.
+
+## Observed failure
+
+A local Codex-backed session remained in `streaming answer` while one Tokio worker consumed a CPU core. The existing SSE and consumer timeouts were per-receive idle timeouts. Repeated unknown or no-op upstream events were normalized to `LlmEvent::Start`, so every event rearmed the consumer timeout despite producing no text, reasoning, tool call, or terminal result. The SSE framer also copied its remaining buffer for every parsed line, amplifying a noisy stream into allocation and copy pressure.
+
+## Contract
+
+### Signal classes
+
+- **Transport activity**: bytes or an explicit provider heartbeat. It updates diagnostics only.
+- **Semantic progress**: non-empty text/reasoning/tool deltas, a completed tool call, or a meaningful novel boundary. It resets the semantic-progress deadline.
+- **Terminal activity**: completion or error. It ends the stream.
+- **Absolute turn deadline**: a monotonic deadline that no event can reset.
+
+`LlmEvent::Start` remains the one-time stream-open semantic event for compatibility. `LlmEvent::TransportHeartbeat` is the explicit no-progress event and must never extend semantic or absolute deadlines.
+
+### Watchdog behavior
+
+The consumer tracks `last_semantic_progress`, transport heartbeat count, current semantic phase, and turn start. Each receive waits only for the remaining semantic budget, not a fresh full budget. On expiry it aborts with bounded diagnostics naming the phase, no-progress duration, and heartbeat count.
+
+The implementation preserves the phase-aware semantic budgets and adds a non-resettable absolute deadline. The absolute deadline defaults to 1,200 seconds and can be overridden with `OMEGON_LLM_ABSOLUTE_TIMEOUT_SECS`; values below 60 seconds are rejected in favor of the default.
+
+### Codex normalization
+
+- Known text, reasoning, tool, boundary, completion, and error events map to their semantic variants.
+- Explicit liveness/no-op events map to `TransportHeartbeat`.
+- Unknown event kinds are counted and logged with bounded cardinality; they may map to `TransportHeartbeat` but never to `Start`.
+- Repeated identical phase events do not constitute semantic progress.
+
+### SSE framing
+
+The parser must consume bytes with a cursor or `BytesMut`-style split, avoiding allocation of both the current line and the complete remainder for every line. Framing changes must preserve CRLF handling, multi-line `data:` events, partial chunks, and terminal flush behavior.
+
+## Decisions
+
+1. Distinguish transport heartbeat from stream start in the provider-neutral event contract.
+2. Base semantic timeout on elapsed time since semantic progress, not elapsed time since any channel receive.
+3. Preserve existing phase-aware timeout values for the first bounded fix.
+4. Add an absolute non-resettable turn deadline as a separate guard.
+5. Optimize SSE framing independently; performance reduction does not substitute for lifecycle bounds.
+6. Diagnostics must be bounded and must not include unbounded upstream payloads or high-cardinality event names.
+
+## Resolved questions and assumptions
+
+- Existing phase-aware idle budgets remain the initial semantic-progress budgets; production telemetry can justify later tuning without changing the contract.
+- The absolute deadline defaults to 1,200 seconds. Operators may override it with `OMEGON_LLM_ABSOLUTE_TIMEOUT_SECS`, subject to a 60-second minimum.
+- `response.created` and the first `response.in_progress` establish stream start. Content-part markers and unknown/no-op Codex event kinds are transport heartbeats. Text, reasoning, and tool payloads remain owned by the full semantic parser.
+- Heartbeat floods are bounded by elapsed semantic time and the absolute deadline, not an event-count breaker. This avoids rejecting a healthy but noisy transport before the time contract expires.
+- SSE framing now avoids remainder copies, but this change does not add a maximum frame-size guard. Existing HTTP/body controls remain the current aggregate defense; a hostile-stream frame cap is separate follow-up scope.
+- The design does not depend on observing a particular upstream flood event name: unknown Codex events are transport-only by default.
+
+## Implementation scope
+
+- `core/crates/omegon/src/bridge.rs`: provider-neutral heartbeat event.
+- `core/crates/omegon/src/providers.rs`: Codex normalization, bounded unknown-event diagnostics, allocation-bounded SSE framing.
+- `core/crates/omegon/src/loop.rs`: semantic and absolute watchdogs with diagnostics.
+- Focused tests in the owning modules for heartbeat floods, semantic reset, hard deadline, partial SSE chunks, CRLF, and unknown-event bounds.
+
+## Acceptance criteria
+
+1. Continuous `TransportHeartbeat` events cannot keep a stream alive beyond its semantic deadline.
+2. Non-empty semantic deltas reset only the semantic deadline.
+3. No event resets the absolute deadline.
+4. Unknown Codex events cannot become repeated `Start` events.
+5. Stall diagnostics report bounded heartbeat/event counts without embedding unbounded payloads.
+6. SSE framing does not copy the entire remainder once per parsed line.
+7. Existing provider stream tests, `just test-crate omegon`, and `just clippy-changed` pass.
+8. An adversarial review finds no event class that accidentally grants an unbounded lease.


### PR DESCRIPTION
## Summary
- distinguish transport heartbeats from semantic model progress
- enforce phase-aware semantic-progress deadlines and a non-resettable absolute turn deadline
- normalize Codex no-op/unknown events without repeated stream starts
- reduce SSE framing copies while preserving fragmented, CRLF, multi-event, and `[DONE]` behavior
- document the provider-neutral liveness contract

## Validation
- `just test-crate omegon` — passed, including 4,271 unit tests and black-box suites
- `just clippy-changed` — passed
- focused heartbeat-flood, absolute-deadline, Codex normalization, and SSE framing regressions
- `cargo fmt --all`
- `git diff --check`
