### PR TITLE
fix(skills): avoid process-wide cwd mutation during migration

### DIFF
--- a/core/crates/omegon/src/migrate.rs
+++ b/core/crates/omegon/src/migrate.rs
@@ -171,20 +171,8 @@ fn claude_skill_roots(cwd: &Path) -> Vec<(PathBuf, bool)> {
 }
 
 fn import_claude_skill(path: &Path, project: bool, cwd: &Path) -> anyhow::Result<()> {
-    if project {
-        let original = std::env::current_dir()?;
-        struct Restore(std::path::PathBuf);
-        impl Drop for Restore {
-            fn drop(&mut self) {
-                let _ = std::env::set_current_dir(&self.0);
-            }
-        }
-        std::env::set_current_dir(cwd)?;
-        let _restore = Restore(original);
-        crate::skills::cmd_import(path, true, false)
-    } else {
-        crate::skills::cmd_import(path, false, false)
-    }
+    let project_root = project.then_some(cwd);
+    crate::skills::import_skill_at_root(path, project_root, false).map(|_| ())
 }
 
 fn migrate_claude_skills(cwd: &Path, r: &mut MigrationReport) {
@@ -1125,8 +1113,10 @@ mod tests {
         std::fs::create_dir_all(skill_dir.join("scripts")).unwrap();
         std::fs::write(skill_dir.join("scripts/run.sh"), "echo ok\n").unwrap();
 
+        let original_cwd = std::env::current_dir().unwrap();
         let report = migrate_claude_code(cwd.path());
 
+        assert_eq!(std::env::current_dir().unwrap(), original_cwd);
         assert!(report.items.iter().any(|item| item.kind == "skill"));
         assert!(
             cwd.path()

--- a/core/crates/omegon/src/skills.rs
+++ b/core/crates/omegon/src/skills.rs
@@ -387,6 +387,15 @@ pub fn import_skill(
     project: bool,
     force: bool,
 ) -> anyhow::Result<SkillImportSummary> {
+    let project_root = project.then(std::env::current_dir).transpose()?;
+    import_skill_at_root(path, project_root.as_deref(), force)
+}
+
+pub(crate) fn import_skill_at_root(
+    path: &std::path::Path,
+    project_root: Option<&std::path::Path>,
+    force: bool,
+) -> anyhow::Result<SkillImportSummary> {
     let source = path.canonicalize()?;
     let (source_dir, skill_file) = if source.is_dir() {
         (source.clone(), source.join("SKILL.md"))
@@ -412,8 +421,8 @@ pub fn import_skill(
         manifest.name
     };
     let slug = validate_skill_name(&name)?;
-    let base = if project {
-        std::env::current_dir()?.join(".omegon/skills")
+    let base = if let Some(project_root) = project_root {
+        project_root.join(".omegon/skills")
     } else {
         skills_dir().ok_or_else(|| anyhow::anyhow!("Cannot determine home directory"))?
     };
@@ -438,7 +447,12 @@ pub fn import_skill(
     let bundle = summarize_imported_skill(&destination, &slug);
     Ok(SkillImportSummary {
         name: slug,
-        scope: if project { "project" } else { "user" }.into(),
+        scope: if project_root.is_some() {
+            "project"
+        } else {
+            "user"
+        }
+        .into(),
         source,
         destination,
         bundle,


### PR DESCRIPTION
## Problem

Claude project-skill migration temporarily changed the process-wide current working directory. Concurrent tests and subprocesses could observe or delete that temporary cwd, causing nondeterministic skill destinations and Pkl startup failures.

## Change

- add an explicit project-root skill import path
- route Claude migration through that API without `set_current_dir`
- assert migration preserves the process cwd

## Validation

- `just test-filter "migrate_claude_code_imports_project_skill_bundle"`
- `just test-filter "migrate_claude_code_skips_existing_skill_with_force_hint"`
- `just test-crate omegon`: 4310 passed, 0 failed, 2 ignored; all integration suites passed
- `just clippy-changed`
- `git diff --check`