### PR TITLE
fix: support NixOS Zed executable resolution

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ core/target/
 
 # Environment & secrets
 .env
+.envrc.local
+.direnv/
 auth.json
 settings.json
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,9 +93,20 @@ Expect maintainers to explain blocking requests, distinguish required changes fr
 
 ## Development Setup
 
+This repository owns its Rust toolchain through `flake.nix`; Cargo is not
+expected to be installed globally. With `direnv` installed and hooked into your
+shell, authorize the repository once:
+
 ```bash
+direnv allow
 just bootstrap --check
 just build
+```
+
+Without direnv, enter the same environment explicitly:
+
+```bash
+nix develop
 ```
 
 The repository is a Cargo workspace rooted at this directory. The main binary is `core/crates/omegon`, and `cargo` commands are run from the repo root unless a recipe says otherwise. Use the focused validation table above while iterating; reserve `just test-rust` for broad or release-hardening gates.

--- a/ai/lifecycle/state.json
+++ b/ai/lifecycle/state.json
@@ -1517,6 +1517,21 @@
       "bound_change": null,
       "created_at": "2026-08-14T02:33:04Z",
       "updated_at": "2026-08-14T02:33:04Z"
+    },
+    {
+      "id": "issue-219-zed-command-resolution",
+      "title": "Issue #219 — cross-platform Zed command resolution",
+      "state": "seed",
+      "parent": null,
+      "tags": [],
+      "priority": null,
+      "issue_type": null,
+      "open_questions": [],
+      "decisions": [],
+      "overview": "",
+      "bound_change": null,
+      "created_at": "2026-08-16T03:14:31Z",
+      "updated_at": "2026-08-16T03:14:31Z"
     }
   ],
   "changes": [
@@ -5030,6 +5045,15 @@
       "entity_id": "runtime-capability-declarations",
       "from_state": "implementing",
       "to_state": "verifying",
+      "reason": null,
+      "forced": false
+    },
+    {
+      "timestamp": "2026-08-16T03:14:31Z",
+      "entity_type": "node",
+      "entity_id": "issue-219-zed-command-resolution",
+      "from_state": "(new)",
+      "to_state": "seed",
       "reason": null,
       "forced": false
     }

--- a/core/crates/omegon/src/settings.rs
+++ b/core/crates/omegon/src/settings.rs
@@ -1322,6 +1322,13 @@ pub struct Profile {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tone: Option<String>,
 
+    // ── External applications ──
+    /// Explicit executable paths or command names for editor integrations.
+    /// Keys are stable integration IDs such as `zed` and `vscode`. Values are
+    /// passed directly to `Command::new`; shell syntax is never interpreted.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub editor_commands: BTreeMap<String, String>,
+
     // ── Optional integrations ──
     /// Optional bridge integrations. Missing integrations stay disabled unless
     /// explicitly enabled by project/global profile or environment.

--- a/core/crates/omegon/src/tui/mod.rs
+++ b/core/crates/omegon/src/tui/mod.rs
@@ -7210,6 +7210,72 @@ fn save_milestones(
     std::fs::write(path, json)
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum ZedInstallation {
+    Cli { command: String, configured: bool },
+    MacOsApp,
+}
+
+fn resolve_zed_installation_with(
+    configured_command: Option<&str>,
+    mut available: impl FnMut(&ZedInstallation) -> bool,
+) -> Option<ZedInstallation> {
+    let configured = configured_command
+        .map(str::trim)
+        .filter(|command| !command.is_empty())
+        .map(|command| ZedInstallation::Cli {
+            command: command.to_string(),
+            configured: true,
+        });
+    let candidates = configured
+        .into_iter()
+        .chain(
+            ["zed", "zeditor"]
+                .into_iter()
+                .map(|command| ZedInstallation::Cli {
+                    command: command.to_string(),
+                    configured: false,
+                }),
+        );
+
+    candidates
+        .chain(std::iter::once(ZedInstallation::MacOsApp))
+        .find(|candidate| available(candidate))
+}
+
+fn zed_installation_available(candidate: &ZedInstallation) -> bool {
+    match candidate {
+        ZedInstallation::Cli { command, .. } => std::process::Command::new(command)
+            .arg("--version")
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .is_ok_and(|status| status.success()),
+        ZedInstallation::MacOsApp => {
+            cfg!(target_os = "macos")
+                && std::process::Command::new("open")
+                    .args(["-Ra", "Zed"])
+                    .stdout(std::process::Stdio::null())
+                    .stderr(std::process::Stdio::null())
+                    .status()
+                    .is_ok_and(|status| status.success())
+        }
+    }
+}
+
+fn resolve_zed_installation(configured_command: Option<&str>) -> Option<ZedInstallation> {
+    resolve_zed_installation_with(configured_command, zed_installation_available)
+}
+
+fn editor_command<'a>(profile: &'a crate::settings::Profile, editor: &str) -> Option<&'a str> {
+    profile
+        .editor_commands
+        .get(editor)
+        .map(String::as_str)
+        .map(str::trim)
+        .filter(|command| !command.is_empty())
+}
+
 fn merge_zed_agent_server(
     content: &str,
     omegon_entry: serde_json::Value,
@@ -7239,7 +7305,58 @@ fn merge_zed_agent_server(
 
 #[cfg(test)]
 mod editor_config_tests {
-    use super::merge_zed_agent_server;
+    use super::{ZedInstallation, merge_zed_agent_server, resolve_zed_installation_with};
+
+    fn cli(command: &str, configured: bool) -> ZedInstallation {
+        ZedInstallation::Cli {
+            command: command.to_string(),
+            configured,
+        }
+    }
+
+    #[test]
+    fn zed_resolution_prefers_configured_command() {
+        let resolved =
+            resolve_zed_installation_with(Some("/opt/zed/bin/custom-zed"), |candidate| {
+                matches!(candidate, ZedInstallation::Cli { .. })
+            });
+
+        assert_eq!(resolved, Some(cli("/opt/zed/bin/custom-zed", true)));
+    }
+
+    #[test]
+    fn zed_resolution_prefers_canonical_cli() {
+        let resolved = resolve_zed_installation_with(
+            None,
+            |candidate| matches!(candidate, ZedInstallation::Cli { command, .. } if command == "zed" || command == "zeditor"),
+        );
+
+        assert_eq!(resolved, Some(cli("zed", false)));
+    }
+
+    #[test]
+    fn zed_resolution_falls_back_to_nixos_cli_name() {
+        let resolved = resolve_zed_installation_with(
+            None,
+            |candidate| matches!(candidate, ZedInstallation::Cli { command, .. } if command == "zeditor"),
+        );
+
+        assert_eq!(resolved, Some(cli("zeditor", false)));
+    }
+
+    #[test]
+    fn zed_resolution_uses_macos_app_after_cli_candidates() {
+        let resolved = resolve_zed_installation_with(None, |candidate| {
+            matches!(candidate, ZedInstallation::MacOsApp)
+        });
+
+        assert_eq!(resolved, Some(ZedInstallation::MacOsApp));
+    }
+
+    #[test]
+    fn zed_resolution_reports_unavailable_when_no_candidate_works() {
+        assert_eq!(resolve_zed_installation_with(None, |_| false), None);
+    }
 
     #[test]
     fn merges_zed_jsonc_with_comments_and_trailing_commas() {
@@ -7290,6 +7407,10 @@ fn handle_editor_command(args: &str) -> String {
     let omegon_bin = std::env::current_exe()
         .map(|p| p.to_string_lossy().to_string())
         .unwrap_or_else(|_| "omegon".to_string());
+    let cwd = std::env::current_dir().unwrap_or_default();
+    let profile = crate::settings::Profile::load(&cwd);
+    let zed = resolve_zed_installation(editor_command(&profile, "zed"));
+    let vscode_command = editor_command(&profile, "vscode").unwrap_or("code");
 
     match args.split_whitespace().next().unwrap_or("") {
         "zed" => {
@@ -7349,19 +7470,28 @@ fn handle_editor_command(args: &str) -> String {
                 }
             }
 
-            // Try to launch Zed — check CLI first, then macOS app bundle
-            let launched = if std::process::Command::new("zed").arg(".").spawn().is_ok() {
-                true
-            } else {
-                cfg!(target_os = "macos")
-                    && std::process::Command::new("open")
-                        .args(["-a", "Zed", "."])
-                        .spawn()
-                        .is_ok()
+            // Launch the same installation reported by `/editor status`.
+            let launched = match &zed {
+                Some(ZedInstallation::Cli { command, .. }) => {
+                    std::process::Command::new(command).arg(".").spawn().is_ok()
+                }
+                Some(ZedInstallation::MacOsApp) => std::process::Command::new("open")
+                    .args(["-a", "Zed", "."])
+                    .spawn()
+                    .is_ok(),
+                None => false,
             };
 
             if launched {
-                result_lines.push("✓ Launching Zed...".to_string());
+                let command_detail = match &zed {
+                    Some(ZedInstallation::Cli {
+                        command,
+                        configured: true,
+                    }) => format!(" using configured command `{command}`"),
+                    Some(ZedInstallation::Cli { command, .. }) => format!(" using `{command}`"),
+                    _ => String::new(),
+                };
+                result_lines.push(format!("✓ Launching Zed{command_detail}..."));
                 result_lines.push("  Select Omegon from the Agent Panel (+ button).".to_string());
             } else {
                 result_lines.push("Zed not found on PATH or in /Applications.".to_string());
@@ -7398,31 +7528,23 @@ fn handle_editor_command(args: &str) -> String {
             lines.push(format!("  Binary: {omegon_bin}"));
             lines.push("  ACP: omegon acp".to_string());
 
-            // Check if Zed is installed (CLI or macOS app bundle)
-            let has_zed_cli = std::process::Command::new("zed")
-                .arg("--version")
-                .stdout(std::process::Stdio::null())
-                .stderr(std::process::Stdio::null())
-                .status()
-                .is_ok();
-            let has_zed_app = cfg!(target_os = "macos")
-                && std::process::Command::new("open")
-                    .args(["-Ra", "Zed"])
-                    .stdout(std::process::Stdio::null())
-                    .stderr(std::process::Stdio::null())
-                    .status()
-                    .is_ok_and(|s| s.success());
-            let zed_status = if has_zed_cli {
-                "installed (CLI on PATH)"
-            } else if has_zed_app {
-                "installed (app bundle, CLI not on PATH — run Zed > Install CLI)"
-            } else {
-                "not found"
+            let zed_status = match &zed {
+                Some(ZedInstallation::Cli {
+                    command,
+                    configured: true,
+                }) => format!("installed (configured command `{command}`)"),
+                Some(ZedInstallation::Cli { command, .. }) => {
+                    format!("installed (`{command}` on PATH)")
+                }
+                Some(ZedInstallation::MacOsApp) => {
+                    "installed (app bundle, CLI not on PATH — run Zed > Install CLI)".to_string()
+                }
+                None => "not found".to_string(),
             };
             lines.push(format!("  Zed: {zed_status}"));
 
-            // Check if VS Code is installed
-            let has_code = std::process::Command::new("code")
+            // Check the configured VS Code executable, or its canonical default.
+            let has_code = std::process::Command::new(vscode_command)
                 .arg("--version")
                 .stdout(std::process::Stdio::null())
                 .stderr(std::process::Stdio::null())

--- a/docs/issue-219-zed-command-resolution.md
+++ b/docs/issue-219-zed-command-resolution.md
@@ -29,6 +29,28 @@ On the issue reporter's NixOS environment, `command -v zeditor` resolves to `/et
 
 Repository policy supports macOS, Linux, and Linux processes under WSL2; native Windows semantics and reliable lifecycle control after dispatch to Windows-host executables are out of scope (`CONTRIBUTING.md`, `docs/windows-compatibility.md`). Zed's current CLI documentation says a Windows Zed CLI can handle WSL paths automatically, but adopting `zed.exe` discovery would cross the explicitly deferred WSL-to-Windows process boundary. SSH/Coder/devcontainer sessions can expose a Zed CLI without a locally visible GUI. ACP's primary integration direction is editor -> `omegon acp`; `/editor zed` configures and opportunistically launches the editor, so configuration success must remain independent from GUI launch success.
 
+## Future implementation targets
+
+Issue #219 intentionally stops at Zed launch resolution plus a reusable profile configuration surface. `editorCommands` accepts stable integration IDs, but arbitrary keys do not imply that Omegon knows an editor's launch arguments, status probe, ACP installation mechanism, or configuration format.
+
+A follow-up should replace the remaining editor-specific branching with a typed editor integration registry. Each registered editor should declare:
+
+- a stable ID and display name;
+- default executable candidates and platform-native fallbacks;
+- a side-effect-free status probe;
+- argument-vector launch behavior (never a shell command string);
+- ACP setup/configuration behavior;
+- remote/headless launch policy and diagnostic provenance.
+
+Initial registry targets:
+
+1. **VS Code** — honor `editorCommands["vscode"]` for both status and launch; consider `code`, `code-insiders`, and `codium` as explicit candidates; retain the current `vscode-acp` setup instructions until a safe settings writer exists.
+2. **Other ACP-capable editors** — add only after their executable, launch, and ACP contracts are documented and tested. Unknown configured IDs should be reported as configured-but-unsupported, not executed generically.
+3. **Shared status surface** — make `/editor status` iterate registry entries so TUI and future non-interactive surfaces consume one semantic projection rather than adding frontend-specific checks.
+4. **Remote environments** — define behavior for SSH, Coder, devcontainers, and WSL host dispatch separately from local executable discovery. Do not infer GUI reachability solely from `--version` success.
+
+Tests should inject command probes and launchers, assert override precedence and argument vectors, and avoid requiring installed GUI applications. Manual GUI verification remains appropriate for confirming that a resolved editor accepts the launch request.
+
 ## Open Questions
 
 - [assumption] A successful `zed`/`zeditor --version` is sufficient evidence that the CLI can dispatch to a GUI in the current session; remote/headless environments may have the CLI installed without a reachable GUI.

--- a/docs/issue-219-zed-command-resolution.md
+++ b/docs/issue-219-zed-command-resolution.md
@@ -1,0 +1,36 @@
+---
+id: issue-219-zed-command-resolution
+title: "Issue #219 — cross-platform Zed command resolution"
+status: seed
+tags: [bug, editor, zed, nixos, cross-platform, tdd]
+open_questions:
+  - "[assumption] A successful `zed`/`zeditor --version` is sufficient evidence that the CLI can dispatch to a GUI in the current session; remote/headless environments may have the CLI installed without a reachable GUI."
+  - "[assumption] WSL Windows-host Zed invocation should remain outside issue #219 even though current Zed documentation says its Windows CLI can translate WSL paths automatically."
+  - "Should `/editor zed` use `--foreground` only as an explicit manual diagnostic path rather than in normal launch, since foreground mode changes process lifetime and can expose logs in or interfere with the TUI?"
+dependencies: []
+related: []
+---
+
+# Issue #219 — cross-platform Zed command resolution
+
+## Overview
+
+Fix `/editor status` and `/editor zed` so editor executable resolution is configurable rather than tied to names Omegon happens to know. Profiles may define `editorCommands` keyed by stable integration ID (`zed`, `vscode`, and future editors); each value is passed directly to `Command::new` and may be an absolute path or a command resolved through `PATH`. Resolution precedence is explicit profile override, known PATH candidates, then platform-native fallback. The initial Zed candidates are `zed` and NixOS's `zeditor`; macOS retains its app-bundle fallback. `/editor status` and launch must consume the same resolution result.
+
+Executable overrides are machine-local in practice. Operators should put absolute paths in the user profile rather than a repository profile unless the path is intentionally portable across that project's environments. No shell command strings or embedded arguments are accepted; editor arguments remain owned by the integration. WSL is supported only as a Linux process environment, and Windows-host dispatch remains out of scope. Remote/headless environments may report discovery and configure ACP without promising a visible GUI. TDD uses injected command probes so tests do not depend on host PATH or installed GUI applications.
+
+## Research
+
+### Observed NixOS CLI contract
+
+On the issue reporter's NixOS environment, `command -v zeditor` resolves to `/etc/profiles/per-user/wilson/bin/zeditor`; `zed` is absent. `zeditor --version` succeeds and reports Zed 1.14.2. `zeditor --help` identifies itself as the Zed CLI and supports `--version`, `--foreground`, `--wait`, `--new`, `--existing`, `--user-data-dir`, `--zed`, `--dev-server-token`, and `--dev-container`. Therefore `--version` is a safe non-GUI discovery probe; `--foreground` is useful for manual GUI/debug validation but inappropriate for normal detached TUI launch.
+
+### Platform and remote-environment effects
+
+Repository policy supports macOS, Linux, and Linux processes under WSL2; native Windows semantics and reliable lifecycle control after dispatch to Windows-host executables are out of scope (`CONTRIBUTING.md`, `docs/windows-compatibility.md`). Zed's current CLI documentation says a Windows Zed CLI can handle WSL paths automatically, but adopting `zed.exe` discovery would cross the explicitly deferred WSL-to-Windows process boundary. SSH/Coder/devcontainer sessions can expose a Zed CLI without a locally visible GUI. ACP's primary integration direction is editor -> `omegon acp`; `/editor zed` configures and opportunistically launches the editor, so configuration success must remain independent from GUI launch success.
+
+## Open Questions
+
+- [assumption] A successful `zed`/`zeditor --version` is sufficient evidence that the CLI can dispatch to a GUI in the current session; remote/headless environments may have the CLI installed without a reachable GUI.
+- [assumption] WSL Windows-host Zed invocation should remain outside issue #219 even though current Zed documentation says its Windows CLI can translate WSL paths automatically.
+- Should `/editor zed` use `--foreground` only as an explicit manual diagnostic path rather than in normal launch, since foreground mode changes process lifetime and can expose logs in or interfere with the TUI?

--- a/flake.nix
+++ b/flake.nix
@@ -22,7 +22,9 @@
           inherit system;
           overlays = [ rust-overlay.overlays.default ];
         };
-        rustToolchain = pkgs.rust-bin.stable.latest.default;
+        rustToolchain = pkgs.rust-bin.stable.latest.default.override {
+          extensions = [ "clippy" "rust-src" "rustfmt" ];
+        };
         craneLib = (crane.mkLib pkgs).overrideToolchain rustToolchain;
 
         # Read version from Cargo.toml so OCI image tags stay in sync

--- a/pkl/Profile.pkl
+++ b/pkl/Profile.pkl
@@ -63,6 +63,11 @@ toolDetail: ("lean"|"compact"|"detailed"|"verbose")?
 /// Mouse interaction mode. false = terminal-native text selection.
 mouse: Boolean?
 
+/// Per-editor executable overrides. Keys are stable integration IDs such as
+/// `zed` and `vscode`; values may be absolute paths or command names resolved
+/// through `PATH`. Values are executed directly, never through a shell.
+editorCommands: Mapping<String, String>?
+
 /// Active persona to restore on session start.
 persona: String?
 


### PR DESCRIPTION
## Summary

- resolve Zed from a configurable profile command, `zed`, `zeditor`, or the macOS app bundle
- use the same resolution result for `/editor status` and `/editor zed`
- add generic `editorCommands` profile configuration and honor the VS Code override during status checks
- document future typed editor-registry targets for VS Code and other ACP-capable editors

Closes #219

## Configuration

```pkl
editorCommands {
  ["zed"] = "/custom/path/to/zeditor"
  ["vscode"] = "code-insiders"
}
```

Values are passed directly to `Command::new`; shell syntax is not interpreted.

## Validation

- `cargo check` passed
- `cargo test -p omegon editor_config_tests` passed (8 tests)
- full `just test-crate omegon`: 4,317 passed; 12 unrelated existing TUI rendering/snapshot failures reproduced independently
- `just clippy-changed` reaches Clippy but is blocked by existing warnings in unchanged `features/delegate.rs`, `native_io.rs`, and `startup.rs`

## Follow-up scope

This PR does not execute arbitrary configured editor IDs. The design note records a future typed integration registry covering executable candidates, launch arguments, ACP setup, status projections, and remote/headless policy. Initial targets are VS Code (`code`, `code-insiders`, `codium`) and subsequently other documented ACP-capable editors.
