### PR TITLE
fix(release): publish nightly prereleases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -505,11 +505,9 @@ jobs:
           # Determine release flags
           IS_NIGHTLY=false
           PRERELEASE_FLAG=""
-          DRAFT_FLAG=""
           if echo "${{ env.RELEASE_TAG }}" | grep -q "\-nightly\."; then
             IS_NIGHTLY=true
             PRERELEASE_FLAG="--prerelease"
-            DRAFT_FLAG="--draft"
           fi
 
           # Collect asset files
@@ -539,7 +537,7 @@ jobs:
             --repo "${{ github.repository }}" \
             --title "${{ env.RELEASE_TAG }}" \
             --generate-notes \
-            $PRERELEASE_FLAG $DRAFT_FLAG \
+            $PRERELEASE_FLAG \
             "${ASSET_FILES[@]}"
 
       - name: Attest build provenance

--- a/tests/test_nightly_standard_release.py
+++ b/tests/test_nightly_standard_release.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 """Regression checks for nightly releases using the standard CI release path."""
 
-from pathlib import Path
 import unittest
+from pathlib import Path
 
 import yaml
 
@@ -39,6 +39,12 @@ class NightlyStandardReleaseTests(unittest.TestCase):
         self.assertIn("Import Apple signing certificate", self.text)
         self.assertIn("codesign --force --options runtime --timestamp", self.text)
         self.assertIn("xcrun notarytool submit", self.text)
+
+    def test_nightly_release_is_published_as_a_prerelease(self) -> None:
+        """A successful nightly build must be visible to update clients."""
+        self.assertIn('PRERELEASE_FLAG="--prerelease"', self.text)
+        self.assertNotIn('DRAFT_FLAG="--draft"', self.text)
+        self.assertNotRegex(self.text, r"gh release create[\s\S]*?--draft")
 
     def test_manual_handoff_path_is_absent(self) -> None:
         self.assertFalse(


### PR DESCRIPTION
## Summary
- publish successful nightlies immediately as prereleases instead of leaving them as drafts
- add a regression test forbidding draft nightly creation
- preserve the standard signed release path

## Validation
- `python3 tests/test_nightly_standard_release.py` (4 passed)
- workflow YAML validation
- `ruff check --ignore EXE001 tests/test_nightly_standard_release.py`
- `git diff --check`

## Operational repair
Published the five complete draft nightlies from August 10, 11, 13, 14, and 15. All now have `draft=false`, `prerelease=true`, and 42 assets.