### PR TITLE
feat(runtime): declare runtime capabilities

### DIFF
--- a/ai/lifecycle/state.json
+++ b/ai/lifecycle/state.json
@@ -1906,6 +1906,24 @@
       "tasks_done": 12,
       "created_at": "2026-08-15T19:29:22Z",
       "updated_at": "2026-08-15T19:29:32Z"
+    },
+    {
+      "name": "runtime-capability-declarations",
+      "title": "runtime-capability-declarations",
+      "state": "verifying",
+      "bound_node": null,
+      "specs": [
+        "runtime-capabilities/declarations"
+      ],
+      "test_files": [
+        "core/crates/omegon/src/capability_admission.rs",
+        "core/crates/omegon/src/bus.rs",
+        "core/crates/omegon-traits/src/lib.rs"
+      ],
+      "tasks_total": 8,
+      "tasks_done": 8,
+      "created_at": "2026-08-16T00:59:26Z",
+      "updated_at": "2026-08-16T01:00:08Z"
     }
   ],
   "milestones": [],
@@ -4958,6 +4976,60 @@
       "entity_id": "vendor-neutral-inference-runtime",
       "from_state": "verifying",
       "to_state": "archived",
+      "reason": null,
+      "forced": false
+    },
+    {
+      "timestamp": "2026-08-16T00:59:26Z",
+      "entity_type": "change",
+      "entity_id": "runtime-capability-declarations",
+      "from_state": "(new)",
+      "to_state": "proposed",
+      "reason": null,
+      "forced": false
+    },
+    {
+      "timestamp": "2026-08-16T00:59:26Z",
+      "entity_type": "change",
+      "entity_id": "runtime-capability-declarations",
+      "from_state": "proposed",
+      "to_state": "specced",
+      "reason": null,
+      "forced": false
+    },
+    {
+      "timestamp": "2026-08-16T00:59:26Z",
+      "entity_type": "change",
+      "entity_id": "runtime-capability-declarations",
+      "from_state": "specced",
+      "to_state": "planned",
+      "reason": null,
+      "forced": false
+    },
+    {
+      "timestamp": "2026-08-16T00:59:29Z",
+      "entity_type": "change",
+      "entity_id": "runtime-capability-declarations",
+      "from_state": "planned",
+      "to_state": "testing",
+      "reason": null,
+      "forced": false
+    },
+    {
+      "timestamp": "2026-08-16T00:59:29Z",
+      "entity_type": "change",
+      "entity_id": "runtime-capability-declarations",
+      "from_state": "testing",
+      "to_state": "implementing",
+      "reason": null,
+      "forced": false
+    },
+    {
+      "timestamp": "2026-08-16T01:00:08Z",
+      "entity_type": "change",
+      "entity_id": "runtime-capability-declarations",
+      "from_state": "implementing",
+      "to_state": "verifying",
       "reason": null,
       "forced": false
     }

--- a/core/crates/omegon-traits/src/lib.rs
+++ b/core/crates/omegon-traits/src/lib.rs
@@ -25,6 +25,191 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 // ═══════════════════════════════════════════════════════════════════════════
+// Runtime capability declaration contract
+//
+// These types describe resident runtime contributions and registry integrity.
+// They are deliberately authority-neutral: admission policy and execution
+// leases remain outside this first contract slice.
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct RuntimeCapabilityId(String);
+
+impl RuntimeCapabilityId {
+    pub fn new(value: impl Into<String>) -> Result<Self, &'static str> {
+        let value = value.into();
+        let Some((namespace, name)) = value.split_once(':') else {
+            return Err("capability id must contain a namespace separator");
+        };
+        if namespace.is_empty()
+            || name.is_empty()
+            || name
+                .split('/')
+                .any(|segment| segment.is_empty() || segment == "..")
+            || !value
+                .chars()
+                .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, ':' | '-' | '_' | '.' | '/'))
+        {
+            return Err("capability id contains invalid characters");
+        }
+        Ok(Self(value))
+    }
+
+    pub fn tool(name: &str) -> Self {
+        Self::new(format!("tool:{name}")).expect("tool names form valid capability ids")
+    }
+
+    pub fn action(name: &str) -> Self {
+        Self::new(format!("action:{name}")).expect("command names form valid capability ids")
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RuntimeCapabilityKind {
+    KernelService,
+    Tool,
+    OperatorAction,
+    Skill,
+    ContextProvider,
+    Projection,
+    TransportAdapter,
+    Workflow,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RuntimeCapabilityOwnerKind {
+    Kernel,
+    Feature,
+    ContributionPack,
+    Extension,
+    Project,
+    Operator,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct RuntimeCapabilityOwner {
+    pub kind: RuntimeCapabilityOwnerKind,
+    pub id: String,
+}
+
+impl RuntimeCapabilityOwner {
+    pub fn feature(id: impl Into<String>) -> Self {
+        Self {
+            kind: RuntimeCapabilityOwnerKind::Feature,
+            id: id.into(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RuntimeInvocationKind {
+    Tool,
+    Command,
+    Cli,
+    Acp,
+    Ipc,
+    WebSocket,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct RuntimeCapabilityInvocation {
+    pub kind: RuntimeInvocationKind,
+    pub name: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RuntimeCapabilityDeclaration {
+    pub id: RuntimeCapabilityId,
+    pub kind: RuntimeCapabilityKind,
+    pub owner: RuntimeCapabilityOwner,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub invocations: Vec<RuntimeCapabilityInvocation>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RuntimeCapabilityGroup {
+    pub name: String,
+    pub members: Vec<RuntimeCapabilityId>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum RuntimeCapabilityDiagnostic {
+    DuplicateCapabilityId {
+        capability_id: RuntimeCapabilityId,
+        first_owner: RuntimeCapabilityOwner,
+        conflicting_owner: RuntimeCapabilityOwner,
+    },
+    AmbiguousInvocation {
+        invocation_kind: RuntimeInvocationKind,
+        name: String,
+        first_capability_id: RuntimeCapabilityId,
+        conflicting_capability_id: RuntimeCapabilityId,
+    },
+    MissingOwner {
+        capability_id: RuntimeCapabilityId,
+    },
+    DanglingGroupMember {
+        group: String,
+        capability_id: RuntimeCapabilityId,
+    },
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RuntimeCapabilityRegistry {
+    pub declarations: Vec<RuntimeCapabilityDeclaration>,
+    pub groups: Vec<RuntimeCapabilityGroup>,
+    pub diagnostics: Vec<RuntimeCapabilityDiagnostic>,
+}
+
+#[cfg(test)]
+mod runtime_capability_contract_tests {
+    use super::*;
+
+    #[test]
+    fn capability_registry_json_round_trip_preserves_identity_and_diagnostics() {
+        let registry = RuntimeCapabilityRegistry {
+            declarations: vec![RuntimeCapabilityDeclaration {
+                id: RuntimeCapabilityId::tool("read"),
+                kind: RuntimeCapabilityKind::Tool,
+                owner: RuntimeCapabilityOwner::feature("core-tools"),
+                invocations: vec![RuntimeCapabilityInvocation {
+                    kind: RuntimeInvocationKind::Tool,
+                    name: "read".into(),
+                }],
+            }],
+            groups: vec![RuntimeCapabilityGroup {
+                name: "core".into(),
+                members: vec![RuntimeCapabilityId::tool("read")],
+            }],
+            diagnostics: vec![RuntimeCapabilityDiagnostic::MissingOwner {
+                capability_id: RuntimeCapabilityId::tool("orphan"),
+            }],
+        };
+
+        let encoded = serde_json::to_vec(&registry).expect("serialize capability registry");
+        let decoded: RuntimeCapabilityRegistry =
+            serde_json::from_slice(&encoded).expect("deserialize capability registry");
+        assert_eq!(decoded, registry);
+    }
+
+    #[test]
+    fn capability_id_rejects_unscoped_or_unsafe_values() {
+        assert!(RuntimeCapabilityId::new("read").is_err());
+        assert!(RuntimeCapabilityId::new("tool:../../read").is_err());
+        assert_eq!(RuntimeCapabilityId::tool("read").as_str(), "tool:read");
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
 // Native IPC contract — transport-facing Auspex/Omegon boundary (v1)
 //
 // Transport:  Unix domain socket

--- a/core/crates/omegon/src/bus.rs
+++ b/core/crates/omegon/src/bus.rs
@@ -354,6 +354,37 @@ impl EventBus {
         );
     }
 
+    /// Build the authority-neutral runtime capability inventory for the
+    /// definitions currently finalized on this bus. This mirrors the legacy
+    /// registries and does not participate in filtering or dispatch.
+    pub fn runtime_capability_registry(&self) -> omegon_traits::RuntimeCapabilityRegistry {
+        let tools = self.tool_defs.iter().map(|(feature_index, definition)| {
+            crate::capability_admission::OwnedToolDefinition {
+                owner: self.features[*feature_index].name().to_string(),
+                definition: definition.clone(),
+            }
+        });
+        let commands = self.command_defs.iter().map(|(feature_index, definition)| {
+            crate::capability_admission::OwnedCommandDefinition {
+                owner: self.features[*feature_index].name().to_string(),
+                definition: definition.clone(),
+            }
+        });
+        let declarations =
+            crate::capability_admission::declarations_from_registries(tools, commands);
+        let groups = crate::features::manage_tools::TOOL_GROUPS
+            .iter()
+            .map(|(name, members)| omegon_traits::RuntimeCapabilityGroup {
+                name: (*name).to_string(),
+                members: members
+                    .iter()
+                    .map(|member| omegon_traits::RuntimeCapabilityId::tool(member))
+                    .collect(),
+            })
+            .collect();
+        crate::capability_admission::validate_registry(declarations, groups)
+    }
+
     fn refresh_tool_inventory(&self) {
         let Some(handle) = &self.tool_inventory else {
             return;
@@ -892,6 +923,78 @@ mod tests {
                 details: json!(null),
             })
         }
+    }
+
+    #[test]
+    fn finalized_bus_projects_read_only_capability_inventory_without_changing_tools() {
+        let mut bus = EventBus::new();
+        bus.register(Box::new(CounterFeature { event_count: 0 }));
+        bus.register(Box::new(NotifierFeature));
+        bus.finalize();
+
+        let legacy_tools = bus.tool_definitions();
+        let registry = bus.runtime_capability_registry();
+        let projected_tools = registry
+            .declarations
+            .iter()
+            .filter(|declaration| declaration.kind == omegon_traits::RuntimeCapabilityKind::Tool)
+            .map(|declaration| declaration.invocations[0].name.as_str())
+            .collect::<Vec<_>>();
+
+        assert_eq!(projected_tools, vec!["count"]);
+        assert_eq!(legacy_tools.len(), projected_tools.len());
+        assert!(
+            registry.diagnostics.iter().all(|diagnostic| matches!(
+                diagnostic,
+                omegon_traits::RuntimeCapabilityDiagnostic::DanglingGroupMember { .. }
+            )),
+            "minimal test bus should expose only expected absent-group diagnostics: {:?}",
+            registry.diagnostics
+        );
+        assert!(
+            registry
+                .declarations
+                .iter()
+                .any(|declaration| declaration.id.as_str() == "action:notify")
+        );
+    }
+
+    #[tokio::test]
+    async fn read_only_capability_inventory_does_not_change_legacy_dispatch() {
+        let mut bus = EventBus::new();
+        bus.register(Box::new(CounterFeature { event_count: 7 }));
+        bus.finalize();
+
+        let before = bus
+            .execute_tool(
+                "count",
+                "before",
+                json!({}),
+                tokio_util::sync::CancellationToken::new(),
+            )
+            .await
+            .expect("legacy dispatch before inventory projection");
+        let registry = bus.runtime_capability_registry();
+        let after = bus
+            .execute_tool(
+                "count",
+                "after",
+                json!({}),
+                tokio_util::sync::CancellationToken::new(),
+            )
+            .await
+            .expect("legacy dispatch after inventory projection");
+
+        assert_eq!(
+            serde_json::to_value(&before).expect("serialize pre-projection result"),
+            serde_json::to_value(&after).expect("serialize post-projection result")
+        );
+        assert!(
+            registry
+                .declarations
+                .iter()
+                .any(|declaration| declaration.id.as_str() == "tool:count")
+        );
     }
 
     #[test]

--- a/core/crates/omegon/src/capability_admission.rs
+++ b/core/crates/omegon/src/capability_admission.rs
@@ -1,0 +1,241 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use omegon_traits::{
+    CommandDefinition, RuntimeCapabilityDeclaration, RuntimeCapabilityDiagnostic,
+    RuntimeCapabilityGroup, RuntimeCapabilityId, RuntimeCapabilityInvocation,
+    RuntimeCapabilityKind, RuntimeCapabilityOwner, RuntimeCapabilityRegistry,
+    RuntimeInvocationKind, ToolDefinition,
+};
+
+#[derive(Clone, Debug)]
+pub(crate) struct OwnedToolDefinition {
+    pub owner: String,
+    pub definition: ToolDefinition,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct OwnedCommandDefinition {
+    pub owner: String,
+    pub definition: CommandDefinition,
+}
+
+pub(crate) fn declarations_from_registries(
+    tools: impl IntoIterator<Item = OwnedToolDefinition>,
+    commands: impl IntoIterator<Item = OwnedCommandDefinition>,
+) -> Vec<RuntimeCapabilityDeclaration> {
+    let mut declarations = tools
+        .into_iter()
+        .map(|owned| RuntimeCapabilityDeclaration {
+            id: RuntimeCapabilityId::tool(&owned.definition.name),
+            kind: RuntimeCapabilityKind::Tool,
+            owner: RuntimeCapabilityOwner::feature(owned.owner),
+            invocations: vec![RuntimeCapabilityInvocation {
+                kind: RuntimeInvocationKind::Tool,
+                name: owned.definition.name,
+            }],
+        })
+        .chain(
+            commands
+                .into_iter()
+                .map(|owned| RuntimeCapabilityDeclaration {
+                    id: RuntimeCapabilityId::action(&owned.definition.name),
+                    kind: RuntimeCapabilityKind::OperatorAction,
+                    owner: RuntimeCapabilityOwner::feature(owned.owner),
+                    invocations: vec![RuntimeCapabilityInvocation {
+                        kind: RuntimeInvocationKind::Command,
+                        name: owned.definition.name,
+                    }],
+                }),
+        )
+        .collect::<Vec<_>>();
+    declarations.sort_by(|left, right| left.id.cmp(&right.id));
+    declarations
+}
+
+pub(crate) fn validate_registry(
+    declarations: Vec<RuntimeCapabilityDeclaration>,
+    groups: Vec<RuntimeCapabilityGroup>,
+) -> RuntimeCapabilityRegistry {
+    let mut diagnostics = Vec::new();
+    let mut ids: BTreeMap<RuntimeCapabilityId, RuntimeCapabilityOwner> = BTreeMap::new();
+    let mut invocations: BTreeMap<(RuntimeInvocationKind, String), RuntimeCapabilityId> =
+        BTreeMap::new();
+
+    for declaration in &declarations {
+        if declaration.owner.id.trim().is_empty() {
+            diagnostics.push(RuntimeCapabilityDiagnostic::MissingOwner {
+                capability_id: declaration.id.clone(),
+            });
+        }
+        if let Some(first_owner) = ids.insert(declaration.id.clone(), declaration.owner.clone()) {
+            diagnostics.push(RuntimeCapabilityDiagnostic::DuplicateCapabilityId {
+                capability_id: declaration.id.clone(),
+                first_owner,
+                conflicting_owner: declaration.owner.clone(),
+            });
+        }
+        for invocation in &declaration.invocations {
+            let key = (invocation.kind, invocation.name.clone());
+            if let Some(first_capability_id) = invocations.insert(key, declaration.id.clone())
+                && first_capability_id != declaration.id
+            {
+                diagnostics.push(RuntimeCapabilityDiagnostic::AmbiguousInvocation {
+                    invocation_kind: invocation.kind,
+                    name: invocation.name.clone(),
+                    first_capability_id,
+                    conflicting_capability_id: declaration.id.clone(),
+                });
+            }
+        }
+    }
+
+    let known_ids = ids.keys().cloned().collect::<BTreeSet<_>>();
+    for group in &groups {
+        for member in &group.members {
+            if !known_ids.contains(member) {
+                diagnostics.push(RuntimeCapabilityDiagnostic::DanglingGroupMember {
+                    group: group.name.clone(),
+                    capability_id: member.clone(),
+                });
+            }
+        }
+    }
+    diagnostics.sort();
+
+    RuntimeCapabilityRegistry {
+        declarations,
+        groups,
+        diagnostics,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use omegon_traits::{
+        CommandAvailability, CommandSafety, CommandSurface, RuntimeCapabilityOwnerKind,
+    };
+    use serde_json::json;
+
+    fn tool(name: &str, owner: &str) -> OwnedToolDefinition {
+        OwnedToolDefinition {
+            owner: owner.into(),
+            definition: ToolDefinition {
+                name: name.into(),
+                label: name.into(),
+                description: format!("{name} description"),
+                parameters: json!({"type": "object"}),
+                capabilities: vec![],
+            },
+        }
+    }
+
+    fn command(name: &str, owner: &str) -> OwnedCommandDefinition {
+        OwnedCommandDefinition {
+            owner: owner.into(),
+            definition: CommandDefinition {
+                name: name.into(),
+                description: format!("{name} description"),
+                subcommands: vec![],
+                availability: CommandAvailability::ALL,
+                safety: CommandSafety::READ_ONLY,
+                surface: CommandSurface::default(),
+            },
+        }
+    }
+
+    #[test]
+    fn declarations_preserve_tool_and_command_ownership() {
+        let declarations = declarations_from_registries(
+            [tool("read", "core-tools")],
+            [command("status", "runtime")],
+        );
+
+        assert_eq!(declarations[0].id.as_str(), "action:status");
+        assert_eq!(declarations[0].owner.id, "runtime");
+        assert_eq!(declarations[1].id.as_str(), "tool:read");
+        assert_eq!(declarations[1].owner.id, "core-tools");
+        assert_eq!(
+            declarations[1].owner.kind,
+            RuntimeCapabilityOwnerKind::Feature
+        );
+    }
+
+    #[test]
+    fn duplicate_ids_report_both_owners() {
+        let declarations =
+            declarations_from_registries([tool("read", "first"), tool("read", "second")], []);
+        let registry = validate_registry(declarations, vec![]);
+
+        assert!(registry.diagnostics.iter().any(|diagnostic| matches!(
+            diagnostic,
+            RuntimeCapabilityDiagnostic::DuplicateCapabilityId {
+                capability_id,
+                first_owner,
+                conflicting_owner,
+            } if capability_id.as_str() == "tool:read"
+                && first_owner.id == "first"
+                && conflicting_owner.id == "second"
+        )));
+    }
+
+    #[test]
+    fn ambiguous_invocation_is_distinct_from_duplicate_identity() {
+        let declarations = vec![
+            RuntimeCapabilityDeclaration {
+                id: RuntimeCapabilityId::new("tool:first").unwrap(),
+                kind: RuntimeCapabilityKind::Tool,
+                owner: RuntimeCapabilityOwner::feature("first"),
+                invocations: vec![RuntimeCapabilityInvocation {
+                    kind: RuntimeInvocationKind::Tool,
+                    name: "shared".into(),
+                }],
+            },
+            RuntimeCapabilityDeclaration {
+                id: RuntimeCapabilityId::new("tool:second").unwrap(),
+                kind: RuntimeCapabilityKind::Tool,
+                owner: RuntimeCapabilityOwner::feature("second"),
+                invocations: vec![RuntimeCapabilityInvocation {
+                    kind: RuntimeInvocationKind::Tool,
+                    name: "shared".into(),
+                }],
+            },
+        ];
+        let registry = validate_registry(declarations, vec![]);
+
+        assert!(registry.diagnostics.iter().any(|diagnostic| matches!(
+            diagnostic,
+            RuntimeCapabilityDiagnostic::AmbiguousInvocation { name, .. } if name == "shared"
+        )));
+    }
+
+    #[test]
+    fn dangling_group_members_are_reported() {
+        let declarations = declarations_from_registries([tool("read", "core")], []);
+        let registry = validate_registry(
+            declarations,
+            vec![RuntimeCapabilityGroup {
+                name: "lifecycle".into(),
+                members: vec![RuntimeCapabilityId::tool("missing")],
+            }],
+        );
+
+        assert_eq!(
+            registry.diagnostics,
+            vec![RuntimeCapabilityDiagnostic::DanglingGroupMember {
+                group: "lifecycle".into(),
+                capability_id: RuntimeCapabilityId::tool("missing"),
+            }]
+        );
+    }
+
+    #[test]
+    fn empty_owner_is_rejected() {
+        let declarations = declarations_from_registries([tool("read", "")], []);
+        let registry = validate_registry(declarations, vec![]);
+        assert!(matches!(
+            registry.diagnostics.as_slice(),
+            [RuntimeCapabilityDiagnostic::MissingOwner { .. }]
+        ));
+    }
+}

--- a/core/crates/omegon/src/main.rs
+++ b/core/crates/omegon/src/main.rs
@@ -45,6 +45,7 @@ mod bootstrap;
 mod bootstrap_projection;
 mod bridge;
 pub mod bus;
+mod capability_admission;
 mod capacity;
 mod cleave;
 mod cleave_smoke;

--- a/openspec/changes/runtime-capability-declarations/design.md
+++ b/openspec/changes/runtime-capability-declarations/design.md
@@ -1,0 +1,24 @@
+# Design: Runtime capability declarations and registry integrity
+
+## Approach
+
+Add shared renderer-neutral declaration vocabulary in `omegon-traits` and an adapter/validator module in `omegon`. The adapter consumes existing `ToolDefinition` and `CommandDefinition` values. It does not participate in filtering or dispatch.
+
+Capability identifiers use explicit kind namespaces (`tool:<name>`, `action:<canonical-name>`). Invocation bindings are separate records so command aliases do not create duplicate capability identities.
+
+Registry validation returns all deterministic diagnostics in stable order rather than failing at the first conflict. The initial inventory is read-only and exists to establish parity before authority migrates in a later slice.
+
+## Constraints
+
+- No mutation of `DisabledTools` or `ToolInventorySnapshot` semantics.
+- No changes to model schema projection or EventBus execution routing.
+- Shared contracts remain serialization-compatible and runtime-neutral.
+- Feature ownership must come from the registration boundary, not inferred from labels or descriptions.
+- Existing command aliases resolve to one canonical action declaration.
+
+## Initial file scope
+
+- `core/crates/omegon-traits/src/lib.rs`
+- `core/crates/omegon/src/capability_admission.rs`
+- `core/crates/omegon/src/lib.rs`
+- `core/crates/omegon/src/bus.rs`

--- a/openspec/changes/runtime-capability-declarations/proposal.md
+++ b/openspec/changes/runtime-capability-declarations/proposal.md
@@ -1,0 +1,27 @@
+---
+state: implementing
+---
+# Runtime capability declarations and registry integrity
+
+## Intent
+
+Introduce an additive, authority-neutral declaration and inventory layer for runtime tools and operator commands so every registered invocation has stable ownership and registry drift is detected before capability admission becomes authoritative.
+
+## Scope
+
+- Define runtime capability identities, kinds, owners, invocation bindings, and declaration diagnostics.
+- Adapt existing tool and command definitions into declarations without changing projection or dispatch.
+- Validate duplicate identities and invocation vocabulary, missing owners, dangling aliases/groups, and unsupported bindings.
+- Expose a read-only inventory for diagnostics and parity tests.
+
+## Non-goals
+
+- Replacing `DisabledTools`, posture policy, tool schema projection, or dispatch authority.
+- Migrating skills, context contributions, IPC/WebSocket actions, or binary feature composition.
+- Adding dynamic admission or generation leases.
+
+## Success criteria
+
+- Existing tools and built-in commands project deterministic declarations with stable owners.
+- Registry integrity failures are structured and directly testable.
+- Existing callable tool behavior is unchanged.

--- a/openspec/changes/runtime-capability-declarations/specs/runtime-capabilities/declarations.md
+++ b/openspec/changes/runtime-capability-declarations/specs/runtime-capabilities/declarations.md
@@ -1,0 +1,48 @@
+# Runtime capability declarations — Delta Spec
+
+## ADDED Requirements
+
+### Requirement: Runtime contributions have stable declarations
+
+The runtime must project registered tools and built-in operator commands into renderer-neutral capability declarations with stable identifiers, kinds, owners, and invocation bindings without changing their existing execution authority.
+
+#### Scenario: Tool declaration preserves invocation ownership
+Given an existing model tool definition registered by a feature
+When the declaration inventory is built
+Then it contains one tool capability with a stable identifier
+And its invocation binding names the tool and owning feature
+
+#### Scenario: Command declaration preserves canonical identity
+Given an existing built-in command definition
+When the declaration inventory is built
+Then it contains one operator-action capability
+And aliases remain invocation bindings to that canonical capability rather than independent capabilities
+
+### Requirement: Registry integrity is validated before authority migration
+
+The declaration inventory must reject ambiguous or structurally invalid registry state with typed diagnostics.
+
+#### Scenario: Duplicate capability identity is rejected
+Given two declarations use the same capability identifier
+When registry integrity is validated
+Then validation reports both conflicting owners
+
+#### Scenario: Duplicate invocation vocabulary is rejected
+Given two capability declarations claim the same kind and invocation name
+When registry integrity is validated
+Then validation reports an ambiguous invocation binding
+
+#### Scenario: Dangling group member is rejected
+Given a declared capability group references an unknown capability
+When registry integrity is validated
+Then validation reports the dangling group member
+
+### Requirement: Slice one remains authority-neutral
+
+Declaration inventory construction must not alter existing tool filtering or execution behavior.
+
+#### Scenario: Callable inventory remains unchanged
+Given an existing operator profile and registered tool set
+When the declaration inventory is built and validated
+Then the legacy callable tool names are unchanged
+And tool dispatch continues through the existing EventBus authority path

--- a/openspec/changes/runtime-capability-declarations/tasks.md
+++ b/openspec/changes/runtime-capability-declarations/tasks.md
@@ -1,0 +1,21 @@
+# Runtime capability declarations — Tasks
+
+## 1. Shared declaration contracts
+<!-- specs: runtime-capabilities/declarations -->
+
+- [x] 1.1 Add stable capability ID, kind, owner, invocation binding, declaration, group, and diagnostic types.
+- [x] 1.2 Add constructor and serialization round-trip tests in `omegon-traits`.
+
+## 2. Registry adapters and integrity validation
+<!-- specs: runtime-capabilities/declarations -->
+
+- [x] 2.1 Adapt owned tool and command definitions into deterministic declarations.
+- [x] 2.2 Validate duplicate IDs, ambiguous invocation bindings, missing owners, and dangling group members.
+- [x] 2.3 Add focused validator tests for every diagnostic and valid alias behavior.
+
+## 3. Read-only runtime integration
+<!-- specs: runtime-capabilities/declarations -->
+
+- [x] 3.1 Build the declaration inventory from EventBus registration ownership without changing filtering or dispatch.
+- [x] 3.2 Add parity coverage proving callable tools and execution behavior remain legacy-owned.
+- [x] 3.3 Run crate tests and changed-file clippy.


### PR DESCRIPTION
## Summary
- add stable, serializable runtime capability declaration contracts
- derive authority-neutral tool and command declarations from finalized EventBus ownership
- validate duplicate IDs, ambiguous invocation bindings, missing owners, and dangling group members
- expose a read-only registry without changing legacy schemas, filtering, dispatch, or RBAC

## TDD evidence
- contract tests were added before the shared types and failed on unresolved imports
- EventBus projection test failed before the read-only adapter existed
- traversal-like capability IDs were rejected after a red regression exposed permissive validation
- dispatch-neutrality test proves projection does not change existing tool execution

## Validation
- `just test-crate omegon`
- `just test-crate omegon-traits` (20 passed)
- `just clippy-changed`
- `cargo check` on changed Rust paths
- `cargo fmt --all`
- `git diff --check`

OpenSpec: `runtime-capability-declarations` — 8/8 tasks complete.