### PR TITLE
fix(tui): keep command admission authoritative under load

### DIFF
--- a/core/crates/omegon/src/tui/mod.rs
+++ b/core/crates/omegon/src/tui/mod.rs
@@ -684,13 +684,25 @@ fn editor_height_for(editor: &Editor, main_area: Rect) -> u16 {
     (editor_rows + 2).clamp(3, max_editor) // +2 for border
 }
 
+enum CommandAdmission {
+    Accepted,
+    Busy(Box<TuiCommand>),
+    Disconnected(Box<TuiCommand>),
+}
+
 fn try_admit_operator_command(
     command_tx: &OperatorCommandTx,
     command: TuiCommand,
-) -> Result<(), Box<TuiCommand>> {
-    command_tx
-        .try_send(command)
-        .map_err(|error| Box::new(error.into_inner()))
+) -> CommandAdmission {
+    match command_tx.try_send(command) {
+        Ok(()) => CommandAdmission::Accepted,
+        Err(tokio::sync::mpsc::error::TrySendError::Full(command)) => {
+            CommandAdmission::Busy(Box::new(command))
+        }
+        Err(tokio::sync::mpsc::error::TrySendError::Closed(command)) => {
+            CommandAdmission::Disconnected(Box::new(command))
+        }
+    }
 }
 
 impl App {
@@ -6006,9 +6018,19 @@ warning: {warning}"
                 queue_mode: self.queue_mode,
                 metadata: PromptMetadata::default(),
             });
-            if let Err(command) = try_admit_operator_command(command_tx, command) {
-                self.restore_prompt_submission(*command, raw_text);
-                return;
+            match try_admit_operator_command(command_tx, command) {
+                CommandAdmission::Accepted => {}
+                CommandAdmission::Busy(command) => {
+                    self.restore_prompt_submission(*command, raw_text);
+                    return;
+                }
+                CommandAdmission::Disconnected(command) => {
+                    self.restore_prompt_submission(*command, raw_text);
+                    self.conversation.push_system(
+                        "Coordinator disconnected; prompt retained. Exit and restart Omegon.",
+                    );
+                    return;
+                }
             }
             if should_interrupt {
                 self.prepare_interrupt_ui();
@@ -6038,11 +6060,23 @@ warning: {warning}"
             queue_mode: self.queue_mode,
             metadata: PromptMetadata::default(),
         });
-        if let Err(command) = try_admit_operator_command(command_tx, command) {
-            self.restore_prompt_submission(*command, raw_text);
-            self.agent_active = false;
-            self.dashboard_handles.session().set_busy(false);
-            return;
+        match try_admit_operator_command(command_tx, command) {
+            CommandAdmission::Accepted => {}
+            CommandAdmission::Busy(command) => {
+                self.restore_prompt_submission(*command, raw_text);
+                self.agent_active = false;
+                self.dashboard_handles.session().set_busy(false);
+                return;
+            }
+            CommandAdmission::Disconnected(command) => {
+                self.restore_prompt_submission(*command, raw_text);
+                self.agent_active = false;
+                self.dashboard_handles.session().set_busy(false);
+                self.conversation.push_system(
+                    "Coordinator disconnected; prompt retained. Exit and restart Omegon.",
+                );
+                return;
+            }
         }
         if let Some(ref mut overlay) = self.tutorial_overlay {
             overlay.check_any_input();
@@ -6069,7 +6103,10 @@ warning: {warning}"
                 queue_mode: self.queue_mode,
                 metadata: PromptMetadata::default(),
             });
-            if try_admit_operator_command(command_tx, command).is_err() {
+            if !matches!(
+                try_admit_operator_command(command_tx, command),
+                CommandAdmission::Accepted
+            ) {
                 self.conversation
                     .push_system("Coordinator busy; voice prompt was not admitted.");
             }
@@ -6092,7 +6129,10 @@ warning: {warning}"
             queue_mode: self.queue_mode,
             metadata: PromptMetadata::default(),
         });
-        if try_admit_operator_command(command_tx, command).is_err() {
+        if !matches!(
+            try_admit_operator_command(command_tx, command),
+            CommandAdmission::Accepted
+        ) {
             self.conversation
                 .push_system("Coordinator busy; voice prompt was not admitted.");
             if was_idle {

--- a/core/crates/omegon/src/tui/mod.rs
+++ b/core/crates/omegon/src/tui/mod.rs
@@ -684,6 +684,15 @@ fn editor_height_for(editor: &Editor, main_area: Rect) -> u16 {
     (editor_rows + 2).clamp(3, max_editor) // +2 for border
 }
 
+fn try_admit_operator_command(
+    command_tx: &OperatorCommandTx,
+    command: TuiCommand,
+) -> Result<(), Box<TuiCommand>> {
+    command_tx
+        .try_send(command)
+        .map_err(|error| Box::new(error.into_inner()))
+}
+
 impl App {
     fn displayed_model_grade(model_provider: &str, model_id: &str, fallback: &str) -> String {
         let model = model_id
@@ -5850,6 +5859,19 @@ warning: {warning}"
         }
     }
 
+    fn restore_prompt_submission(&mut self, command: TuiCommand, raw_text: String) {
+        if let TuiCommand::SubmitPrompt(submission) = command {
+            self.editor.set_text(&raw_text);
+            for path in submission.image_paths {
+                self.editor.insert_attachment(path);
+            }
+        }
+        self.show_command_toast(CommandToast::new(
+            "Coordinator busy; prompt retained",
+            CommandSeverity::Warning,
+        ));
+    }
+
     async fn submit_editor_buffer(&mut self, command_tx: &OperatorCommandTx) {
         let (raw_text, attachments) = self.editor.take_submission();
         if raw_text.is_empty() && attachments.is_empty() {
@@ -5927,23 +5949,25 @@ warning: {warning}"
                     }
                     self.history.push(raw_text.clone());
                     self.exit_history_recall();
-                    let _ = command_tx
-                        .send(TuiCommand::ShellHandoff {
+                    let _ = try_admit_operator_command(
+                        command_tx,
+                        TuiCommand::ShellHandoff {
                             keyboard_enhancement: self.keyboard_enhancement,
-                        })
-                        .await;
+                        },
+                    );
                     return;
                 }
 
                 self.history.push(raw_text.clone());
                 self.exit_history_recall();
                 self.conversation.push_user(&raw_text);
-                let _ = command_tx
-                    .send(TuiCommand::RunShellCommand {
+                let _ = try_admit_operator_command(
+                    command_tx,
+                    TuiCommand::RunShellCommand {
                         command: text,
                         respond_to: None,
-                    })
-                    .await;
+                    },
+                );
                 return;
             }
             PromptPrefixMode::Agent
@@ -5974,24 +5998,27 @@ warning: {warning}"
             let should_interrupt = matches!(self.queue_mode, PromptQueueMode::InterruptAfterTurn);
             self.history.push(raw_text.clone());
             self.history_idx = None;
-            let _ = command_tx
-                .send(TuiCommand::SubmitPrompt(PromptSubmission {
-                    text: final_text,
-                    image_paths: attachments,
-                    submitted_by: "local-tui".to_string(),
-                    via: "tui",
-                    queue_mode: self.queue_mode,
-                    metadata: PromptMetadata::default(),
-                }))
-                .await;
+            let command = TuiCommand::SubmitPrompt(PromptSubmission {
+                text: final_text,
+                image_paths: attachments,
+                submitted_by: "local-tui".to_string(),
+                via: "tui",
+                queue_mode: self.queue_mode,
+                metadata: PromptMetadata::default(),
+            });
+            if let Err(command) = try_admit_operator_command(command_tx, command) {
+                self.restore_prompt_submission(*command, raw_text);
+                return;
+            }
             if should_interrupt {
                 self.prepare_interrupt_ui();
-                let _ = command_tx
-                    .send(TuiCommand::CancelActiveTurn {
+                let _ = try_admit_operator_command(
+                    command_tx,
+                    TuiCommand::CancelActiveTurn {
                         submitted_by: "local-tui".to_string(),
                         via: "tui",
-                    })
-                    .await;
+                    },
+                );
             }
             if let Some(ref mut overlay) = self.tutorial_overlay {
                 overlay.check_any_input();
@@ -6003,16 +6030,20 @@ warning: {warning}"
         self.exit_history_recall();
         self.agent_active = true;
         self.dashboard_handles.session().set_busy(true);
-        let _ = command_tx
-            .send(TuiCommand::SubmitPrompt(PromptSubmission {
-                text: final_text,
-                image_paths: attachments,
-                submitted_by: "local-tui".to_string(),
-                via: "tui",
-                queue_mode: self.queue_mode,
-                metadata: PromptMetadata::default(),
-            }))
-            .await;
+        let command = TuiCommand::SubmitPrompt(PromptSubmission {
+            text: final_text,
+            image_paths: attachments,
+            submitted_by: "local-tui".to_string(),
+            via: "tui",
+            queue_mode: self.queue_mode,
+            metadata: PromptMetadata::default(),
+        });
+        if let Err(command) = try_admit_operator_command(command_tx, command) {
+            self.restore_prompt_submission(*command, raw_text);
+            self.agent_active = false;
+            self.dashboard_handles.session().set_busy(false);
+            return;
+        }
         if let Some(ref mut overlay) = self.tutorial_overlay {
             overlay.check_any_input();
         }
@@ -6030,34 +6061,45 @@ warning: {warning}"
         }
         let decorated = format!("🎙 {text}");
         if self.agent_active {
-            let _ = command_tx
-                .send(TuiCommand::SubmitPrompt(PromptSubmission {
-                    text: decorated,
-                    image_paths: Vec::new(),
-                    submitted_by: "voice".to_string(),
-                    via: "voice",
-                    queue_mode: self.queue_mode,
-                    metadata: PromptMetadata::default(),
-                }))
-                .await;
-            return;
-        }
-
-        self.conversation.push_user(&decorated);
-        self.history.push(decorated.clone());
-        self.exit_history_recall();
-        self.agent_active = true;
-        self.dashboard_handles.session().set_busy(true);
-        let _ = command_tx
-            .send(TuiCommand::SubmitPrompt(PromptSubmission {
+            let command = TuiCommand::SubmitPrompt(PromptSubmission {
                 text: decorated,
                 image_paths: Vec::new(),
                 submitted_by: "voice".to_string(),
                 via: "voice",
                 queue_mode: self.queue_mode,
                 metadata: PromptMetadata::default(),
-            }))
-            .await;
+            });
+            if try_admit_operator_command(command_tx, command).is_err() {
+                self.conversation
+                    .push_system("Coordinator busy; voice prompt was not admitted.");
+            }
+            return;
+        }
+
+        let was_idle = !self.agent_active;
+        if was_idle {
+            self.conversation.push_user(&decorated);
+            self.history.push(decorated.clone());
+            self.exit_history_recall();
+            self.agent_active = true;
+            self.dashboard_handles.session().set_busy(true);
+        }
+        let command = TuiCommand::SubmitPrompt(PromptSubmission {
+            text: decorated,
+            image_paths: Vec::new(),
+            submitted_by: "voice".to_string(),
+            via: "voice",
+            queue_mode: self.queue_mode,
+            metadata: PromptMetadata::default(),
+        });
+        if try_admit_operator_command(command_tx, command).is_err() {
+            self.conversation
+                .push_system("Coordinator busy; voice prompt was not admitted.");
+            if was_idle {
+                self.agent_active = false;
+                self.dashboard_handles.session().set_busy(false);
+            }
+        }
     }
 
     fn suppress_editor_input_for(&mut self, duration: Duration) {
@@ -7679,16 +7721,17 @@ pub async fn run_tui(
 
     // Queue initial prompt if provided (--initial-prompt / --initial-prompt-file)
     if let Some(prompt) = config.initial_prompt {
-        let _ = command_tx
-            .send(TuiCommand::SubmitPrompt(PromptSubmission {
+        let _ = try_admit_operator_command(
+            &command_tx,
+            TuiCommand::SubmitPrompt(PromptSubmission {
                 text: prompt,
                 image_paths: Vec::new(),
                 submitted_by: "startup".to_string(),
                 via: "tui",
                 queue_mode: app.queue_mode,
                 metadata: PromptMetadata::default(),
-            }))
-            .await;
+            }),
+        );
     }
 
     // Start tutorial overlay if --tutorial flag was passed (e.g. from demo exec)
@@ -7698,7 +7741,7 @@ pub async fn run_tui(
     }
 
     let mut scheduler = TuiFrameScheduler::new(std::time::Instant::now());
-    let mut terminal_input = terminal_input::TerminalInputPump::spawn();
+    let mut terminal_input = terminal_input::TerminalInputPump::spawn(interrupt_tx);
     let mut runtime_trace = runtime_trace::TuiRuntimeTrace::new(config.debug_tui);
 
     loop {
@@ -7712,11 +7755,6 @@ pub async fn run_tui(
         // ingesting producer traffic so streaming cannot starve scrolling,
         // cancellation, or editor control.
         let mut handled_input = false;
-        while let Ok(interrupt) = terminal_input.try_recv_interrupt() {
-            // This channel is consumed outside the presentation task. The send
-            // is non-awaiting so cancellation cannot queue behind a wedged draw.
-            let _ = interrupt_tx.try_send(interrupt);
-        }
         let mut handled_input_count = 0_u64;
         let input_started = std::time::Instant::now();
         for _ in 0..16 {
@@ -7864,10 +7902,6 @@ pub async fn run_tui(
             let _ = command_tx.send(TuiCommand::Quit { confirmed: true }).await;
             eprintln!("{}", boundary.message());
             break;
-        }
-
-        while let Ok(interrupt) = terminal_input.try_recv_interrupt() {
-            let _ = interrupt_tx.try_send(interrupt);
         }
 
         // If the agent budget was exhausted, yield only long enough to service

--- a/core/crates/omegon/src/tui/terminal_input.rs
+++ b/core/crates/omegon/src/tui/terminal_input.rs
@@ -55,15 +55,13 @@ fn route_input(
 
 pub(crate) struct TerminalInputPump {
     events: mpsc::Receiver<Event>,
-    interrupts: mpsc::Receiver<TerminalInterrupt>,
     boundaries: mpsc::Receiver<TerminalBoundaryFault>,
     stop: Arc<AtomicBool>,
 }
 
 impl TerminalInputPump {
-    pub(crate) fn spawn() -> Self {
+    pub(crate) fn spawn(interrupt_tx: mpsc::Sender<TerminalInterrupt>) -> Self {
         let (event_tx, events) = mpsc::channel(INPUT_QUEUE_CAPACITY);
-        let (interrupt_tx, interrupts) = mpsc::channel(INTERRUPT_QUEUE_CAPACITY);
         let (boundary_tx, boundaries) = mpsc::channel(1);
         let stop = Arc::new(AtomicBool::new(false));
         let worker_stop = Arc::clone(&stop);
@@ -96,7 +94,6 @@ impl TerminalInputPump {
 
         Self {
             events,
-            interrupts,
             boundaries,
             stop,
         }
@@ -104,12 +101,6 @@ impl TerminalInputPump {
 
     pub(crate) fn try_recv(&mut self) -> Result<Event, mpsc::error::TryRecvError> {
         self.events.try_recv()
-    }
-
-    pub(crate) fn try_recv_interrupt(
-        &mut self,
-    ) -> Result<TerminalInterrupt, mpsc::error::TryRecvError> {
-        self.interrupts.try_recv()
     }
 
     pub(crate) fn try_recv_boundary(

--- a/core/crates/omegon/src/tui/tests.rs
+++ b/core/crates/omegon/src/tui/tests.rs
@@ -1337,6 +1337,24 @@ async fn saturated_active_turn_lane_retains_prompt_and_does_not_interrupt() {
 }
 
 #[tokio::test]
+async fn disconnected_command_lane_retains_prompt_and_reports_boundary() {
+    let mut app = test_app();
+    app.agent_active = true;
+    app.editor.set_text("retain after disconnect");
+    let (tx, rx) = tokio::sync::mpsc::channel(1);
+    drop(rx);
+
+    tokio::time::timeout(
+        std::time::Duration::from_millis(100),
+        app.submit_editor_buffer(&tx),
+    )
+    .await
+    .expect("disconnected lane must not block");
+
+    assert_eq!(app.editor.render_text(), "retain after disconnect");
+}
+
+#[tokio::test]
 async fn saturated_command_lane_retains_prompt_draft_without_blocking() {
     let mut app = active_test_app();
     app.editor.set_text("queued behind blocked turn");

--- a/core/crates/omegon/src/tui/tests.rs
+++ b/core/crates/omegon/src/tui/tests.rs
@@ -1321,6 +1321,36 @@ async fn star_prefix_wraps_prompt_as_memory_injection_request() {
     }
 }
 #[tokio::test]
+async fn saturated_active_turn_lane_retains_prompt_and_does_not_interrupt() {
+    let mut app = active_test_app();
+    app.queue_mode = PromptQueueMode::InterruptAfterTurn;
+    app.editor.set_text("do not lose this steering prompt");
+    let (tx, mut rx) = tokio::sync::mpsc::channel(1);
+    tx.try_send(TuiCommand::StartWebDashboard)
+        .expect("fill coordinator lane");
+
+    app.submit_editor_buffer(&tx).await;
+
+    assert_eq!(app.editor.render_text(), "do not lose this steering prompt");
+    assert!(!app.interrupt_pending);
+    assert!(matches!(rx.try_recv(), Ok(TuiCommand::StartWebDashboard)));
+}
+
+#[tokio::test]
+async fn saturated_command_lane_retains_prompt_draft_without_blocking() {
+    let mut app = active_test_app();
+    app.editor.set_text("queued behind blocked turn");
+    let (tx, mut rx) = tokio::sync::mpsc::channel(1);
+    tx.try_send(TuiCommand::StartWebDashboard)
+        .expect("fill coordinator lane");
+
+    app.submit_editor_buffer(&tx).await;
+
+    assert_eq!(app.editor.render_text(), "queued behind blocked turn");
+    assert!(matches!(rx.try_recv(), Ok(TuiCommand::StartWebDashboard)));
+}
+
+#[tokio::test]
 async fn submitting_while_agent_active_submits_to_runtime_queue_without_interrupt_by_default() {
     let mut app = test_app();
     let (tx, mut rx) = test_tx_with_rx();


### PR DESCRIPTION
## Summary
- route priority Ctrl-C directly from the terminal input owner to generation-scoped runtime interrupt admission
- make ordinary TUI command admission non-blocking and transactional under saturation or coordinator disconnect
- preserve editor drafts/attachments and roll back speculative idle busy state when admission fails

## Validation
- `just test-crate omegon` — 4317 unit tests passed, 2 ignored; all integration suites passed
- `cargo clippy -p omegon --all-targets -- -D warnings`
- `git diff origin/main...HEAD --check`

## Behavioral contract
- Ctrl-C never waits behind presentation or ordinary command traffic
- active-turn follow-up submissions are either admitted or retained in the editor
- idle submissions do not leave false busy state after failed admission
- saturation and coordinator disconnect remain distinguishable
