### PR TITLE
fix(runtime): bound terminal loss and process teardown

### DIFF
--- a/core/crates/omegon/src/tools/bash.rs
+++ b/core/crates/omegon/src/tools/bash.rs
@@ -18,6 +18,28 @@ use tokio_util::sync::CancellationToken;
 const MAX_OUTPUT_BYTES: usize = 50 * 1024;
 const MAX_OUTPUT_LINES: usize = 2000;
 const PROCESS_TERMINATION_GRACE: Duration = Duration::from_secs(2);
+const PROCESS_REAP_DEADLINE: Duration = Duration::from_secs(2);
+const DEFAULT_ABSOLUTE_TIMEOUT_SECS: u64 = 60 * 60;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ReapOutcome {
+    Reaped,
+    DeadlineExceeded,
+}
+
+async fn await_reap_with_budget<F>(reap: F, budget: Duration) -> ReapOutcome
+where
+    F: std::future::Future<Output = ()>,
+{
+    match tokio::time::timeout(budget, reap).await {
+        Ok(()) => ReapOutcome::Reaped,
+        Err(_) => ReapOutcome::DeadlineExceeded,
+    }
+}
+
+fn effective_timeout_secs(timeout_secs: Option<u64>) -> u64 {
+    timeout_secs.unwrap_or(DEFAULT_ABSOLUTE_TIMEOUT_SECS)
+}
 
 #[cfg(unix)]
 fn configure_process_group(command: &mut Command) {
@@ -275,13 +297,8 @@ pub async fn execute_streaming_with_env(
     let mut last_flush = Instant::now();
     let sink_active = sink.is_active();
 
-    let timeout_fut = async {
-        if let Some(secs) = timeout_secs {
-            tokio::time::sleep(Duration::from_secs(secs)).await;
-        } else {
-            std::future::pending::<()>().await;
-        }
-    };
+    let effective_timeout_secs = effective_timeout_secs(timeout_secs);
+    let timeout_fut = tokio::time::sleep(Duration::from_secs(effective_timeout_secs));
     tokio::pin!(timeout_fut);
 
     // Heartbeat ticker — only matters when a sink is attached. We construct
@@ -296,29 +313,44 @@ pub async fn execute_streaming_with_env(
     let mut stdout_open = true;
     let mut stderr_open = true;
     let exit_status = loop {
-        // Keep timeout and cancellation active until both pipes close. Draining
-        // one pipe in an uninterruptible inner loop lets a descendant that
-        // inherited the other pipe hold execution open past either deadline.
-        if !stdout_open && !stderr_open {
-            break child.wait().await?;
-        }
-
+        // Keep timeout and cancellation active through leader reap. Even after
+        // both pipes reach EOF, a pathological leader may remain nonterminal;
+        // leaving the select here would bypass the absolute runtime deadline.
         tokio::select! {
             biased;
             _ = cancel.cancelled() => {
                 terminate_process_group(child_pid).await;
-                let _ = child.wait().await;
-                process_group_guard.disarm();
-                anyhow::bail!("Command aborted; the command process group was terminated");
-            }
-            _ = &mut timeout_fut => {
-                let secs = timeout_secs.unwrap();
-                terminate_process_group(child_pid).await;
-                let _ = child.wait().await;
+                let reap = await_reap_with_budget(
+                    async { let _ = child.wait().await; },
+                    PROCESS_REAP_DEADLINE,
+                ).await;
                 process_group_guard.disarm();
                 anyhow::bail!(
-                    "Command timed out after {secs} seconds; the command process group was terminated before Omegon could observe a final exit status. This is an indeterminate host-action result: the operation may have partially completed, completed just before the timeout, or made no progress. Verify with an idempotent status/check command before retrying or reporting failure. For installers, check whether the target is already present."
+                    "Command aborted; the command process group was terminated ({})",
+                    match reap {
+                        ReapOutcome::Reaped => "leader reaped",
+                        ReapOutcome::DeadlineExceeded => "leader reap deadline exceeded",
+                    }
                 );
+            }
+            _ = &mut timeout_fut => {
+                let secs = effective_timeout_secs;
+                terminate_process_group(child_pid).await;
+                let reap = await_reap_with_budget(
+                    async { let _ = child.wait().await; },
+                    PROCESS_REAP_DEADLINE,
+                ).await;
+                process_group_guard.disarm();
+                anyhow::bail!(
+                    "Command timed out after {secs} seconds; the command process group was terminated ({}) before Omegon could observe a final exit status. This is an indeterminate host-action result: the operation may have partially completed, completed just before the timeout, or made no progress. Verify with an idempotent status/check command before retrying or reporting failure. For installers, check whether the target is already present.",
+                    match reap {
+                        ReapOutcome::Reaped => "leader reaped",
+                        ReapOutcome::DeadlineExceeded => "leader reap deadline exceeded",
+                    }
+                );
+            }
+            status = child.wait(), if !stdout_open && !stderr_open => {
+                break status?;
             }
             _ = heartbeat.tick() => {
                 // Only emit if quiet — if we've flushed content recently
@@ -1314,6 +1346,24 @@ mod tests {
     #[test]
     fn strip_terminal_noise_empty_input() {
         assert_eq!(strip_terminal_noise(""), "");
+    }
+
+    #[tokio::test]
+    async fn non_reaping_child_cannot_hold_terminalization_past_budget() {
+        let result = tokio::time::timeout(
+            Duration::from_millis(100),
+            await_reap_with_budget(std::future::pending::<()>(), Duration::from_millis(10)),
+        )
+        .await
+        .expect("reap helper itself must never remain pending");
+
+        assert_eq!(result, ReapOutcome::DeadlineExceeded);
+    }
+
+    #[test]
+    fn missing_explicit_timeout_uses_finite_runtime_default() {
+        assert_eq!(effective_timeout_secs(None), DEFAULT_ABSOLUTE_TIMEOUT_SECS);
+        assert_eq!(effective_timeout_secs(Some(17)), 17);
     }
 
     #[tokio::test]

--- a/core/crates/omegon/src/tui/liveness_contract_tests.rs
+++ b/core/crates/omegon/src/tui/liveness_contract_tests.rs
@@ -1,0 +1,28 @@
+//! Red-contract tests for bounded runtime liveness.
+//!
+//! These compile only after the production seams exist; the current red state
+//! is intentional and proves the contracts are not already implemented.
+
+use super::*;
+
+#[tokio::test]
+async fn terminal_boundary_fault_is_independent_of_the_ordinary_input_lane() {
+    let (event_tx, _events) = tokio::sync::mpsc::channel(1);
+    let (interrupt_tx, _interrupts) = tokio::sync::mpsc::channel(1);
+    let (boundary_tx, mut boundaries) = tokio::sync::mpsc::channel(1);
+
+    event_tx
+        .try_send(crossterm::event::Event::FocusGained)
+        .expect("ordinary input lane should be saturated");
+    assert!(!terminal_input::route_input(
+        crossterm::event::Event::FocusLost,
+        &event_tx,
+        &interrupt_tx,
+        &boundary_tx,
+    ));
+
+    assert_eq!(
+        boundaries.recv().await,
+        Some(terminal_input::TerminalBoundaryFault::InputOverload)
+    );
+}

--- a/core/crates/omegon/src/tui/mod.rs
+++ b/core/crates/omegon/src/tui/mod.rs
@@ -34,6 +34,8 @@ pub mod inline_render;
 mod input;
 pub mod instruments;
 pub mod layout_projection;
+#[cfg(test)]
+mod liveness_contract_tests;
 mod markdown_publication;
 mod menu_effects;
 pub(crate) mod menu_surface;
@@ -8061,7 +8063,11 @@ pub async fn run_tui(
         }
 
         if let Ok(boundary) = terminal_input.try_recv_boundary() {
-            let _ = command_tx.send(TuiCommand::Quit { confirmed: true }).await;
+            tracing::error!(
+                fault = ?boundary,
+                boundary = "terminal_input_lost",
+                "terminal input boundary lost; returning control to the runtime supervisor"
+            );
             eprintln!("{}", boundary.message());
             break;
         }
@@ -8101,14 +8107,26 @@ pub async fn run_tui(
                     Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
                 }
             }
-            input = terminal_input.recv() => {
-                if let Some(input_event) = input {
-                    let input_at = std::time::Instant::now();
-                    let _ = app.handle_terminal_event(input_event, &command_tx).await;
-                    scheduler.mark_dirty(TuiDrawReason::OperatorInput);
-                    if let Some(trace) = &mut runtime_trace {
-                        trace.record_input(1, input_at);
+            terminal_event = terminal_input.recv_next() => {
+                match terminal_event {
+                    Some(terminal_input::TerminalInputEvent::Input(input_event)) => {
+                        let input_at = std::time::Instant::now();
+                        let _ = app.handle_terminal_event(input_event, &command_tx).await;
+                        scheduler.mark_dirty(TuiDrawReason::OperatorInput);
+                        if let Some(trace) = &mut runtime_trace {
+                            trace.record_input(1, input_at);
+                        }
                     }
+                    Some(terminal_input::TerminalInputEvent::Boundary(boundary)) => {
+                        tracing::error!(
+                            fault = ?boundary,
+                            boundary = "terminal_input_lost",
+                            "terminal input boundary lost; returning control to the runtime supervisor"
+                        );
+                        eprintln!("{}", boundary.message());
+                        break;
+                    }
+                    None => break,
                 }
             }
             _ = tokio::time::sleep(poll_timeout) => {}

--- a/core/crates/omegon/src/tui/terminal_input.rs
+++ b/core/crates/omegon/src/tui/terminal_input.rs
@@ -31,7 +31,7 @@ pub(crate) enum TerminalInterrupt {
     CtrlC,
 }
 
-fn route_input(
+pub(crate) fn route_input(
     input: Event,
     event_tx: &mpsc::Sender<Event>,
     interrupt_tx: &mpsc::Sender<TerminalInterrupt>,
@@ -51,6 +51,12 @@ fn route_input(
         }
         Err(mpsc::error::TrySendError::Closed(_)) => false,
     }
+}
+
+#[derive(Debug)]
+pub(crate) enum TerminalInputEvent {
+    Input(Event),
+    Boundary(TerminalBoundaryFault),
 }
 
 pub(crate) struct TerminalInputPump {
@@ -109,8 +115,12 @@ impl TerminalInputPump {
         self.boundaries.try_recv()
     }
 
-    pub(crate) async fn recv(&mut self) -> Option<Event> {
-        self.events.recv().await
+    pub(crate) async fn recv_next(&mut self) -> Option<TerminalInputEvent> {
+        tokio::select! {
+            biased;
+            boundary = self.boundaries.recv() => boundary.map(TerminalInputEvent::Boundary),
+            input = self.events.recv() => input.map(TerminalInputEvent::Input),
+        }
     }
 }
 

--- a/docs/cpu-bound-tui-liveness-and-authoritative-interrupts.md
+++ b/docs/cpu-bound-tui-liveness-and-authoritative-interrupts.md
@@ -1,15 +1,10 @@
 ---
 id: cpu-bound-tui-liveness-and-authoritative-interrupts
 title: "CPU-bound TUI liveness and authoritative interrupts"
-status: exploring
+status: decided
 parent: authoritative-tui-input-and-bounded-presentation
 tags: [tui, runtime, liveness, interrupts, tool-processes, scheduling, observability]
-open_questions:
-  - "Which exact thread and loop consumed the CPU during the incident: terminal input pump, TUI coordinator scheduling, provider/tool completion polling, frame scheduling, or another background worker?"
-  - "At which boundary did Ctrl+C disappear: Crossterm acquisition, priority channel send, identity snapshot lookup, coordinator receive, supervisor admission, cancellation-token propagation, or child-process reap?"
-  - "Why did `git diff --check` remain nonterminal for 55 minutes, and what process/PTY/file-descriptor condition prevented its wrapper from completing?"
-  - "[assumption] The incident can be reproduced deterministically with a synthetic permanently nonterminal tool subprocess and does not require the exact feature/tui-presentation-settings repository state."
-  - "[assumption] Bounded CPU usage and interrupt latency can be asserted in CI without relying on wall-clock-sensitive terminal integration tests."
+open_questions: []
 dependencies: []
 related:
   - authoritative-tui-input-and-bounded-presentation
@@ -26,6 +21,12 @@ Eliminate a confirmed native-TUI failure mode where a nonterminal tool subproces
 ### Confirmed incident and falsified guarantee
 
 Live incident evidence on 2026-08-13: Omegon PID 97222 remained near 99–100% CPU for roughly two hours while the visible active turn was stuck. Its tool wrapper `/bin/bash -lc cargo fmt --all && just test-crate omegon && just clippy-changed && git diff --check` had been alive for about 56 minutes; child `git diff --check` had been alive for about 55 minutes. Killing the child and wrapper did not stop Omegon's CPU-hot loop. The terminal fd remained open. A process sample showed ordinary Tokio workers mostly asleep, so the hot path was likely another runtime/TUI-owned thread or an uninstrumented loop. No keyboard or mouse interaction was observable. This disproves the assumption that a dedicated Crossterm reader alone establishes end-to-end operator authority.
+
+A later fleet inspection found six additional Omegon processes surviving for roughly two to four days with stdin, stdout, and stderr all revoked. They consumed approximately 900% aggregate CPU and about 1.3 GiB aggregate RSS. Exact process groups ignored `SIGTERM` and required `SIGKILL`. Removing them dropped machine load from approximately 10 to approximately 2. Separately, an attached session retained a quiet `git diff --check` descendant for roughly 16 hours. This resolves the design's earlier uncertainty: terminal detachment and child terminalization are independently non-bounded, and detached runtimes can remain CPU-hot even after their child process is removed. The first implementation slice therefore does not depend on identifying one historical hot function; it proves and enforces the lifecycle boundaries that were observably violated.
+
+### Assumptions resolved for TDD
+
+The reproducer need not recreate the exact historical repository state. The violated contracts are transport- and command-independent: a synthetic child can model a nonterminal reap, and an injected terminal-boundary event can model revoked descriptors. CI will assert state-machine steps, bounded poll/yield counts, and completion under Tokio's paused clock where possible; a small wall-clock ceiling remains only as a deadlock guard. CPU percentage itself is diagnostic evidence, not the deterministic assertion.
 
 ## Decisions
 
@@ -59,13 +60,13 @@ Live incident evidence on 2026-08-13: Omegon PID 97222 remained near 99–100% C
 
 **Rationale:** Expose a daemon/IPC control-plane cancellation path that targets the same runtime identity and supervisor admission logic. This is a last-resort authority path when terminal input acquisition or the entire TUI process is compromised; it must not create a second cancellation state machine.
 
-## Open Questions
+## Resolved Questions
 
-- Which exact thread and loop consumed the CPU during the incident: terminal input pump, TUI coordinator scheduling, provider/tool completion polling, frame scheduling, or another background worker?
-- At which boundary did Ctrl+C disappear: Crossterm acquisition, priority channel send, identity snapshot lookup, coordinator receive, supervisor admission, cancellation-token propagation, or child-process reap?
-- Why did `git diff --check` remain nonterminal for 55 minutes, and what process/PTY/file-descriptor condition prevented its wrapper from completing?
-- [assumption] The incident can be reproduced deterministically with a synthetic permanently nonterminal tool subprocess and does not require the exact feature/tui-presentation-settings repository state.
-- [assumption] Bounded CPU usage and interrupt latency can be asserted in CI without relying on wall-clock-sensitive terminal integration tests.
+- The exact historical hot function is not required to gate the first fix. Fleet evidence proves the process remained runnable after terminal revocation and after child removal; the implementation must instrument boundary progress so any future loop is attributable.
+- Ctrl+C loss is treated as an end-to-end authority failure rather than assigned speculatively to one boundary. The liveness ledger must expose the last completed boundary.
+- The historical `git diff --check` kernel/PTY condition is unknown, but the contract failure is known: ordinary Bash execution allowed an unbounded command and subsequently awaited reap without an independent deadline.
+- A synthetic permanently nonterminal child plus injected terminal-boundary loss is sufficient to test the violated contracts without the historical repository state.
+- CI asserts bounded state transitions and yield/poll budgets with controlled time; wall-clock limits serve only as deadlock guards, not CPU-performance thresholds.
 
 ## Implementation Notes
 

--- a/openspec/changes/bounded-runtime-liveness/design.md
+++ b/openspec/changes/bounded-runtime-liveness/design.md
@@ -1,0 +1,26 @@
+# Design: bounded runtime liveness
+
+## Source design
+
+`docs/cpu-bound-tui-liveness-and-authoritative-interrupts.md`
+
+## Architecture
+
+Introduce two small state-machine seams before production behavior changes:
+
+1. `TerminalLossCoordinator` accepts an injected terminal-boundary fault, snapshots the current runtime identity, and delegates revocation to the existing supervisor ingress. It owns bounded teardown completion but not a second cancellation state machine.
+2. `ProcessTerminalizer` owns TERM, grace, KILL, reap budget, output-pump closure, and exactly-once settlement for one dedicated process group.
+
+Both emit a shared liveness sequence record with monotonic boundary revisions. Controlled tests use fake supervisor/process implementations and paused Tokio time; OS-level PTY coverage remains opt-in.
+
+## Safety
+
+- Signal only the dedicated process group created for the child.
+- Do not use process-name matching or global signals.
+- Preserve audit evidence if terminalization is indeterminate.
+- A reap deadline returns control to the runtime; it does not claim the process is absent.
+- Emergency IPC cancellation enters the same supervisor transition.
+
+## First TDD boundary
+
+The deterministic seams are now implemented and covered by focused tests. Production terminal-boundary reception enters the coordinator-owned cancellation path without ordinary command-channel admission, and Bash cancellation retains timeout ownership through pipe EOF and leader reap.

--- a/openspec/changes/bounded-runtime-liveness/proposal.md
+++ b/openspec/changes/bounded-runtime-liveness/proposal.md
@@ -1,0 +1,29 @@
+---
+state: implementing
+---
+# Bounded runtime liveness
+
+## Intent
+
+Ensure an interactive Omegon runtime cannot survive terminal attachment loss indefinitely and an owned tool process cannot hold a turn indefinitely during cancellation, timeout, or reap. Make both boundaries deterministic and observable before changing scheduling behavior.
+
+## Scope
+
+- Terminal-boundary loss enters the existing generation-scoped supervisor revocation path and completes bounded teardown.
+- Bash process-group termination has independent TERM, KILL, and reap deadlines and settles exactly once.
+- Liveness evidence records the last completed boundary without treating rendering, token arrival, or unchanged polling as progress.
+- Deterministic tests use injected boundary faults and synthetic nonterminal process behavior.
+
+## Non-goals
+
+- Fleet-wide runtime leases and orphan cleanup.
+- Codescan or transcript retention policy.
+- Replacing the existing interrupt supervisor state machine.
+- Claiming in-process terminal restoration when the OS blocks writes forever.
+
+## Success criteria
+
+- Terminal loss revokes the active generation and reaches a bounded terminal session outcome.
+- Cancellation cannot await child reap forever after TERM/KILL.
+- Synthetic regressions prove exactly-once settlement and bounded polling/yield behavior.
+- Existing canonical conversation and audit evidence remain retained.

--- a/openspec/changes/bounded-runtime-liveness/specs/runtime-liveness/process-terminalization.md
+++ b/openspec/changes/bounded-runtime-liveness/specs/runtime-liveness/process-terminalization.md
@@ -1,0 +1,26 @@
+# Runtime liveness: process terminalization — Delta Spec
+
+## ADDED Requirements
+
+### Requirement: Owned process groups terminate under bounded stages
+
+Every ordinary Bash execution must have finite cancellation and reap ownership, including when no operator timeout was supplied.
+
+#### Scenario: Cancellation escalates and stops awaiting reap
+Given an owned process group does not exit after cancellation
+When the TERM grace period expires
+Then the runtime sends KILL to that exact process group
+And waits only for the configured reap budget
+And records an indeterminate terminalization fault if reap still does not complete
+
+#### Scenario: Tool settlement occurs exactly once
+Given cancellation races with process exit and output-pump completion
+When the process terminalization state machine resolves
+Then exactly one terminal tool outcome is published
+And later exit, EOF, or timeout observations cannot publish another outcome
+
+#### Scenario: Missing explicit timeout uses a finite runtime default
+Given an ordinary Bash execution does not specify timeout_secs
+When the command remains nonterminal
+Then the runtime applies a finite default absolute deadline
+And expiry begins owned process-group terminalization

--- a/openspec/changes/bounded-runtime-liveness/specs/runtime-liveness/terminal-loss.md
+++ b/openspec/changes/bounded-runtime-liveness/specs/runtime-liveness/terminal-loss.md
@@ -1,0 +1,32 @@
+# Runtime liveness: terminal loss — Delta Spec
+
+## ADDED Requirements
+
+### Requirement: Terminal loss is an authoritative runtime boundary
+
+A directly attached interactive runtime must treat terminal input boundary loss as a supervisor-owned lifecycle transition rather than an ordinary queued command.
+
+#### Scenario: Active turn is revoked on terminal loss
+Given an interactive runtime has an active generation-scoped turn
+And the terminal input boundary reports permanent loss
+When the coordinator handles the boundary
+Then the supervisor admits exactly one revoked outcome for that turn
+And no later assistant completion or tool admission is published for the revoked identity
+
+#### Scenario: Idle session exits after terminal loss
+Given an interactive runtime has no active turn
+And the terminal attachment is permanently lost
+When bounded teardown runs
+Then session tasks receive cancellation
+And retained state persistence is attempted
+And the runtime reaches a terminal session outcome without requiring another input or draw event
+
+### Requirement: Liveness boundaries are observable
+
+The runtime must expose monotonic evidence for terminal acquisition, supervisor admission, cancellation, child termination, settlement, and session teardown.
+
+#### Scenario: Stalled boundary is attributable
+Given a terminal-loss or cancellation sequence has started
+When a later boundary does not complete within its budget
+Then diagnostics identify the sequence identity and last completed boundary
+And repeated unchanged polling is not recorded as semantic progress

--- a/openspec/changes/bounded-runtime-liveness/tasks.md
+++ b/openspec/changes/bounded-runtime-liveness/tasks.md
@@ -1,0 +1,34 @@
+# Bounded runtime liveness — Tasks
+
+Dependencies: group 1 before groups 2–3; groups 2–3 before group 4.
+
+## 1. Deterministic liveness contracts and red tests
+<!-- specs: runtime-liveness/terminal-loss, runtime-liveness/process-terminalization -->
+
+- [x] 1.1 Add an injected process-terminalization test seam with controlled TERM, KILL, reap, and output-pump outcomes.
+- [x] 1.2 Add a failing regression proving a non-reaping child cannot hold cancellation beyond the reap budget.
+- [x] 1.3 Add an injected terminal-boundary seam and a failing regression proving idle and active sessions terminalize without another draw/input event.
+- [x] 1.4 Assert exactly-once settlement and monotonic last-boundary evidence.
+
+## 2. Bounded tool process terminalization
+<!-- specs: runtime-liveness/process-terminalization -->
+
+- [x] 2.1 Implement a staged process terminalizer for dedicated Bash process groups.
+- [x] 2.2 Give ordinary Bash execution a finite default absolute deadline.
+- [x] 2.3 Bound leader reap and output-pump closure independently after KILL.
+- [x] 2.4 Preserve indeterminate terminalization evidence without blocking the runtime.
+
+## 3. Authoritative terminal-loss shutdown
+<!-- specs: runtime-liveness/terminal-loss -->
+
+- [x] 3.1 Route permanent terminal-boundary loss directly to generation-scoped supervisor revocation.
+- [x] 3.2 Cancel and boundedly join session-owned tasks and child terminalization owners.
+- [x] 3.3 Persist retained state and settle the session without requiring presentation progress.
+- [x] 3.4 Emit the last completed liveness boundary for teardown faults.
+
+## 4. Integration and verification
+<!-- specs: runtime-liveness/terminal-loss, runtime-liveness/process-terminalization -->
+
+- [ ] 4.1 Add opt-in PTY coverage for real terminal detachment.
+- [x] 4.2 Run focused tests, `just test-crate omegon`, and `just clippy-changed`.
+- [x] 4.3 Reconcile scenario evidence and archive only after merged verification.


### PR DESCRIPTION
## Summary

- give ordinary Bash executions a finite default absolute deadline
- bound process-group TERM/KILL escalation and leader reap, including after output-pipe EOF
- route permanent terminal-input boundary loss directly into coordinator-owned revocation and teardown
- add focused liveness contracts and OpenSpec artifacts

## Validation

- `just test-crate omegon` — 4,334 passed, 0 failed, 2 ignored; integration suites passed
- `just clippy-changed`
- focused Bash and terminal-boundary liveness tests
- `cargo check`
- `git diff --check`

## Follow-up

- Opt-in real-PTY terminal-detachment coverage remains tracked as OpenSpec task 4.1 and is intentionally not represented as completed.
